### PR TITLE
(1/3) runtime clock support for 256 games

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -35,6 +35,7 @@
 
 cdvdStruct cdvd;
 
+u32 PS2CLK = PS2CLK_DEFAULT;
 u32 PSXCLK = 36864000;
 
 static constexpr s32 GMT9_OFFSET_SECONDS = 9 * 60 * 60; // 32400
@@ -73,7 +74,7 @@ static void CDVDSECTORREADY_INT(u32 eCycle)
 
 	if (EmuConfig.Speedhacks.fastCDVD)
 	{
-		if (eCycle < Cdvd_FullSeek_Cycles && eCycle > 1)
+		if (eCycle < Cdvd_FullSeek_Cycles() && eCycle > 1)
 			eCycle *= 0.5f;
 	}
 
@@ -86,7 +87,7 @@ static void CDVDREAD_INT(u32 eCycle)
 	// Keep long seeks out though, as games may try to push dmas while seeking. (Tales of the Abyss)
 	if (EmuConfig.Speedhacks.fastCDVD)
 	{
-		if (eCycle < Cdvd_FullSeek_Cycles && eCycle > 1)
+		if (eCycle < Cdvd_FullSeek_Cycles() && eCycle > 1)
 			eCycle *= 0.5f;
 	}
 
@@ -1496,12 +1497,12 @@ static uint cdvdStartSeek(uint newsector, CDVD_MODE_TYPE mode, bool transition_t
 		{
 			// Full Seek
 			CDVD_LOG("CdSeek Begin > to sector %d, from %d - delta=%d [FULL]", cdvd.SeekToSector, cdvd.CurrentSector, delta);
-			seektime = Cdvd_FullSeek_Cycles;
+			seektime = Cdvd_FullSeek_Cycles();
 		}
 		else
 		{
 			CDVD_LOG("CdSeek Begin > to sector %d, from %d - delta=%d [FAST]", cdvd.SeekToSector, cdvd.CurrentSector, delta);
-			seektime = Cdvd_FastSeek_Cycles;
+			seektime = Cdvd_FastSeek_Cycles();
 		}
 		isSeeking = true;
 	}

--- a/pcsx2/CDVD/CDVD_internal.h
+++ b/pcsx2/CDVD/CDVD_internal.h
@@ -155,8 +155,8 @@ static constexpr uint DVD_MAX_ROTATION_X1 = 1515;
 // Legacy Note: FullSeek timing causes many games to load very slow, but it likely not the real problem.
 // Games breaking with it set to PSXCLK*40 : "wrath unleashed" and "Shijou Saikyou no Deshi Kenichi".
 
-static constexpr uint Cdvd_FullSeek_Cycles = (36864000UL * 100UL) / 1000UL; // average number of cycles per fullseek (100ms)
-static constexpr uint Cdvd_FastSeek_Cycles = (36864000UL * 30UL) / 1000UL;  // average number of cycles per fastseek (37ms)
+static inline uint Cdvd_FullSeek_Cycles() { return (PSXCLK * 100UL) / 1000UL; } // average number of IOP cycles per fullseek (100ms)
+static inline uint Cdvd_FastSeek_Cycles() { return (PSXCLK * 30UL) / 1000UL; }  // average number of IOP cycles per fastseek (37ms)
 bool trayState = 0; // Used to check if the CD tray status has changed since the last time
 
 static const char* mg_zones[8] = {"Japan", "USA", "Europe", "Oceania", "Asia", "Russia", "China", "Mexico"};

--- a/pcsx2/Common.h
+++ b/pcsx2/Common.h
@@ -6,8 +6,11 @@
 #include "common/Pcsx2Defs.h"
 
 static const u32 BIAS = 2;				// Bus is half of the actual ps2 speed
-static const u32 PS2CLK = 294912000;	//hz	/* 294.912 mhz */
-extern u32 PSXCLK;	/* 36.864 Mhz */
+// EE bus clock: S246 runs at console speed (294.912 MHz), S256 runs 4/3 faster (393.216 MHz)
+static const u32 PS2CLK_DEFAULT = 294912000;	//hz	/* 294.912 mhz — PS2 console / S246 */
+static const u32 PS2CLK_S256    = 393216000;	//hz	/* 393.216 mhz — S256 (294.912 * 4/3) */
+extern u32 PS2CLK;
+extern u32 PSXCLK;	/* 36.864 Mhz (S246) or 49.152 Mhz (S256) */
 
 
 #include "Memory.h"

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -8,6 +8,7 @@
 #include "R3000A.h"
 #include "Counters.h"
 #include "IopCounters.h"
+#include "IopMem.h"
 
 #include "GS.h"
 #include "GS/GS.h"
@@ -30,6 +31,7 @@ uint g_FrameCount = 0;
 Counter counters[4];
 SyncCounter hsyncCounter;
 SyncCounter vsyncCounter;
