### PR TITLE
initial support ATA/ATAPI subsystem and few more things

### DIFF
--- a/pcsx2/DEV9/ACATA.cpp
+++ b/pcsx2/DEV9/ACATA.cpp
@@ -1,10 +1,56 @@
 #include "ACATA.h"
 #include "ACATAPI.h"
+#include "ACCORE.h"
 #include "common/Console.h"
 
 #include "ACMACROS.h"
 
+#include <sys/stat.h>
+#include <cstring>
+
 #include "ACATA_CMD_RESPONSES"
+
+static u8 ata_pio_buf[131072];
+static u32 ata_pio_len = 0;
+static u32 ata_pio_pos = 0;
+static u16 ata_identify_buf[256];
+
+static u32 ata_total_sectors = 0;
+
+static void ata_build_identify()
+{
+	memset(ata_identify_buf, 0, sizeof(ata_identify_buf));
+	ata_identify_buf[0] = 0x0040;
+	for (int i = 10; i <= 19; i++) ata_identify_buf[i] = 0x2020;
+	ata_identify_buf[23] = 0x312E; ata_identify_buf[24] = 0x3030;
+	ata_identify_buf[25] = 0x2020; ata_identify_buf[26] = 0x2020;
+	ata_identify_buf[27] = 0x4E41; ata_identify_buf[28] = 0x4D43;
+	ata_identify_buf[29] = 0x4F20; ata_identify_buf[30] = 0x4844;
+	ata_identify_buf[31] = 0x4420; ata_identify_buf[32] = 0x4452;
+	ata_identify_buf[33] = 0x4956; ata_identify_buf[34] = 0x4520;
+	for (int i = 35; i <= 46; i++) ata_identify_buf[i] = 0x2020;
+	ata_identify_buf[47] = 0x8010;
+	ata_identify_buf[49] = 0x0300;
+	ata_identify_buf[53] = 0x0007;
+	if (ACATA::TH::IMAGE) {
+		struct stat st;
+		if (fstat(fileno(ACATA::TH::IMAGE), &st) == 0 && st.st_size > 0) {
+			ata_total_sectors = (u32)(st.st_size / 512);
+			ata_identify_buf[60] = ata_total_sectors & 0xFFFF;
+			ata_identify_buf[61] = (ata_total_sectors >> 16) & 0xFFFF;
+		}
+	}
+	ata_identify_buf[63] = 0x0407;
+	ata_identify_buf[80] = 0x001E;
+	ata_identify_buf[82] = 0x0068;
+	ata_identify_buf[83] = 0x4000;
+	ata_identify_buf[84] = 0x4000;
+	ata_identify_buf[85] = 0x0068;
+	ata_identify_buf[86] = 0x0000;
+	ata_identify_buf[87] = 0x4000;
+	ata_identify_buf[88] = 0x001F;
+	ata_identify_buf[128] = 0x0001;
+}
 
 std::string ACATA::imgpath = "";
 ACMEDIATYPE ACATA::MediaType;
@@ -14,6 +60,7 @@ u32 ACATA::last_write = 0;
 u32 atacmd_responding = -1;
 u32 atacmd_response_traverse = 0;
 
