### PR TITLE
sio2: delayed IRQ based on transfer size + AuthF3 terminator fix

### DIFF
--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -277,7 +277,7 @@ void GameList::FillBootParametersForEntry(VMBootParameters* params, const Entry*
 				Console.WriteLnFmt("ARCADE: setting card   to: '{}'", card);
 			}*/
 		} else {
-			Console.Error("cannot read arcade game config '%s'", entry->path);
+			Console.Error("cannot read arcade game config '%s'", entry->path.c_str());
 		}
 	}
 	else

--- a/pcsx2/IopHw.h
+++ b/pcsx2/IopHw.h
@@ -311,6 +311,7 @@ enum IopEventId
 	IopEvt_CdvdSectorReady,
 	IopEvt_DEV9,
 	IopEvt_USB,
+	IopEvt_SIO2,
 };
 
 extern void PSX_INT( IopEventId n, s32 ecycle);

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -12,6 +12,7 @@
 #include "IopBios.h"
 #include "IopHw.h"
 #include "IopDma.h"
+#include "SIO/Sio2.h"
 #include "CDVD/Ps1CD.h"
 #include "CDVD/CDVD.h"
 
@@ -192,11 +193,13 @@ static __fi void _psxTestInterrupts()
 	// as follows helps speed up most games.
 
 	if( psxRegs.interrupt & ((1 << IopEvt_Cdvd) | (1 << IopEvt_Dma11) | (1 << IopEvt_Dma12)
-		| (1 << IopEvt_Cdrom) | (1 << IopEvt_CdromRead) | (1 << IopEvt_DEV9) | (1 << IopEvt_USB)))
+		| (1 << IopEvt_Cdrom) | (1 << IopEvt_CdromRead) | (1 << IopEvt_DEV9) | (1 << IopEvt_USB)
+		| (1 << IopEvt_SIO2)))
 	{
 		IopTestEvent(IopEvt_Cdvd,		cdvdActionInterrupt);
 		IopTestEvent(IopEvt_Dma11,		psxDMA11Interrupt);	// SIO2
 		IopTestEvent(IopEvt_Dma12,		psxDMA12Interrupt);	// SIO2
+		IopTestEvent(IopEvt_SIO2,		sio2DelayedInterrupt);
 		IopTestEvent(IopEvt_Cdrom,		cdrInterrupt);
 		IopTestEvent(IopEvt_CdromRead,	cdrReadInterrupt);
 		IopTestEvent(IopEvt_DEV9,		dev9Interrupt);

--- a/pcsx2/SIO/Memcard/MemoryCardProtocol.cpp
+++ b/pcsx2/SIO/Memcard/MemoryCardProtocol.cpp
@@ -517,7 +517,6 @@ void MemoryCardProtocol::AuthF3()
 	}
 	else
 	{
-		mcd->term = Terminator::READY;
 		The2bTerminator(5);
 	}
 }

--- a/pcsx2/SIO/Sio2.cpp
+++ b/pcsx2/SIO/Sio2.cpp
@@ -3,6 +3,8 @@
 
 #include "Common.h"
 #include "Host.h"
+#include "IopHw.h"
+#include "R3000A.h"
 #include "IopDma.h"
 #include "Recording/InputRecording.h"
 #include "SIO/Memcard/MemoryCardProtocol.h"
@@ -87,6 +89,7 @@ void Sio2::SoftReset()
 	// Clear dmaBlockSize, in case the next SIO2 command is not sent over DMA11.
 	dmaBlockSize = 0;
 	queueComplete = false;
+	transferBytes = 0;
 
 	// Anything in g_Sio2FifoIn which was not necessary to consume should be cleared out prior to the next SIO2 cycle.
 	while (!g_Sio2FifoIn.empty())
@@ -114,8 +117,24 @@ void Sio2::SetCtrl(u32 value)
 
 	if (this->ctrl & Sio2Ctrl::START_TRANSFER)
 	{
-		Interrupt();
+		this->ctrl &= ~Sio2Ctrl::START_TRANSFER;
+
+		const u32 cmd0 = CmdQueue[0];
+		const u32 cmdPort = cmd0 & 0x3;
+		const u32 send1 = PortCtrl0[cmdPort];
+		const u32 send2 = PortCtrl1[cmdPort];
+		const bool useBaud1 = (cmd0 >> 30) & 1;
+		const u32 baudDiv = useBaud1 ? (send1 >> 24) : ((send1 >> 16) & 0xFF);
+		const u32 interBytePer = (send2 >> 16) & 0xFF;
+		const u32 cyclesPerByte = 8 * (baudDiv + 1) + interBytePer;
+		const u32 delay = static_cast<u32>(transferBytes) * cyclesPerByte + 64;
+		PSX_INT(IopEvt_SIO2, delay);
 	}
+}
+
+void sio2DelayedInterrupt()
+{
+	g_Sio2.Interrupt();
 }
 
 void Sio2::SetCmd(size_t position, u32 value)
@@ -416,6 +435,7 @@ void Sio2::Write(u8 data)
 	}
 
 	g_Sio2FifoIn.push_back(data);
+	transferBytes++;
 
 	// We have received as many command bytes as we expect, and...
 	//
@@ -512,6 +532,7 @@ bool Sio2::DoState(StateWrapper& sw)
 	sw.Do(&processedLength);
 	sw.Do(&dmaBlockSize);
 	sw.Do(&queueComplete);
+	sw.Do(&transferBytes);
 
 	sw.Do(&g_Sio2FifoIn);
 	sw.Do(&g_Sio2FifoOut);

--- a/pcsx2/SIO/Sio2.h
+++ b/pcsx2/SIO/Sio2.h
@@ -40,6 +40,7 @@ public:
 	// does not accidentally use dmaBlockSize.
 	size_t dmaBlockSize = 0;
 	bool queueComplete = false;
+	size_t transferBytes = 0;
 
 	Sio2();
 	~Sio2();
@@ -59,6 +60,8 @@ public:
 	void Pad();
 	void Multitap();
 	void Infrared();
+
+	friend void sio2DelayedInterrupt();
 	void Memcard();
 
 	void Write(u8 data);
@@ -68,3 +71,4 @@ public:
 extern std::deque<u8> g_Sio2FifoIn;
 extern std::deque<u8> g_Sio2FifoOut;
 extern Sio2 g_Sio2;
+extern void sio2DelayedInterrupt();

--- a/pcsx2/SIO/SioTypes.h
+++ b/pcsx2/SIO/SioTypes.h
@@ -160,4 +160,5 @@ namespace Terminator
 {
 	static constexpr u32 NOT_READY = 0x66;
 	static constexpr u32 READY = 0x55;
+	static constexpr u32 AUTHENTICATED = 0x5a;
 } // namespace Terminator


### PR DESCRIPTION
SIO2 interrupt now fires after a delay proportional to the transfer size and baud rate instead of instantly. It matches real hardware timing.

AuthF3 (MagicGate auth reset) no longer resets the communication terminator to 0x55. On real hardware, only SetTerminator changes it. The repeated/quick reset caused memory card short probes to fail after IOP module reloads, returning error -2.

Fixes dongle-based arcade games (System 246) that reload IOP modules mid-boot.

SCII - no regression
TK4 - boots up to loading screen (missing ATA)