+bool s_sys256_mode = false;
 
 u64 nextStartCounter;	// records the cpuRegs.cycle value of the last call to rcntUpdate()
 s32 nextDeltaCounter;	// delta from nextsCounter, in cycles, until the next rcntUpdate()
@@ -202,7 +204,7 @@ void rcntInit()
 
 static void vSyncInfoCalc(vSyncTimingInfo* info, double framesPerSecond, u32 scansPerFrame)
 {
-	constexpr double clock = static_cast<double>(PS2CLK);
+	const double clock = static_cast<double>(PS2CLK);
 
 	const u64 Frame = clock * 10000ULL / framesPerSecond;
 	const u64 Scanline = Frame / scansPerFrame;

--- a/pcsx2/Counters.h
+++ b/pcsx2/Counters.h
@@ -120,6 +120,7 @@ extern SyncCounter vsyncCounter;
 extern s32 nextDeltaCounter;		// delta until the next counter event (must be signed)
 extern u64 nextStartCounter;
 extern uint g_FrameCount;
+extern bool s_sys256_mode;
 
 extern void rcntUpdate_hScanline();
 extern void rcntUpdate_vSync();

--- a/pcsx2/HwWrite.cpp
+++ b/pcsx2/HwWrite.cpp
@@ -178,7 +178,6 @@ void _hwWrite32( u32 mem, u32 value )
 						u64 cycle = psxRegs.cycle;
 						//pgifInit();
 						psxReset();
-						PSXCLK =  33868800;
 						SPU2::Reset(true);
 						setPs1CDVDSpeed(cdvd.Speed);
 						psxHu32(HW_ICFG) = 0x8;

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -48,8 +48,8 @@ void psxReset()
 	psxRegs.iopCycleEECarry = 0;
 	psxRegs.iopNextEventCycle = psxRegs.cycle + 4;
 
+	PSXCLK = (PS2CLK == PS2CLK_S256) ? 49152000 : 36864000;
 	psxHwReset();
-	PSXCLK = 36864000;
 	ioman::reset();
 	psxBiosReset();
 }

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -192,6 +192,7 @@ static bool s_fast_boot_requested = false;
 static bool s_gs_open_on_initialize = false;
 static bool s_thread_affinities_set = false;
 static bool s_acgame_sys246 = false;
+static bool s_acgame_sys256 = false;
 
 static LimiterModeType s_limiter_mode = LimiterModeType::Nominal;
 static s64 s_limiter_ticks_per_frame = 0;
@@ -1300,6 +1301,9 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				s_disc_serial = s_serial = INI.GetStringValue("game", "gameid");
 				std::string platform = INI.GetStringValue("game", "platform", "");
 				s_acgame_sys246 = (platform == "246" || platform == "256");
+				s_acgame_sys256 = (platform == "256");
+				if (s_acgame_sys256)
+					PS2CLK = PS2CLK_S256;
 				if (s_acgame_sys246)
 				{
 					Console.WriteLnFmt(Color_Green, "ACGAME: System {} detected — extended IOP RAM", platform);
@@ -1597,6 +1601,11 @@ VMBootResult VMManager::Initialize(const VMBootParameters& boot_params, Error* e
 	mmap_ResetBlockTracking();
 	if (s_acgame_sys246)
 		EmuConfig.Cpu.ExtraMemory = true;
+	if (s_acgame_sys256)
+	{
+		s_sys256_mode = true;
+		Console.WriteLnFmt(Color_Green, "S256: bus clock 393MHz, IOP 49MHz");
+	}
 	memSetExtraMemMode(EmuConfig.Cpu.ExtraMemory);
 	Internal::ClearCPUExecutionCaches();
 	FPControlRegister::SetCurrent(EmuConfig.Cpu.FPUFPCR);
@@ -1757,6 +1766,9 @@ void VMManager::Shutdown(bool save_resume_state)
 	SaveSessionTime(s_disc_serial);
 	s_elf_override = {};
 	s_acgame = {};
+	PS2CLK = PS2CLK_DEFAULT;
+	PSXCLK = 36864000;
+	s_sys256_mode = false;
 	ClearELFInfo();
 	CDVDsys_ClearFiles();
 


### PR DESCRIPTION
PS2CLK is now a runtime variable (was compile-time const). When acgame sets platform=256, PS2CLK=393216000 (4/3x) and PSXCLK=49152000. CDVD seek cycles, EE counters, and EELOAD hook all adapt to the runtime clock. SBUS_F240 IOP reset no longer clobbers PSXCLK with the PS1 value.

Cobra The Arcade boots to attract. Probably other S256 games too (untested).

Add `platform=256` in .acgame file to enable the correct clock speed.

Should be automatic in the future. But need full database of GAME IDS first.