+
 u16 ACATA::read16(u32 addr) {
     last_read = addr;
     switch (addr)
@@ -21,7 +68,6 @@ u16 ACATA::read16(u32 addr) {
     case ACATA_R_DATA:
         return ACATA::handle_dataR(addr);
     case ACATA_R_STATUS_ALT:
-        R_STATUS = 0;
         return R_STATUS;
     case ACATA_R_NSECTOR:
         return R_NSECTOR;
@@ -36,9 +82,9 @@ u16 ACATA::read16(u32 addr) {
     case ACATA_R_HCYL:
         return R_HCYL;
     case ACATA_R_STATUS:
+        // reading R_STATUS after writing zero to it? this is the ACATA probe. we have to respond BUSY at least once for the driver to keep going
+        // FIXME
         if (ACATA::last_write == ACATA_R_STATUS && ACATA::cmd_handled == 0 && ((R_SELECT & ACATA_UNIT1) == 0)) {
-            // reading R_STATUS after writing zero to it? this is the ACATA probe. we have to respond BUSY at least once for the driver to keep going
-            // FIXME
             if (R_STATUS & ATA_STAT_BUSY)
                 CLRB(R_STATUS, ATA_STAT_BUSY);
             else
@@ -53,20 +99,16 @@ u16 ACATA::read16(u32 addr) {
     return 0;
 }
 
-#define MMIO_RESPOND(V, O, N) if (V == O) V = N
-
-
 void ACATA::write16(u32 addr, u16 val) {
     last_write = addr;
-    u16 V = val;
     switch (addr) {
-    case ACATA_R_NSECTOR: R_NSECTOR = val; break;
-    case ACATA_R_SECTOR:  R_SECTOR  = val; break;
-    case ACATA_R_FEATURE: R_FEATURE = val; break;
-    case ACATA_R_CONTROL: R_CONTROL = val; break;
-    case ACATA_R_LCYL:    R_LCYL    = val; break;
-    case ACATA_R_HCYL:    R_HCYL    = val; break;
-    case ACATA_R_SELECT:  R_SELECT  = val; break;
+    case ACATA_R_NSECTOR: R_NSECTOR = val & 0xFF; break;
+    case ACATA_R_SECTOR:  R_SECTOR  = val & 0xFF; break;
+    case ACATA_R_FEATURE: R_FEATURE = val & 0xFF; break;
+    case ACATA_R_CONTROL: R_CONTROL = val & 0xFF; break;
+    case ACATA_R_LCYL:    R_LCYL    = val & 0xFF; break;
+    case ACATA_R_HCYL:    R_HCYL    = val & 0xFF; break;
+    case ACATA_R_SELECT:  R_SELECT  = val & 0xFF; break;
     case ACATA_R_COMMAND:
         // uyjulian says: "Yeah it should be masked and high byte is command type"
         ACATA::handle_cmd(val & 0xFF); return;
@@ -91,12 +133,14 @@ void ACATA::handle_dataW(u32 addr, u16 val) { // writes at R_DATA
         if (ACATA::cmd_handledc < 6) { // packet is followed by a 6 word PIO
             ACATA::ata_c_packet.raw[ACATA::cmd_handledc++] = val;
             if (ACATA::cmd_handledc == 6) {
-                ACATAPI::handle_cmd(ACATA::ata_c_packet);
                 CLRB(R_STATUS, ATA_STAT_DRQ); // keep up DRQ only while the packet comes in?
+                ACATAPI::handle_cmd(ACATA::ata_c_packet);
             }
+        } else if (ACATAPI::has_pio_write()) {
+            ACATAPI::pio_write_word(val);
         }
         break;
-    
+
     default:
         Console.Error("ACATA: writing from %X while no pending CMD", addr);
         break;
@@ -107,18 +151,61 @@ u16 ACATA::handle_dataR(u32 addr) { // PIO read at R_DATA
     switch (ACATA::cmd_handled) {
     case ATA_C_IDENTIFY_PACKET_DEVICE:
         if (ACATA::cmd_handledc < 256) {
-            return ATA_R_IDENTIFY_PACKET_DEVICE[ACATA::cmd_handledc++];
-        } else {ACATA::cmd_handled = -1; CLRB(R_STATUS, ATA_STAT_DRQ);}
+            u16 word = ATA_R_IDENTIFY_PACKET_DEVICE[ACATA::cmd_handledc++];
+            if (ACATA::cmd_handledc >= 256) {
+                ACATA::cmd_handled = -1;
+                CLRB(R_STATUS, ATA_STAT_DRQ);
+                R_STATUS |= ATA_STAT_READY;
+            }
+            return word;
+        }
         break;
     case ATA_C_IDENTIFY_DEVICE:
         if (ACATA::cmd_handledc < 256) {
-            return ATA_R_IDENTIFY_DEVICE[ACATA::cmd_handledc++];
-        } else {ACATA::cmd_handled = -1; CLRB(R_STATUS, ATA_STAT_DRQ);}
+            u16 word = ata_identify_buf[ACATA::cmd_handledc++];
+            if (ACATA::cmd_handledc >= 256) {
+                ACATA::cmd_handled = -1;
+                CLRB(R_STATUS, ATA_STAT_DRQ);
+                R_STATUS |= ATA_STAT_READY;
+                ACCORE::intr(ACCORE::INTRN_ATA);
+            }
+            return word;
+        }
+        break;
+    case ATA_C_READ_SECTOR:
+        if (ata_pio_pos * 2 < ata_pio_len) {
+            u32 off = ata_pio_pos * 2;
+            u16 val = ata_pio_buf[off] | ((u16)ata_pio_buf[off + 1] << 8);
+            ata_pio_pos++;
+            if (ata_pio_pos * 2 >= ata_pio_len) {
+                ACATA::cmd_handled = -1;
+                CLRB(R_STATUS, ATA_STAT_DRQ);
+                R_STATUS |= ATA_STAT_READY;
+                ACCORE::intr(ACCORE::INTRN_ATA);
+            }
+            return val;
+        }
         break;
     case ATA_C_SET_FEATURES:
     break;
+    case ATA_C_SCE_SECURITY_CONTROL:
+        if (ACATA::cmd_handledc < 256) {
+            u32 off = ACATA::cmd_handledc * 2;
+            u16 word = ata_pio_buf[off] | ((u16)ata_pio_buf[off + 1] << 8);
+            ACATA::cmd_handledc++;
+            if (ACATA::cmd_handledc >= 256) {
+                ACATA::cmd_handled = -1;
+                CLRB(R_STATUS, ATA_STAT_DRQ);
+                R_STATUS |= ATA_STAT_READY;
+                ACCORE::intr(ACCORE::INTRN_ATA);
+            }
+            return word;
+        }
+        break;
     case ATA_C_PACKET:
-    break;
+        if (ACATAPI::has_pio_data())
+            return ACATAPI::pio_read_word();
+        break;
     
     default:
         Console.Error("ACATA: reading from %X while no pending CMD", ACATA_R_DATA);
@@ -127,6 +214,7 @@ u16 ACATA::handle_dataR(u32 addr) { // PIO read at R_DATA
 }
 
 void ACATA::handle_cmd(u16 val) {
+    CLRB(R_STATUS, ATA_STAT_DRQ);
     switch (val) {
     case ATA_C_NOP:
         ACATA::cmd_handled = val;
@@ -139,26 +227,181 @@ void ACATA::handle_cmd(u16 val) {
         ACATA::cmd_handledc = 0;
         R_STATUS |= ATA_STAT_DRQ;
     break;
-    case ATA_C_IDENTIFY_DEVICE:
-        Console.Warning("ATA_C_IDENTIFY_DEVICE");
-        ACATA::cmd_handled = val;
-        ACATA::cmd_handledc = 0;
-        R_STATUS |= ATA_STAT_DRQ;
-    break;
     case ATA_C_PACKET:
         ACATA::cmd_handled = val;
         ACATA::cmd_handledc = 0;
-        if (!ACATA_ISDMA) Console.Error("ATA_C_PACKET: over PIO recieved");
+        R_NSECTOR = 0x01; // ATAPI: Command/Data=1, IO=0 -> ready for command packet
         R_STATUS |= ATA_STAT_DRQ;
         CLRB(R_STATUS, ATA_STAT_BUSY);
+        CLRB(R_STATUS, ATA_STAT_ERR);
         CLRB(R_STATUS_ALT, ATA_STAT_ERR); // when packet is sent, ACCDVD fails if this bit is set or timeout consumed
+        ACCORE::intr(ACCORE::INTRN_ATA);
     break;
+    case ATA_C_IDENTIFY_DEVICE:
+        Console.Warning("ATA_C_IDENTIFY_DEVICE");
+        ata_build_identify();
+        ACATA::cmd_handled = val;
+        ACATA::cmd_handledc = 0;
+        R_STATUS |= ATA_STAT_DRQ;
+        CLRB(R_STATUS, ATA_STAT_BUSY);
+        ACCORE::intr(ACCORE::INTRN_ATA);
+    break;
+    case ATA_C_READ_SECTOR: {
+        u32 lba = R_SECTOR | (R_LCYL << 8) | (R_HCYL << 16) | ((R_SELECT & 0x0F) << 24);
+        u32 count = R_NSECTOR ? R_NSECTOR : 256;
+        u32 total = count * 512;
+        if (!ACATA::TH::IMAGE || total > sizeof(ata_pio_buf)) {
+            R_STATUS |= ATA_STAT_ERR;
+            R_ERROR = ATA_ERR_ABORT;
+            ACCORE::intr(ACCORE::INTRN_ATA);
+            break;
+        }
+        fseeko(ACATA::TH::IMAGE, (off_t)lba * 512, SEEK_SET);
+        size_t rd = fread(ata_pio_buf, 1, total, ACATA::TH::IMAGE);
+        if (rd != total) {
+            Console.Error("ATA_C_READ_SECTOR: short read (%zu/%u) at LBA %u", rd, total, lba);
+            R_STATUS |= ATA_STAT_ERR;
+            R_ERROR = ATA_ERR_ABORT;
+            ACCORE::intr(ACCORE::INTRN_ATA);
+            break;
+        }
+        ACATA::cmd_handled = val;
+        ACATA::cmd_handledc = 0;
+        ata_pio_len = total;
+        ata_pio_pos = 0;
+        R_STATUS |= ATA_STAT_DRQ;
+        CLRB(R_STATUS, ATA_STAT_BUSY);
+        CLRB(R_STATUS, ATA_STAT_ERR);
+        ACCORE::intr(ACCORE::INTRN_ATA);
+        break;
+    }
+    case ATA_C_READ_DMA:
+    case ATA_C_READ_DMA_WITHOUT_RETRIES: {
+        u32 lba = R_SECTOR | (R_LCYL << 8) | (R_HCYL << 16) | ((R_SELECT & 0x0F) << 24);
+        u32 count = R_NSECTOR ? R_NSECTOR : 256;
+        ACATA::TH::LBA = lba;
+        ACATA::TH::nsector = count;
+        ACATA::TH::sectorsize = 512;
+        ACCORE::DMA::PendTrasnfType = ACCORE::DMA::ATA;
+        ACATA::cmd_handled = val;
+        R_STATUS |= ATA_STAT_BUSY;
+        CLRB(R_STATUS, ATA_STAT_DRQ);
+        break;
+    }
     case ATA_C_SET_FEATURES:
         Console.Warning("ATA_C_SET_FEATURES: FEATURE:%04X, R_NSECTOR:%04X, R_SECTOR:%04X, R_LCYL:%04X, R_HCYL:%04X",
             R_FEATURE, R_NSECTOR, R_SECTOR, R_LCYL, R_HCYL);
+        CLRB(R_STATUS, ATA_STAT_ERR);
+        R_STATUS |= ATA_STAT_READY;
+        ACCORE::intr(ACCORE::INTRN_ATA);
     break;
-    
-    
+    case ATA_C_WRITE_DMA:
+    case ATA_C_WRITE_DMA_WITHOUT_RETRIES: {
+        u32 lba = R_SECTOR | (R_LCYL << 8) | (R_HCYL << 16) | ((R_SELECT & 0x0F) << 24);
+        u32 count = R_NSECTOR ? R_NSECTOR : 256;
+        ACATA::TH::LBA = lba;
+        ACATA::TH::nsector = count;
+        ACATA::TH::sectorsize = 512;
+        ACCORE::DMA::PendTrasnfType = ACCORE::DMA::ATA_WRITE;
+        ACATA::cmd_handled = val;
+        R_STATUS |= ATA_STAT_BUSY;
+        CLRB(R_STATUS, ATA_STAT_DRQ);
+        break;
+    }
+    case ATA_C_SMART:
+        CLRB(R_STATUS, ATA_STAT_ERR);
+        CLRB(R_STATUS, ATA_STAT_BUSY);
+        R_STATUS |= ATA_STAT_READY;
+        ACCORE::intr(ACCORE::INTRN_ATA);
+        break;
+    case ATA_C_IDLE:
+    case ATA_C_IDLE_IMMEDIATE:
+    case ATA_C_STANDBY:
+    case ATA_C_STANDBY_IMMEDIATE:
+    case ATA_C_SLEEP:
+    case ATA_C_CHECK_POWER_MODE:
+        R_NSECTOR = 0xFF;
+        CLRB(R_STATUS, ATA_STAT_ERR);
+        CLRB(R_STATUS, ATA_STAT_BUSY);
+        R_STATUS |= ATA_STAT_READY;
+        ACCORE::intr(ACCORE::INTRN_ATA);
+        break;
+    case ATA_C_SCE_SECURITY_CONTROL:
+        if (R_FEATURE == 0xEC) {
+            memset(ata_pio_buf, 0, 512);
+            ata_pio_len = 512;
+            ata_pio_pos = 0;
+            ACATA::cmd_handled = val;
+            ACATA::cmd_handledc = 0;
+            R_STATUS |= ATA_STAT_DRQ;
+            CLRB(R_STATUS, ATA_STAT_BUSY);
+            CLRB(R_STATUS, ATA_STAT_ERR);
+            ACCORE::intr(ACCORE::INTRN_ATA);
+        } else {
+            CLRB(R_STATUS, ATA_STAT_ERR);
+            CLRB(R_STATUS, ATA_STAT_BUSY);
+            R_STATUS |= ATA_STAT_READY;
+            ACCORE::intr(ACCORE::INTRN_ATA);
+        }
+        break;
+    case ATA_C_READ_NATIVE_MAX_ADDRESS: {
+        u32 max_lba = ata_total_sectors ? ata_total_sectors - 1 : 0;
+        R_SECTOR = max_lba & 0xFF;
+        R_LCYL = (max_lba >> 8) & 0xFF;
+        R_HCYL = (max_lba >> 16) & 0xFF;
+        R_SELECT = (R_SELECT & 0xF0) | ((max_lba >> 24) & 0x0F);
+        CLRB(R_STATUS, ATA_STAT_ERR);
+        CLRB(R_STATUS, ATA_STAT_BUSY);
+        R_STATUS |= ATA_STAT_READY;
+        ACCORE::intr(ACCORE::INTRN_ATA);
+        break;
+    }
+    case ATA_C_SET_MAX_ADDRESS:
+        CLRB(R_STATUS, ATA_STAT_ERR);
+        CLRB(R_STATUS, ATA_STAT_BUSY);
+        R_STATUS |= ATA_STAT_READY;
+        ACCORE::intr(ACCORE::INTRN_ATA);
+        break;
+    case ATA_C_SECURITY_SET_PASSWORD:
+    case ATA_C_SECURITY_UNLOCK:
+    case ATA_C_SECURITY_ERASE_PREPARE:
+    case ATA_C_SECURITY_ERASE_UNIT:
+    case ATA_C_SECURITY_FREEZE_LOCK:
+    case ATA_C_SECURITY_DISABLE_PASSWORD:
+        CLRB(R_STATUS, ATA_STAT_ERR);
+        CLRB(R_STATUS, ATA_STAT_BUSY);
+        R_STATUS |= ATA_STAT_READY;
+        ACCORE::intr(ACCORE::INTRN_ATA);
+        break;
+    case ATA_C_FLUSH_CACHE:
+    case ATA_C_FLUSH_CACHE_EXT:
+        CLRB(R_STATUS, ATA_STAT_BUSY);
+        R_STATUS |= ATA_STAT_READY;
+        ACCORE::intr(ACCORE::INTRN_ATA);
+    break;
+    case ATA_C_EXECUTE_DEVICE_DIAGNOSTIC:
+        R_ERROR = 0x01;
+        CLRB(R_STATUS, ATA_STAT_BUSY);
+        R_STATUS |= ATA_STAT_READY;
+        ACCORE::intr(ACCORE::INTRN_ATA);
+    break;
+    case ATA_C_INITIALIZE_DEVICE_PARAMETERS:
+        CLRB(R_STATUS, ATA_STAT_ERR);
+        CLRB(R_STATUS, ATA_STAT_BUSY);
+        R_STATUS |= ATA_STAT_READY;
+        ACCORE::intr(ACCORE::INTRN_ATA);
+        break;
+    case ATA_C_DEVICE_RESET:
+        R_ERROR = 0x01;
+        R_NSECTOR = 0x01;
+        R_SECTOR = 0x01;
+        R_LCYL = 0x00;
+        R_HCYL = 0x00;
+        R_SELECT = 0x00;
+        CLRB(R_STATUS, ATA_STAT_BUSY);
+        R_STATUS |= ATA_STAT_READY;
+        break;
+
     default:
         Console.Error("unhandled ATACMD %X", val);
         break;

--- a/pcsx2/DEV9/ACATA.h
+++ b/pcsx2/DEV9/ACATA.h
@@ -89,6 +89,7 @@ namespace ACATA
         void IO_Thread();
         void IO_Read();
         void IO_Read(u32* addr, u32 val); //alternate version to vomit data straight away to a ptr
+        void IO_Write(u32* addr, u32 size);
         int IO_OpenImage();
         int IO_CloseImage();
     }

--- a/pcsx2/DEV9/ACATAPI.cpp
+++ b/pcsx2/DEV9/ACATAPI.cpp
@@ -5,26 +5,220 @@
 
 #include "ACMACROS.h"
 
+#include <sys/stat.h>
+#include <cstring>
+
+static u8 atapi_pio_buf[65536];
+static u32 atapi_pio_len = 0;
+static u32 atapi_pio_pos = 0;
+
+static u8 atapi_pio_write_buf[65536];
+static u32 atapi_pio_write_len = 0;
+static u32 atapi_pio_write_pos = 0;
+static u8 mode_page_01[12] = {};
+static bool mode_page_01_set = false;
+
+static void atapi_pio_write_setup(u32 len) {
+    atapi_pio_write_len = len;
+    atapi_pio_write_pos = 0;
+    memset(atapi_pio_write_buf, 0, std::min(len, (u32)sizeof(atapi_pio_write_buf)));
+    ACATA::R_LCYL = len & 0xFF;
+    ACATA::R_HCYL = (len >> 8) & 0xFF;
+    ACATA::R_NSECTOR = 0x00;
+    ACATA::R_STATUS |= ATA_STAT_DRQ;
+    CLRB(ACATA::R_STATUS, ATA_STAT_BUSY);
+    CLRB(ACATA::R_STATUS, ATA_STAT_ERR);
+    ACCORE::intr(ACCORE::INTRN_ATA);
+}
+
+static void atapi_pio_setup(u32 len) {
+    atapi_pio_len = len;
+    atapi_pio_pos = 0;
+    ACATA::R_LCYL = len & 0xFF;
+    ACATA::R_HCYL = (len >> 8) & 0xFF;
+    ACATA::R_NSECTOR = 0x02;
+    ACATA::R_STATUS |= ATA_STAT_DRQ;
+    CLRB(ACATA::R_STATUS, ATA_STAT_BUSY);
+    CLRB(ACATA::R_STATUS, ATA_STAT_ERR);
+    ACCORE::intr(ACCORE::INTRN_ATA);
+}
+
+static void atapi_complete_nodata() {
+    atapi_pio_len = 0;
+    atapi_pio_pos = 0;
+    ACATA::R_NSECTOR = 0x03;
+    CLRB(ACATA::R_STATUS, ATA_STAT_DRQ);
+    CLRB(ACATA::R_STATUS, ATA_STAT_ERR);
+    CLRB(ACATA::R_STATUS, ATA_STAT_BUSY);
+    ACATA::R_STATUS |= ATA_STAT_READY;
+    ACATA::R_LCYL = 0;
+    ACATA::R_HCYL = 0;
+    ACCORE::intr(ACCORE::INTRN_ATA);
+}
+
+u16 ACATAPI::pio_read_word() {
+    if (atapi_pio_pos * 2 < atapi_pio_len) {
+        u32 offset = atapi_pio_pos * 2;
+        u16 val = atapi_pio_buf[offset];
+        if (offset + 1 < atapi_pio_len)
+            val |= (u16)atapi_pio_buf[offset + 1] << 8;
+        atapi_pio_pos++;
+        if (atapi_pio_pos * 2 >= atapi_pio_len) {
+            ACATA::R_NSECTOR = 0x03;
+            CLRB(ACATA::R_STATUS, ATA_STAT_DRQ);
+            ACATA::R_STATUS |= ATA_STAT_READY;
+            ACCORE::intr(ACCORE::INTRN_ATA);
+        }
+        return val;
+    }
+    return 0;
+}
+
+bool ACATAPI::has_pio_data() {
+    return atapi_pio_len > 0 && atapi_pio_pos * 2 < atapi_pio_len;
+}
+
+void ACATAPI::pio_write_word(u16 val) {
+    if (atapi_pio_write_pos * 2 >= atapi_pio_write_len)
+        return;
+    u32 offset = atapi_pio_write_pos * 2;
+    atapi_pio_write_buf[offset] = val & 0xFF;
+    if (offset + 1 < atapi_pio_write_len)
+        atapi_pio_write_buf[offset + 1] = (val >> 8) & 0xFF;
+    atapi_pio_write_pos++;
+    if (atapi_pio_write_pos * 2 >= atapi_pio_write_len) {
+        if (atapi_pio_write_len >= 12 && atapi_pio_write_buf[8] == 0x01) {
+            memcpy(mode_page_01, atapi_pio_write_buf, 12);
+            mode_page_01_set = true;
+        }
+        atapi_pio_write_len = 0;
+        atapi_complete_nodata();
+    }
+}
+
+bool ACATAPI::has_pio_write() {
+    return atapi_pio_write_len > 0 && atapi_pio_write_pos * 2 < atapi_pio_write_len;
+}
+
 void ACATAPI::handle_cmd(atapi_packet_t P) {
     u32 transf_lba = ATAPI_PKT_GETLBA(P);
     u32 nsec = ATAPI_PKT_GETLEN(P);
     switch (P.pkt.opcode) {
-    case ATAPICMD::READ_10: {
-        //Console.Warning("ACATAPI:READ_10: tlen:%X, lba:%X", P.pkt.transf_len, transf_lba);
-        ACATA::TH::nsector = nsec;
-        ACATA::TH::LBA = transf_lba;
-        if (ACATA_ISDMA) ACCORE::DMA::PendTrasnfType = ACCORE::DMA::ATAPI;
+    case ATAPICMD::TEST_UNIT_READY:
+        atapi_complete_nodata();
+        break;
+
+    case ATAPICMD::READ_CAPACITY: {
+        struct stat st;
+        if (ACATA::TH::IMAGE && fstat(fileno(ACATA::TH::IMAGE), &st) == 0 && st.st_size > 0) {
+            u32 last_lba = (u32)(st.st_size / ACATAPI::CONSTANTS::DVD_SECTORSIZE) - 1;
+            u32 block_len = ACATAPI::CONSTANTS::DVD_SECTORSIZE;
+            atapi_pio_buf[0] = (last_lba >> 24) & 0xFF;
+            atapi_pio_buf[1] = (last_lba >> 16) & 0xFF;
+            atapi_pio_buf[2] = (last_lba >>  8) & 0xFF;
+            atapi_pio_buf[3] = last_lba & 0xFF;
+            atapi_pio_buf[4] = (block_len >> 24) & 0xFF;
+            atapi_pio_buf[5] = (block_len >> 16) & 0xFF;
+            atapi_pio_buf[6] = (block_len >>  8) & 0xFF;
+            atapi_pio_buf[7] = block_len & 0xFF;
+            atapi_pio_setup(8);
+        } else {
+            Console.Error("ACATAPI:READ_CAPACITY: image not open or fstat failed");
+            ACATA::R_STATUS |= ATA_STAT_ERR;
+            ACATA::R_ERROR = ATA_ERR_ABORT;
         }
         break;
-    
+    }
+
+    case ATAPICMD::MODE_SENSE: {
+        u8 page_code = P.raw8[2] & 0x3F;
+        u16 alloc_len = (P.raw8[7] << 8) | P.raw8[8];
+        memset(atapi_pio_buf, 0, 64);
+        u32 resp_len = 0;
+        if (page_code == 0x01) {
+            resp_len = 20;
+            if (mode_page_01_set) {
+                memcpy(atapi_pio_buf, mode_page_01, 12);
+            } else {
+                atapi_pio_buf[0] = 0x00; atapi_pio_buf[1] = 0x12;
+                atapi_pio_buf[2] = (ACATA::MediaType == ACMEDIATYPE::ACDVD) ? 0x41 :
+                                   (ACATA::MediaType == ACMEDIATYPE::ACCD)  ? 0x01 : 0x00;
+                atapi_pio_buf[8] = 0x01; atapi_pio_buf[9] = 0x0A;
+                atapi_pio_buf[11] = 0x05;
+            }
+        } else if (page_code == 0x2A) {
+            resp_len = 28;
+            atapi_pio_buf[0] = 0x00; atapi_pio_buf[1] = 0x1A;
+            atapi_pio_buf[8] = 0x2A; atapi_pio_buf[9] = 0x12;
+            atapi_pio_buf[10] = 0x03;
+            atapi_pio_buf[16] = 0x15; atapi_pio_buf[17] = 0xA4;
+            atapi_pio_buf[22] = 0x15; atapi_pio_buf[23] = 0xA4;
+        } else {
+            resp_len = 8;
+            atapi_pio_buf[0] = 0x00; atapi_pio_buf[1] = 0x06;
+        }
+        if (alloc_len > 0 && alloc_len < resp_len)
+            resp_len = alloc_len;
+        atapi_pio_setup(resp_len);
+        break;
+    }
+
+    case ATAPICMD::READ_10: {
+        //Console.Warning("ACATAPI:READ_10: tlen:%X, lba:%X", P.pkt.transf_len, transf_lba);
+        if (!ACATA::TH::IMAGE || nsec == 0) {
+            Console.Error("ACATAPI:READ_10: no image or zero sectors");
+            ACATA::R_STATUS |= ATA_STAT_ERR;
+            ACATA::R_ERROR = ATA_ERR_ABORT;
+            atapi_complete_nodata();
+            break;
+        }
+        if (ACATA_ISDMA) {
+            ACATA::TH::LBA = transf_lba;
+            ACATA::TH::nsector = nsec;
+            ACATA::TH::sectorsize = ACATAPI::CONSTANTS::DVD_SECTORSIZE;
+            ACCORE::DMA::PendTrasnfType = ACCORE::DMA::ATAPI;
+            ACATA::R_NSECTOR = 0x02;
+            CLRB(ACATA::R_STATUS, ATA_STAT_DRQ);
+            CLRB(ACATA::R_STATUS, ATA_STAT_ERR);
+            ACCORE::intr(ACCORE::INTRN_ATA);
+        } else {
+            u32 total = nsec * ACATAPI::CONSTANTS::DVD_SECTORSIZE;
+            if (total > sizeof(atapi_pio_buf)) {
+                Console.Error("ACATAPI:READ_10: transfer too large (%u bytes)", total);
+                ACATA::R_STATUS |= ATA_STAT_ERR;
+                ACATA::R_ERROR = ATA_ERR_ABORT;
+                atapi_complete_nodata();
+                break;
+            }
+            off_t offset = (off_t)transf_lba * ACATAPI::CONSTANTS::DVD_SECTORSIZE;
+            fseeko(ACATA::TH::IMAGE, offset, SEEK_SET);
+            size_t rd = fread(atapi_pio_buf, 1, total, ACATA::TH::IMAGE);
+            if (rd == total) {
+                atapi_pio_setup(total);
+            } else {
+                Console.Error("ACATAPI:READ_10: short read (%zu/%u)", rd, total);
+                ACATA::R_STATUS |= ATA_STAT_ERR;
+                ACATA::R_ERROR = ATA_ERR_ABORT;
+                atapi_complete_nodata();
+            }
+        }
+        break;
+    }
+
+    case ATAPICMD::MODE_SELECT: {
+        u16 param_len = ATAPI_PKT_GETLEN(P);
+        if (param_len > 0) {
+            atapi_pio_write_setup(param_len);
+        } else {
+            atapi_complete_nodata();
+        }
+        break;
+    }
+
     default:
         Console.Error("ACATAPI: UNK_CMD %02X, lba:%08X, nsec:%04X", P.raw8[0], transf_lba, nsec);
         break;
     }
-}
-
-u16 ACATAPI::Read10(u32 lba, u16 tlen) {
-
 }
 
 void ACATAPI::Setup() {

--- a/pcsx2/DEV9/ACATAPI.h
+++ b/pcsx2/DEV9/ACATAPI.h
@@ -31,8 +31,11 @@ typedef union {
 namespace ACATAPI
 {
     void handle_cmd(atapi_packet_t P);
-    u16 Read10(u32 lba, u16 tlen);
     void Setup(); // change ACATA stuff to handle CDROM instead of HDD
+    u16 pio_read_word();
+    bool has_pio_data();
+    void pio_write_word(u16 val);
+    bool has_pio_write();
 
     enum CONSTANTS {
         DVD_SECTORSIZE = 0x800,

--- a/pcsx2/DEV9/ACATA_CMD_RESPONSES
+++ b/pcsx2/DEV9/ACATA_CMD_RESPONSES
@@ -15,7 +15,7 @@ static const uint16_t ATA_R_IDENTIFY_PACKET_DEVICE[256] {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, //[50
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,// [61
     0x0007, //Word 62: Single-word DMA
-    0x0007, //Word 63: Multiword DMA
+    0x0007, //Word 63: Multiword DMA modes 0,1,2 supported
     0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,//[80]
     0,0,0,0,0,0,0,//[87]
     0x0000,//Word 88 — Ultra DMA

--- a/pcsx2/DEV9/ACATA_IO.cpp
+++ b/pcsx2/DEV9/ACATA_IO.cpp
@@ -97,8 +97,28 @@ void ACATA::TH::IO_Read() {
 	}
 }
 
+void ACATA::TH::IO_Write(u32* addr, u32 size) {
+	const s64 lba = ACATA::TH::LBA;
+	const u64 pos = lba * ACATA::TH::sectorsize;
+	u64 size2 = (u64)sectorsize * nsector;
+	if (size != size2)
+		Console.Error("ACATA::TH::IO_Write> mismatch %ld vs %ld", size, size2);
+	if (FileSystem::FSeek64(IMAGE, pos, SEEK_SET) != 0) {
+		Console.ErrorFmt("ACATA:IO_Write: failed to seek pos:{}", pos);
+		return;
+	}
+	if (std::fwrite(addr, sectorsize, nsector, IMAGE) != static_cast<size_t>(nsector)) {
+		Console.ErrorFmt("ACATA:IO_Write: size:{} at:{} failed", size2, pos);
+		return;
+	}
+	std::fflush(IMAGE);
+}
+
 int ACATA::TH::IO_OpenImage() {
-    ACATA::TH::IMAGE = std::fopen(ACATA::imgpath.c_str(), "rb");
+    ACATA::TH::IMAGE = std::fopen(ACATA::imgpath.c_str(), "r+b");
+	if (!ACATA::TH::IMAGE) {
+		ACATA::TH::IMAGE = std::fopen(ACATA::imgpath.c_str(), "rb");
+	}
 	if (!ACATA::TH::IMAGE) {
 		Console.ErrorFmt("{}> fail to fopen '{}' w/ error {} '{}'", __FUNCTION__, ACATA::imgpath, errno, strerror(errno));
 		return errno;

--- a/pcsx2/DEV9/ACCORE.cpp
+++ b/pcsx2/DEV9/ACCORE.cpp
@@ -4,6 +4,7 @@
 #include "ACJV.h"
 #include "ACMACROS.h"
 #include "common/Console.h"
+#include "R3000A.h"
 
 #define ANS(addr, what) case addr: Console.Error("%-16s %08X: %04X", __FUNCTION__, addr, what); return what
 
@@ -27,21 +28,24 @@ void ACCORE::Write16(u32 mem, u16 value) {
 		switch (mem) {
 		case ACJV_CTR_START: Console.Warning("ACJV::START"); ACJV::enabled = true; break;
 		case ACJV_CTR_STOP:  Console.Warning("ACJV::STOP");  ACJV::enabled = false;  break;
-		case 0x1241510C:  Console.Warning("ACCORE::INTR  DISABLE_ACATA_INTR"); break;
-		case 0x1241511C:  Console.Warning("ACCORE::INTR  DISABLE_ACUART_INTR"); break;
+		case 0x1241510C: Console.Warning("ACCORE::INTR  DISABLE_ACATA_INTR"); break;
+		case 0x1241511C: Console.Warning("ACCORE::INTR  DISABLE_ACUART_INTR"); break;
+		case 0x1241511E: break;
 		// ACFPGA UPLOAD MMIO ///TODOx6: move this handling to ACFPGA.cpp
+		// unknown addresses set to 0 on ACCORE. most likely stopping other stuff. games do write to these
+		case 0x1241600A:
+		case 0x12416004:
+		case 0x12416006:
 		case 0x12416014:
-		case 0x12416018:
 		case 0x12416016:
+		case 0x12416018:
 		case 0x1241601A:
+		case 0x1241601E:
+		case 0x12416032:
+		case 0x12416036:
+		case 0x1241603A:
+		case 0x12417000:
 			break;
-		// unknown addresses set to 0 on ACCORE. most likely stopping other stuff
-		//case 0x12416032: break;
-		//case 0x12416032: break;
-		//case 0x12416036: break;
-		//case 0x1241603A: break;
-		//case 0x12417000: break;
-		//case 0x1241601E: break;
 		case ACCORE_FPGA_BEGIN_PROGRAM:
 			INTR_REG |= (0x1000|0x2000);
 			break;
@@ -53,30 +57,31 @@ void ACCORE::Write16(u32 mem, u16 value) {
 		}
 }
 
+bool ACCORE::hasPendingInterrupt() {
+	return INTR_REG != 0;
+}
+
 void ACCORE::intr(int INTRN) {
 	switch (INTRN)
 	{
 	case INTRN_ATA:
 		INTR_REG |= CAUS_ATA;
 		break;
-	
+
 	default:
-		
+
 		return;
 	}
-	//dev9Irq(1);
-	//iopIntcIrq(13);
+	dev9Irq(1);
 }
 
 void ACCORE::Interrupt(u32 mem, u16 v) {
 	switch (mem)
 	{
 	case ACCORE_INTR_ATA:
-		Console.Warning("ACCORE:  ACATA_INTR_CLEAR: %04X", v);
 		CLRB(INTR_REG, CAUS_ATA);
 		break;
 	case ACCORE_INTR_UART:
-		Console.Warning("ACCORE: ACUART_INTR_CLEAR: %04X", v);
 		break;
 	default:
 		Console.Warning("ACCORE: unknown INTR write to: %08X", mem);

--- a/pcsx2/DEV9/ACCORE.h
+++ b/pcsx2/DEV9/ACCORE.h
@@ -12,11 +12,13 @@ namespace ACCORE {
     void Write16(u32 addr, u16 val);
 	void intr(int INTRN);
 	void Interrupt(u32 mem, u16 val);
+	bool hasPendingInterrupt();
 	namespace DMA {
         enum TT {
             NONE = 0,
             ATA,
             ATAPI,
+            ATA_WRITE,
         };
 		extern enum TT PendTrasnfType;
 	}

--- a/pcsx2/DEV9/ACRAM.cpp
+++ b/pcsx2/DEV9/ACRAM.cpp
@@ -4,23 +4,68 @@
 #include "MemoryTypes.h"
 #include "IopMem.h"
 
-#define OOB_REPORT(T) Console.Error("%s: out of bound index: %08X", __FUNCTION__, T);
-#define GET_RAM_OFF(t) ((t - ACRAM_ADDR_BASE)/2) // u8 buffer on u16 MMIO, halve the address to get real offset
+#include <cstring>
+
+#define OOB_REPORT(T) Console.Error("%s: out of bound index: %08X", __FUNCTION__, T)
+#define GET_RAM_OFF(addr) (((addr) - ACRAM_ADDR_BASE) / 2) // u8 buffer on u16 MMIO, halve the address to get real offset
+
+ACRAM::BankState ACRAM::banks[ACRAM_NUM_BANKS] = {};
 
 u16 ACRAM::Read16(u32 addr) {
-    u32 T = GET_RAM_OFF(addr);
-    if (T < ACRAM_MAX_SIZE) {
-        u8 A = iopMem->ACRAM[T];
-        Console.WriteLn(Color_Blue, "%-16s %05X = %02X", __FUNCTION__, T, A);
-        return A;
-    } else OOB_REPORT(addr);
+    u32 off = GET_RAM_OFF(addr);
+    if (off < ACRAM_MAX_SIZE)
+        return iopMem->ACRAM[off];
+    OOB_REPORT(addr);
     return 0;
 }
 
+// Per-bank pointer tracking: real ACRAM has 2 independent banks with separate DMA controllers.
+// Without this, bank 1 writes (streaming) overwrite bank 0 pointers (disc cache), corrupting
+// the source table and hanging the game at load. Ref: ps2sdk acram/src/ram.c
 void ACRAM::Write16(u32 addr, u16 val) {
-    u32 T = GET_RAM_OFF(addr);
-    if (T < ACRAM_MAX_SIZE) {
-        Console.WriteLn(Color_Blue, "%-16s %05X = %02X", __FUNCTION__, T, val);
-        iopMem->ACRAM[T] = (u8)(val&0xFF);
-    } else OOB_REPORT(addr);
+    u32 offset = addr - ACRAM_ADDR_BASE;
+    int bank = (offset >> 21) & 1; // bit 21 selects bank: 64MB = 2x32MB (e.g. TK4: bank0=disc cache, bank1=streaming)
+    u32 reg = offset & ACRAM_REG_MASK;
+    u32 bank_base = bank * ACRAM_BANK_SIZE;
+
+    if (reg >= ACRAM_REG_READ && reg < ACRAM_REG_WRITE)
+        banks[bank].read_addr = bank_base + ((u32)val << 11); // val is a page number, <<11 = 2KB granularity
+    else if (reg >= ACRAM_REG_WRITE && reg < 0x80000)
+        banks[bank].write_addr = bank_base + ((u32)val << 11);
+
+    u32 off = GET_RAM_OFF(addr);
+    if (off < ACRAM_MAX_SIZE)
+        iopMem->ACRAM[off] = (u8)(val & 0xFF);
+    else
+        OOB_REPORT(addr);
+}
+
+int ACRAM::BankFromDmaTarget(u32 dma_target) { // same bit 21 bank select as Write16
+    return ((dma_target - ACRAM_ADDR_BASE) >> 21) & 1;
+}
+
+void ACRAM::DmaRead(u32* iop_buf, u32 size_bytes, int bank) {
+    u32& addr = banks[bank].read_addr;
+    addr &= (ACRAM_MAX_SIZE - 1);
+    if (addr + size_bytes <= ACRAM_MAX_SIZE) {
+        std::memcpy(iop_buf, &iopMem->ACRAM[addr], size_bytes);
+    } else {
+        u32 first = ACRAM_MAX_SIZE - addr;
+        std::memcpy(iop_buf, &iopMem->ACRAM[addr], first);
+        std::memcpy((u8*)iop_buf + first, &iopMem->ACRAM[0], size_bytes - first);
+    }
+    addr = (addr + size_bytes) & (ACRAM_MAX_SIZE - 1);
+}
+
+void ACRAM::DmaWrite(u32* iop_buf, u32 size_bytes, int bank) {
+    u32& addr = banks[bank].write_addr;
+    addr &= (ACRAM_MAX_SIZE - 1);
+    if (addr + size_bytes <= ACRAM_MAX_SIZE) {
+        std::memcpy(&iopMem->ACRAM[addr], iop_buf, size_bytes);
+    } else {
+        u32 first = ACRAM_MAX_SIZE - addr;
+        std::memcpy(&iopMem->ACRAM[addr], iop_buf, first);
+        std::memcpy(&iopMem->ACRAM[0], (u8*)iop_buf + first, size_bytes - first);
+    }
+    addr = (addr + size_bytes) & (ACRAM_MAX_SIZE - 1);
 }

--- a/pcsx2/DEV9/ACRAM.h
+++ b/pcsx2/DEV9/ACRAM.h
@@ -12,15 +12,38 @@
  * System246 Rack B : Builtin on the namco board, seems like 64mb version
  * System246 Rack C : same than Rack B
  * System256 : ACRAM is no longer part of the system
+ *
+ * 64MB = 2 x 32MB banks. Each bank has independent DMA read/write pointers.
+ * Ref: ps2sdk/iop/arcade/acram/src/ram.c, ps2sdk/iop/arcade/accore/src/dma.c
+ *
+ * Address map (base = 0x14000000, bank select = bit 21):
+ *   [base + (bank<<21) + 0x60000]  Read pointer register
+ *   [base + (bank<<21) + 0x70000]  Write pointer register
+ *   [base + (bank<<21) + 0x100000] DMA IO port (written to IOP 0x1F801410)
+ *
+ * Register value = addr >> 11. Reconstructed: bank_base + (val << 11).
  */
 
-#define ACRAM_ADDR_BASE 0x14000000
-#define ACRAM_RANGE     0x1400
-#define ACRAM_MAX_SIZE  _64mb
+#define ACRAM_ADDR_BASE   0x14000000
+#define ACRAM_RANGE       0x1400
+#define ACRAM_MAX_SIZE    _64mb
+#define ACRAM_BANK_SIZE   0x2000000  // 32MB per bank
+#define ACRAM_NUM_BANKS   2
+#define ACRAM_REG_READ    0x60000
+#define ACRAM_REG_WRITE   0x70000
+#define ACRAM_REG_MASK    0x1FFFFF   // isolate register offset within bank
 
 namespace ACRAM
 {
+    struct BankState {
+        u32 read_addr;
+        u32 write_addr;
+    };
+
     u16 Read16(u32 addr);
     void Write16(u32 addr, u16 val);
+    void DmaRead(u32* iop_buf, u32 size_bytes, int bank);
+    void DmaWrite(u32* iop_buf, u32 size_bytes, int bank);
+    int BankFromDmaTarget(u32 dma_target);
+    extern BankState banks[ACRAM_NUM_BANKS];
 }
-

--- a/pcsx2/DEV9/ACUART.cpp
+++ b/pcsx2/DEV9/ACUART.cpp
@@ -1,15 +1,84 @@
 #include "ACUART.h"
 #include "common/Console.h"
 
-#define ANS(addr, what) case addr: return what
+// 16550 UART register emulation for Namco System 246 arcade I/O
+// Ref: ps2sdk iop/arcade/acuart/src/uart.c
+// Register map (16-bit access, 2-byte stride from base 0x12418000):
+//   +0x00  THR/RBR/DLL  (TX/RX data or divisor latch low when DLAB=1)
+//   +0x02  IER/DLH      (interrupt enable or divisor latch high when DLAB=1)
+//   +0x04  IIR/FCR      (interrupt ID read / FIFO control write)
+//   +0x06  LCR          (line control, bit 7 = DLAB)
+//   +0x08  MCR          (modem control)
+//   +0x0A  LSR          (line status)
+//   +0x0C  MSR          (modem status)
+//   +0x0E  SCR          (scratch)
+
+static u16 uart_ier = 0;
+static u16 uart_lcr = 0;
+static u16 uart_mcr = 0;
+static u16 uart_scr = 0;
+static u16 uart_dll = 0;
+static u16 uart_dlh = 0;
+static u16 uart_fcr_shadow = 0;
 
 u16 ACUART::Read16(u32 addr) {
-    return 0;
+	const u32 reg = addr & 0xFFF;
+	switch (reg) {
+	case 0x000: // RBR or DLL
+		if (uart_lcr & 0x80)
+			return uart_dll;
+		return 0; // no RX data
+	case 0x002: // IER or DLH
+		if (uart_lcr & 0x80)
+			return uart_dlh;
+		return uart_ier;
+	case 0x004: // IIR (read-only)
+		return 0x01; // no interrupt pending, 16550 mode
+	case 0x006: // LCR
+		return uart_lcr;
+	case 0x008: // MCR
+		return uart_mcr;
+	case 0x00A: // LSR
+		// bit 5 = THRE (TX holding register empty)
+		// bit 6 = TEMT (TX shift register empty)
+		// both set = transmitter idle, ready to accept data
+		return 0x60;
+	case 0x00C: // MSR
+		return 0;
+	case 0x00E: // SCR
+		return uart_scr;
+	default:
+		return 0;
+	}
 }
 
 void ACUART::Write16(u32 addr, u16 val) {
-    switch (addr) {
-    case 0xB2418002: break; // this seems to be some sort of reg. set to 0 on module stop, and certain bits applied after writing/reading
-    case 0xB2418004: if (val == 7) Console.Warning("ACUART::STOP()"); break;
-    }
+	const u32 reg = addr & 0xFFF;
+	switch (reg) {
+	case 0x000: // THR or DLL
+		if (uart_lcr & 0x80)
+			uart_dll = val;
+		// else: TX data — silently consumed
+		break;
+	case 0x002: // IER or DLH — set to 0 on module stop, bits toggled during xmit (acUartModuleStop, uart_xmit)
+		if (uart_lcr & 0x80)
+			uart_dlh = val;
+		else
+			uart_ier = val;
+		break;
+	case 0x004: // FCR (write-only) — val=7 on module stop: enable FIFO + reset RX/TX (acUartModuleStop)
+		uart_fcr_shadow = val & 0xC9; // preserve trigger level + enable bits
+		break;
+	case 0x006: // LCR
+		uart_lcr = val;
+		break;
+	case 0x008: // MCR
+		uart_mcr = val;
+		break;
+	case 0x00E: // SCR
+		uart_scr = val;
+		break;
+	default:
+		break;
+	}
 }

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -8,6 +8,8 @@
 #include "IopDma.h"
 #include "ACATA.h"
 #include "ACCORE.h"
+#include "ACRAM.h"
+#include "IopHw.h"
 
 #ifdef _WIN32
 #include "common/RedtapeWindows.h"
@@ -216,6 +218,8 @@ int DEV9irqHandler(void)
 	//dev9Ru16(SPD_R_INTR_STAT)|= dev9.irqcause;
 	//DevCon.WriteLn("DEV9: DEV9irqHandler %x, %x", dev9.irqcause, dev9.irqmask);
 	if (dev9.irqcause & dev9.irqmask)
+		return 1;
+	if (ACCORE::hasPendingInterrupt()) // S246 arcade: ATA/ATAPI interrupts go through ACCORE
 		return 1;
 	return 0;
 }
@@ -1072,11 +1076,24 @@ void DEV9readDMA8Mem(u32* pMem, int size)
 	if (ACCORE::DMA::PendTrasnfType == ACCORE::DMA::ATAPI) {
 		ACATA::TH::IO_Read(pMem, size);
 		ACCORE::DMA::PendTrasnfType = ACCORE::DMA::NONE;
+		ACATA::R_STATUS = ATA_STAT_READY;
 		psxDMA8Interrupt();
-	//} else if (ACCORE::DMA::PendTrasnfType == ACCORE::DMA::PTRNSF::ATA) { // TODOx6: impmement me
-
+		ACCORE::intr(ACCORE::INTRN_ATA);
+	} else if (ACCORE::DMA::PendTrasnfType == ACCORE::DMA::ATA) {
+		ACATA::TH::IO_Read(pMem, size);
+		ACCORE::DMA::PendTrasnfType = ACCORE::DMA::NONE;
+		ACATA::R_STATUS = ATA_STAT_READY;
+		psxDMA8Interrupt();
+		ACCORE::intr(ACCORE::INTRN_ATA);
 	} else {
-		Console.Error("%s: requested DMA transfer of 0x%-8X bytes while no pending transfer (%d)", __FUNCTION__, size, ACCORE::DMA::PendTrasnfType);
+		u32 dma_target = psxHu32(0x1410); // check if DMA targets ACRAM (0x14xxxxxx)
+		if ((dma_target & 0xFF000000) == 0x14000000) {
+			int bank = ACRAM::BankFromDmaTarget(dma_target);
+			ACRAM::DmaRead(pMem, size, bank);
+			psxDMA8Interrupt();
+		} else {
+			Console.Error("%s: requested DMA transfer of 0x%-8X bytes while no pending transfer (%d)", __FUNCTION__, size, ACCORE::DMA::PendTrasnfType);
+		}
 	}
 
 #if 0 // TODO: purely for dealing with an "itch". castrate all retail DEV9 operations out of the emu when it's on a working state if possible
@@ -1103,10 +1120,27 @@ void DEV9readDMA8Mem(u32* pMem, int size)
 
 void DEV9writeDMA8Mem(u32* pMem, int size)
 {
+	size >>= 1;
+
+	if (ACCORE::DMA::PendTrasnfType == ACCORE::DMA::ATA_WRITE) {
+		ACATA::TH::IO_Write(pMem, size);
+		ACCORE::DMA::PendTrasnfType = ACCORE::DMA::NONE;
+		ACATA::R_STATUS = ATA_STAT_READY;
+		psxDMA8Interrupt();
+		ACCORE::intr(ACCORE::INTRN_ATA);
+		return;
+	}
+
+	u32 dma_target_w = psxHu32(0x1410);
+	if ((dma_target_w & 0xFF000000) == 0x14000000) {
+		int bank = ACRAM::BankFromDmaTarget(dma_target_w);
+		ACRAM::DmaWrite(pMem, size, bank);
+		psxDMA8Interrupt();
+		return;
+	}
+
 	if (!EmuConfig.DEV9.EthEnable && !EmuConfig.DEV9.HddEnable)
 		return;
-
-	size >>= 1;
 
 	DevCon.WriteLn("DEV9: *DEV9writeDMA8Mem: size %x", size);
 

--- a/pcsx2/IopCounters.cpp
+++ b/pcsx2/IopCounters.cpp
@@ -244,9 +244,9 @@ static void _rcntTestTarget(int i)
 	PSXCNT_LOG("IOP Counter[%d] target 0x%I64x >= 0x%I64x (mode: %x)",
 			   i, psxCounters[i].count, psxCounters[i].target, psxCounters[i].mode.modeval);
 
+	// Target interrupt
 	if (psxCounters[i].mode.targetIntr)
 	{
-		// Target interrupt
 		_rcntFireInterrupt(i, false);
 	}
 
@@ -431,7 +431,7 @@ void psxVBlankStart()
 {
 	cdvdVsync();
 	iopIntcIrq(0);
-	
+
 	_psxCheckStartGate(1);
 	_psxCheckStartGate(3);
 
@@ -479,7 +479,7 @@ void psxRcntUpdate()
 		_rcntTestTarget(i);
 	}
 
-	const u32 spu2_delta = (psxRegs.cycle - lClocks) % 768;
+	const u32 spu2_delta = (psxRegs.cycle - lClocks) % psxCounters[6].rate;
 	psxCounters[6].startCycle = psxRegs.cycle - spu2_delta;
 	psxCounters[6].deltaCycles = psxCounters[6].rate;
 	SPU2async();

--- a/pcsx2/IopDma.cpp
+++ b/pcsx2/IopDma.cpp
@@ -10,6 +10,7 @@
 #include "SIO/Sio2.h"
 
 #include "Sif.h"
+#include "IopMem.h"
 #include "DEV9/DEV9.h"
 
 using namespace R3000A;
@@ -72,9 +73,6 @@ int psxDma4Interrupt()
 
 void spu2DMA4Irq()
 {
-#ifdef SPU2IRQTEST
-	Console.Warning("spu2DMA4Irq()");
-#endif
 	SPU2interruptDMA4();
 	if (HW_DMA4_CHCR & 0x01000000)
 	{
@@ -100,9 +98,6 @@ int psxDma7Interrupt()
 
 void spu2DMA7Irq()
 {
-#ifdef SPU2IRQTEST
-	Console.Warning("spu2DMA7Irq()");
-#endif
 	SPU2interruptDMA7();
 	if (HW_DMA7_CHCR & 0x01000000)
 	{
@@ -156,17 +151,15 @@ void psxDma8(u32 madr, u32 bcr, u32 chcr)
 	switch (chcr & 0x01000201)
 	{
 		case 0x01000201: //cpu to dev9 transfer
-			Console.Warning("*** DMA 8 - DEV9 mem2dev9 *** %lx addr = %lx size = %lx", chcr, madr, bcr);
 			DEV9writeDMA8Mem((u32*)iopPhysMem(madr), size);
 			break;
 
 		case 0x01000200: //dev9 to cpu transfer
-			PSXDMA_LOG("*** DMA 8 - DEV9 dev9mem *** %lx addr = %lx size = %lx", chcr, madr, bcr);
 			DEV9readDMA8Mem((u32*)iopPhysMem(madr), size);
 			break;
 
 		default:
-			Console.Warning("*** DMA 8 - DEV9 unknown *** %lx addr = %lx size = %lx", chcr, madr, bcr);
+			Console.Error("*** DMA 8 - DEV9 unknown *** %lx addr = %lx size = %lx", chcr, madr, bcr);
 			break;
 	}
 }

--- a/pcsx2/IopHw.h
+++ b/pcsx2/IopHw.h
@@ -310,6 +310,7 @@ enum IopEventId
 	IopEvt_CdvdRead,
 	IopEvt_CdvdSectorReady,
 	IopEvt_DEV9,
+	IopEvt_Dma8,
 	IopEvt_USB,
 	IopEvt_SIO2,
 };

--- a/pcsx2/IopIrq.cpp
+++ b/pcsx2/IopIrq.cpp
@@ -39,9 +39,6 @@ void fwIrq()
 
 void spu2Irq()
 {
-	#ifdef SPU2IRQTEST
-		Console.Warning("spu2Irq");
-	#endif
 	iopIntcIrq(9);
 }
 

--- a/pcsx2/IopMem.cpp
+++ b/pcsx2/IopMem.cpp
@@ -170,7 +170,7 @@ u16 iopMemRead16(u32 mem)
 		return V;
 	} else if (t == ACSRAM_RANGE) {
 		return ACSRAM::Read16(mem);
-	} else if (t == ACRAM_RANGE) {
+	} else if ((t & 0xFF00) == ACRAM_RANGE) {
 		return ACRAM::Read16(mem);
 	} else if ((t & 0xFF00) == ACATA_RANGE) {
 		V = ACATA::read16(mem);
@@ -354,9 +354,8 @@ void iopMemWrite16(u32 mem, u16 value)
 	} else if (t == ACJV_RANGE) {
 		if (ACJV::enabled) {
 			ACJV::Write16(mem, value);
-    		// Console.Error("%-16s %08X = %04X", "ACJV::write16", mem, value);
 		}
-	} else if (t == ACRAM_RANGE) {
+	} else if ((t & 0xFF00) == ACRAM_RANGE) {
 		ACRAM::Write16(mem, value);
 	} else if (t == ACSRAM_RANGE) {
 		ACSRAM::Write16(mem, value);

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -193,7 +193,7 @@ static __fi void _psxTestInterrupts()
 	// as follows helps speed up most games.
 
 	if( psxRegs.interrupt & ((1 << IopEvt_Cdvd) | (1 << IopEvt_Dma11) | (1 << IopEvt_Dma12)
-		| (1 << IopEvt_Cdrom) | (1 << IopEvt_CdromRead) | (1 << IopEvt_DEV9) | (1 << IopEvt_USB)
+		| (1 << IopEvt_Cdrom) | (1 << IopEvt_CdromRead) | (1 << IopEvt_DEV9) | (1 << IopEvt_Dma8) | (1 << IopEvt_USB)
 		| (1 << IopEvt_SIO2)))
 	{
 		IopTestEvent(IopEvt_Cdvd,		cdvdActionInterrupt);
@@ -203,6 +203,7 @@ static __fi void _psxTestInterrupts()
 		IopTestEvent(IopEvt_Cdrom,		cdrInterrupt);
 		IopTestEvent(IopEvt_CdromRead,	cdrReadInterrupt);
 		IopTestEvent(IopEvt_DEV9,		dev9Interrupt);
+		IopTestEvent(IopEvt_Dma8,		psxDMA8Interrupt);
 		IopTestEvent(IopEvt_USB,		usbInterrupt);
 	}
 }

--- a/pcsx2/R5900.cpp
+++ b/pcsx2/R5900.cpp
@@ -604,7 +604,7 @@ void eeloadHook()
 	int argc = cpuRegs.GPR.n.a0.SD[0];
 	if (argc) // calls to EELOAD *after* the first one during the startup process will come here
 	{
-#if 1 //DEBUG_LAUNCHARG
+#if DEBUG_LAUNCHARG
 		Console.WriteLn("eeloadHook: EELOAD was called with %d arguments according to $a0 and %d according to vargs block:",
 			argc, memRead32(cpuRegs.GPR.n.a1.UD[0] - 4));
 		for (int a = 0; a < argc; a++)
@@ -696,12 +696,14 @@ void eeloadHook()
 		if (!elfname.empty())
 		{
 			// Find and save location of default/fallback call "rom0:OSDSYS"; to be used later by eeloadHook2()
-			for (g_osdsys_str = EELOAD_START; g_osdsys_str < EELOAD_START + EELOAD_SIZE; g_osdsys_str += 8) // strings are 64-bit aligned
+			g_osdsys_str = 0;
+			for (u32 scan = EELOAD_START; scan < EELOAD_START + EELOAD_SIZE; scan += 8) // strings are 64-bit aligned
 			{
-				if (!strcmp((char*)PSM(g_osdsys_str), "rom0:OSDSYS"))
+				if (!strcmp((char*)PSM(scan), "rom0:OSDSYS"))
 				{
-					// Overwrite OSDSYS with game's ELF name
-					strcpy((char*)PSM(g_osdsys_str), elfname.c_str());
+					// Overwrite OSDSYS with game's ELF path; launch args are injected later by eeloadHook2()
+					strcpy((char*)PSM(scan), elfname.c_str());
+					g_osdsys_str = scan;
 				}
 			}
 		}

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -5,6 +5,7 @@
 #include "SPU2/defs.h"
 #include "SPU2/Debug.h"
 #include "SPU2/Dma.h"
+#include "Common.h"
 #include "Host/AudioStream.h"
 #include "Host.h"
 #include "GS/GSCapture.h"
@@ -40,7 +41,7 @@ float DCFilterIn[2], DCFilterOut[2];
 
 u32 SPU2::GetConsoleSampleRate()
 {
-	return s_psxmode ? PSX_SAMPLE_RATE : SAMPLE_RATE;
+	return s_psxmode ? PSX_SAMPLE_RATE : (PSXCLK / 768);
 }
 
 // --------------------------------------------------------------------------------------

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -7,6 +7,7 @@
 // This module contains (most!) stuff which is directly related to SPU2 emulation.
 // Contents should be cross-platform compatible whenever possible.
 
+#include "Common.h"
 #include "IopCounters.h"
 #include "IopDma.h"
 #include "IopHw.h"
@@ -311,7 +312,7 @@ __forceinline void CheckDMAProgress(int cid)
 	}
 }
 
-static constexpr uint TickInterval = 768;
+static uint TickInterval = 768;
 static constexpr int SanityInterval = 4800;
 
 __forceinline void TimeUpdate(u32 cClocks)

--- a/pcsx2/USB/USB.cpp
+++ b/pcsx2/USB/USB.cpp
@@ -20,7 +20,7 @@
 #include <stdexcept>
 #include <string>
 
-#define PSXCLK 36864000 /* 36.864 Mhz */
+#include "Common.h"
 
 namespace USB
 {

--- a/pcsx2/USB/qemu-usb/usb-ohci.cpp
+++ b/pcsx2/USB/qemu-usb/usb-ohci.cpp
@@ -1401,7 +1401,7 @@ u32 ohci_mem_read(OHCIState* ptr, u32 addr)
 {
 	auto val = ohci_mem_read_impl(ptr, addr);
 	int idx = (addr - ptr->mem_base) >> 2;
-	if (idx < countof(reg_names))
+	if (idx < (int)std::size(reg_names))
 	{
 		Console.Warning("ohci_mem_read %s(%d): %08x\n", reg_names[idx], idx, val);
 	}
@@ -1501,7 +1501,7 @@ void ohci_mem_write_impl(OHCIState* ptr, u32 addr, u32 val);
 void ohci_mem_write(OHCIState* ptr, u32 addr, u32 val)
 {
 	int idx = (addr - ptr->mem_base) >> 2;
-	if (idx < countof(reg_names))
+	if (idx < (int)std::size(reg_names))
 	{
 		Console.Warning("ohci_mem_write %s(%d): %08x\n", reg_names[idx], idx, val);
 	}

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -191,6 +191,7 @@ static u32 s_frame_advance_count = 0;
 static bool s_fast_boot_requested = false;
 static bool s_gs_open_on_initialize = false;
 static bool s_thread_affinities_set = false;
+static bool s_acgame_sys246 = false;
 
 static LimiterModeType s_limiter_mode = LimiterModeType::Nominal;
 static s64 s_limiter_ticks_per_frame = 0;
@@ -1297,12 +1298,26 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				s_acmedia = INI.GetStringValue("data", "media");
 				s_imgname = INI.GetStringValue("data", "mediasrc");
 				s_disc_serial = s_serial = INI.GetStringValue("game", "gameid");
+				std::string platform = INI.GetStringValue("game", "platform", "");
+				s_acgame_sys246 = (platform == "246" || platform == "256");
+				if (s_acgame_sys246)
+				{
+					Console.WriteLnFmt(Color_Green, "ACGAME: System {} detected — extended IOP RAM", platform);
+				}
 
 				std::string card;
 				if ((card = INI.GetStringValue("data", "dongle", "")) != "") {
+					std::string src = Path::Combine(basedir, card);
+					std::string dst = Path::Combine(EmuFolders::MemoryCards, card);
+					if (FileSystem::FileExists(src.c_str()) && !FileSystem::FileExists(dst.c_str()))
+						FileSystem::CopyFilePath(src.c_str(), dst.c_str(), false);
 					Host::SetBaseStringSettingValue("MemoryCards", "Slot1_Filename", card.c_str());
 				}
 				if ((card = INI.GetStringValue("data", "card", "")) != "") {
+					std::string src = Path::Combine(basedir, card);
+					std::string dst = Path::Combine(EmuFolders::MemoryCards, card);
+					if (FileSystem::FileExists(src.c_str()) && !FileSystem::FileExists(dst.c_str()))
+						FileSystem::CopyFilePath(src.c_str(), dst.c_str(), false);
 					Host::SetBaseStringSettingValue("MemoryCards", "Slot2_Filename", card.c_str());
 				}
 				/// TODOx6: Decide if we want to lock mc1 access if .ACGAME does not ask for it
@@ -1312,6 +1327,7 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 
 				//FileMcd_Reopen(s_serial);
 				s_elf_override = Path::Combine(basedir, INI.GetStringValue("data", "elf"));
+				EmuConfig.CurrentGameArgs = INI.GetStringValue("data", "args");
 				ACSRAM::filepath = Path::Combine(basedir, INI.GetStringValue("data", "sram", "sram.bin"));
 				ACATA::SetEnv(basedir, s_imgname, s_acmedia);
 				int R;
@@ -1322,7 +1338,7 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				Console.WriteLnFmt(Color_Green, "ACGAME: elf:'{}'", s_elf_override);
 				Console.WriteLnFmt(Color_Green, "ACGAME: sram:'{}'", ACSRAM::filepath);
 				Console.WriteLnFmt(Color_Green, "ACGAME: media:'{}'", ACATA::imgpath);
-				
+
 				return true;
 			}
 		}
@@ -1579,6 +1595,8 @@ VMBootResult VMManager::Initialize(const VMBootParameters& boot_params, Error* e
 	s_cpu_implementation_changed = false;
 	UpdateCPUImplementations();
 	mmap_ResetBlockTracking();
+	if (s_acgame_sys246)
+		EmuConfig.Cpu.ExtraMemory = true;
 	memSetExtraMemMode(EmuConfig.Cpu.ExtraMemory);
 	Internal::ClearCPUExecutionCaches();
 	FPControlRegister::SetCurrent(EmuConfig.Cpu.FPUFPCR);

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -644,11 +644,10 @@ static void psxRecompileIrxImport()
 	const std::string libname = iopMemReadString(import_table + 12, 8);
 
 	irxHLE hle = irxImportHLE(libname, index);
-#ifdef PCSX2_DEVBUILD
 	const irxDEBUG debug = irxImportDebug(libname, index);
+#ifdef PCSX2_DEVBUILD
 	const char* funcname = irxImportFuncname(libname, index);
 #else
-	const irxDEBUG debug = 0;
 	const char* funcname = nullptr;
 #endif
 

--- a/pcsx2/x86/ix86-32/iR5900.cpp
+++ b/pcsx2/x86/ix86-32/iR5900.cpp
@@ -2218,12 +2218,15 @@ static void recRecompile(const u32 startpc)
 			const u32 typeBexecjump = memRead32(EELOAD_START + 0x5B0); // v1.20, v1.50, v1.60 (3000x models)
 			const u32 typeCexecjump = memRead32(EELOAD_START + 0x618); // v1.60 (3900x models)
 			const u32 typeDexecjump = memRead32(EELOAD_START + 0x600); // v1.70, v1.90, v2.00, v2.20, v2.30
-			if ((typeBexecjump >> 26 == 3) || (typeCexecjump >> 26 == 3) || (typeDexecjump >> 26 == 3)) // JAL to 0x822B8
+			const u32 typeEexecjump = memRead32(EELOAD_START + 0x4E8); // COH-H System 246 (Namco arcade)
+			if ((typeBexecjump >> 26 == 3) || (typeCexecjump >> 26 == 3) || (typeDexecjump >> 26 == 3) || (typeEexecjump >> 26 == 3)) // JAL to 0x822B8
 				g_eeloadExec = EELOAD_START + 0x2B8;
 			else if (typeAexecjump >> 26 == 3) // JAL to 0x82170
 				g_eeloadExec = EELOAD_START + 0x170;
-			else // There might be other types of EELOAD, because these models' BIOSs have not been examined: 18000, 3500x, 3700x, 5500x, and 7900x. However, all BIOS versions have been examined except for v1.01 and v1.10.
-				Console.WriteLn("recRecompile: Could not enable launch arguments for fast boot mode; unidentified BIOS version! Please report this to the PCSX2 developers.");
+			else
+			{
+				Console.WriteLn("recRecompile: Could not enable launch arguments for fast boot mode; unidentified BIOS version!");
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR adds the storage and I/O subsystem needed to boot many games.

Main feature is full ATA/ATAPI emulation layer (with task-file registers, PIO and DMA transfers, IDENTIFY, PACKET commands). We let the hardware talk by giving it the tools it needs to. No hacks.

After testing Tekken 4, Soul Calibur II and Cobra many times, I had to do some more work:
  - ACRAM now tracks two independent 32MB banks with their own DMA pointers. This fixes a streaming hang in Tekken 4, where bank 0 and bank 1 writes were overwriting each other.
  - DMA8 is wired up properly.
  - BIOS checks for a serial port at boot, now ACUART responds
  - SPU2 and USB timing were hardcoded toPS2 clock; now follows actual IOP clock (faster on S246).
  - VMManager now reads the .acgame file to detect S246/S256 games, enable the 8MB IOP RAM they require (e.g.: Cobra), and pass launch arguments to the game ELF. 
  - Dongle and card files are auto-copied to the memcard folder so games find them without manual setup **(need more testing)**
  - S246 BIOS has EELOAD exec jump at a different offset. Now launch arguments reach the game.
  
Minor cleanup too.

TESTED:
Tekken 4 now boots to attract mode
Soul Calibur II, no regression
Cobra: The Arcade fails to boot, triggers an erase on boot (must investigate, maybe a timing issue but NOT a cycle speed issue - was tested with 256 clocks too, no change)