### PR TITLE
(3/3) boot: fix dongle boot race, suppress DAEMON sec_checker thread

### DIFF
--- a/pcsx2-qt/Settings/JVSControlsWidget.cpp
+++ b/pcsx2-qt/Settings/JVSControlsWidget.cpp
@@ -50,6 +50,9 @@ void JVSControlsWidget::bindDIPSwitchWidgets()
 		ACJV::CONFIG_SECTION, video_sync_split.name, video_sync_split.default_value);
 	m_ui.toggleVideoSyncSplit->initialize(m_dialog->getProfileSettingsInterface(),
 		InputBindingInfo::Type::Button, ACJV::CONFIG_SECTION, video_sync_split.toggle_bind_name);
+
+	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(m_dialog->getProfileSettingsInterface(), m_ui.suppressDaemon,
+		ACJV::CONFIG_SECTION, "SuppressDaemon", true);
 }
 
 #include "moc_JVSControlsWidget.cpp"

--- a/pcsx2-qt/Settings/JVSControlsWidget.ui
+++ b/pcsx2-qt/Settings/JVSControlsWidget.ui
@@ -172,6 +172,22 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="extraGroup">
+         <property name="title">
+          <string>Extra</string>
+         </property>
+         <layout class="QVBoxLayout" name="extraLayout">
+          <item>
+           <widget class="QCheckBox" name="suppressDaemon">
+            <property name="text">
+             <string>Suppress DAEMON security thread</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -35,6 +35,7 @@
 
 cdvdStruct cdvd;
 
+u32 PS2CLK = PS2CLK_DEFAULT;
 u32 PSXCLK = 36864000;
 
 static constexpr s32 GMT9_OFFSET_SECONDS = 9 * 60 * 60; // 32400
@@ -73,7 +74,7 @@ static void CDVDSECTORREADY_INT(u32 eCycle)
 
 	if (EmuConfig.Speedhacks.fastCDVD)
 	{
-		if (eCycle < Cdvd_FullSeek_Cycles && eCycle > 1)
+		if (eCycle < Cdvd_FullSeek_Cycles() && eCycle > 1)
 			eCycle *= 0.5f;
 	}
 
@@ -86,7 +87,7 @@ static void CDVDREAD_INT(u32 eCycle)
 	// Keep long seeks out though, as games may try to push dmas while seeking. (Tales of the Abyss)
 	if (EmuConfig.Speedhacks.fastCDVD)
 	{
-		if (eCycle < Cdvd_FullSeek_Cycles && eCycle > 1)
+		if (eCycle < Cdvd_FullSeek_Cycles() && eCycle > 1)
 			eCycle *= 0.5f;
 	}
 
@@ -1496,12 +1497,12 @@ static uint cdvdStartSeek(uint newsector, CDVD_MODE_TYPE mode, bool transition_t
 		{
 			// Full Seek
 			CDVD_LOG("CdSeek Begin > to sector %d, from %d - delta=%d [FULL]", cdvd.SeekToSector, cdvd.CurrentSector, delta);
-			seektime = Cdvd_FullSeek_Cycles;
+			seektime = Cdvd_FullSeek_Cycles();
 		}
 		else
 		{
 			CDVD_LOG("CdSeek Begin > to sector %d, from %d - delta=%d [FAST]", cdvd.SeekToSector, cdvd.CurrentSector, delta);
-			seektime = Cdvd_FastSeek_Cycles;
+			seektime = Cdvd_FastSeek_Cycles();
 		}
 		isSeeking = true;
 	}

--- a/pcsx2/CDVD/CDVD_internal.h
+++ b/pcsx2/CDVD/CDVD_internal.h
@@ -155,8 +155,8 @@ static constexpr uint DVD_MAX_ROTATION_X1 = 1515;
 // Legacy Note: FullSeek timing causes many games to load very slow, but it likely not the real problem.
 // Games breaking with it set to PSXCLK*40 : "wrath unleashed" and "Shijou Saikyou no Deshi Kenichi".
 
-static constexpr uint Cdvd_FullSeek_Cycles = (36864000UL * 100UL) / 1000UL; // average number of cycles per fullseek (100ms)
-static constexpr uint Cdvd_FastSeek_Cycles = (36864000UL * 30UL) / 1000UL;  // average number of cycles per fastseek (37ms)
+static inline uint Cdvd_FullSeek_Cycles() { return (PSXCLK * 100UL) / 1000UL; } // average number of IOP cycles per fullseek (100ms)
+static inline uint Cdvd_FastSeek_Cycles() { return (PSXCLK * 30UL) / 1000UL; }  // average number of IOP cycles per fastseek (37ms)
 bool trayState = 0; // Used to check if the CD tray status has changed since the last time
 
 static const char* mg_zones[8] = {"Japan", "USA", "Europe", "Oceania", "Asia", "Russia", "China", "Mexico"};

--- a/pcsx2/Common.h
+++ b/pcsx2/Common.h
@@ -6,8 +6,11 @@
 #include "common/Pcsx2Defs.h"
 
 static const u32 BIAS = 2;				// Bus is half of the actual ps2 speed
-static const u32 PS2CLK = 294912000;	//hz	/* 294.912 mhz */
-extern u32 PSXCLK;	/* 36.864 Mhz */
+// EE bus clock: S246 runs at console speed (294.912 MHz), S256 runs 4/3 faster (393.216 MHz)
+static const u32 PS2CLK_DEFAULT = 294912000;	//hz	/* 294.912 mhz — PS2 console / S246 */
+static const u32 PS2CLK_S256    = 393216000;	//hz	/* 393.216 mhz — S256 (294.912 * 4/3) */
+extern u32 PS2CLK;
+extern u32 PSXCLK;	/* 36.864 Mhz (S246) or 49.152 Mhz (S256) */
 
 
 #include "Memory.h"

--- a/pcsx2/Counters.cpp
+++ b/pcsx2/Counters.cpp
@@ -8,6 +8,7 @@
 #include "R3000A.h"
 #include "Counters.h"
 #include "IopCounters.h"
+#include "IopMem.h"
 
 #include "GS.h"
 #include "GS/GS.h"
@@ -30,6 +31,7 @@ uint g_FrameCount = 0;
 Counter counters[4];
 SyncCounter hsyncCounter;
 SyncCounter vsyncCounter;
+bool s_sys256_mode = false;
 
 u64 nextStartCounter;	// records the cpuRegs.cycle value of the last call to rcntUpdate()
 s32 nextDeltaCounter;	// delta from nextsCounter, in cycles, until the next rcntUpdate()
@@ -202,7 +204,7 @@ void rcntInit()
 
 static void vSyncInfoCalc(vSyncTimingInfo* info, double framesPerSecond, u32 scansPerFrame)
 {
-	constexpr double clock = static_cast<double>(PS2CLK);
+	const double clock = static_cast<double>(PS2CLK);
 
 	const u64 Frame = clock * 10000ULL / framesPerSecond;
 	const u64 Scanline = Frame / scansPerFrame;

--- a/pcsx2/Counters.h
+++ b/pcsx2/Counters.h
@@ -120,6 +120,7 @@ extern SyncCounter vsyncCounter;
 extern s32 nextDeltaCounter;		// delta until the next counter event (must be signed)
 extern u64 nextStartCounter;
 extern uint g_FrameCount;
+extern bool s_sys256_mode;
 
 extern void rcntUpdate_hScanline();
 extern void rcntUpdate_vSync();

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -58,7 +58,7 @@ static constexpr const std::array<u16, ACJV::NUM_DIP_SWITCHES> s_dip_switch_mask
 }};
 
 static constexpr const std::array<ACJV::DIPSwitchInfo, ACJV::NUM_DIP_SWITCHES> s_dip_switch_info = {{
-	{"TestMode", TRANSLATE_NOOP("JVS", "Test Mode"), "ToggleTestMode", true},
+	{"TestMode", TRANSLATE_NOOP("JVS", "Test Mode"), "ToggleTestMode", false},
 	{"VideoVoltage", TRANSLATE_NOOP("JVS", "Video Voltage"), "ToggleVideoVoltage", true},
 	{"MonitorSyncFrequency", TRANSLATE_NOOP("JVS", "Monitor Sync Frequency"), "ToggleMonitorSyncFrequency", true},
 	{"VideoSyncSplit", TRANSLATE_NOOP("JVS", "Video Sync Split"), "ToggleVideoSyncSplit", true},
@@ -69,6 +69,41 @@ static constexpr const std::array<InputBindingInfo, ACJV::NUM_DIP_SWITCHES> s_di
 	{s_dip_switch_info[1].toggle_bind_name, TRANSLATE_NOOP("JVS", "Toggle Video Voltage"), nullptr, InputBindingInfo::Type::Button, 1, GenericInputBinding::Unknown},
 	{s_dip_switch_info[2].toggle_bind_name, TRANSLATE_NOOP("JVS", "Toggle Monitor Sync Frequency"), nullptr, InputBindingInfo::Type::Button, 2, GenericInputBinding::Unknown},
 	{s_dip_switch_info[3].toggle_bind_name, TRANSLATE_NOOP("JVS", "Toggle Video Sync Split"), nullptr, InputBindingInfo::Type::Button, 3, GenericInputBinding::Unknown},
+}};
+
+static constexpr const std::array<InputBindingInfo, 12> s_jvs_p1_button_bindings = {{
+	{"P1_Up",      TRANSLATE_NOOP("JVS", "P1 Up"),       nullptr, InputBindingInfo::Type::Button, JVS_BTN_UP,      GenericInputBinding::DPadUp},
+	{"P1_Down",    TRANSLATE_NOOP("JVS", "P1 Down"),     nullptr, InputBindingInfo::Type::Button, JVS_BTN_DOWN,    GenericInputBinding::DPadDown},
+	{"P1_Left",    TRANSLATE_NOOP("JVS", "P1 Left"),     nullptr, InputBindingInfo::Type::Button, JVS_BTN_LEFT,    GenericInputBinding::DPadLeft},
+	{"P1_Right",   TRANSLATE_NOOP("JVS", "P1 Right"),    nullptr, InputBindingInfo::Type::Button, JVS_BTN_RIGHT,   GenericInputBinding::DPadRight},
+	{"P1_Button1", TRANSLATE_NOOP("JVS", "P1 Button 1"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_1,       GenericInputBinding::Square},
+	{"P1_Button2", TRANSLATE_NOOP("JVS", "P1 Button 2"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_2,       GenericInputBinding::Triangle},
+	{"P1_Button3", TRANSLATE_NOOP("JVS", "P1 Button 3"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_3,       GenericInputBinding::Unknown},
+	{"P1_Button4", TRANSLATE_NOOP("JVS", "P1 Button 4"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_4,       GenericInputBinding::Cross},
+	{"P1_Button5", TRANSLATE_NOOP("JVS", "P1 Button 5"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_5,       GenericInputBinding::Circle},
+	{"P1_Button6", TRANSLATE_NOOP("JVS", "P1 Button 6"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_6,       GenericInputBinding::Unknown},
+	{"P1_Start",   TRANSLATE_NOOP("JVS", "P1 Start"),    nullptr, InputBindingInfo::Type::Button, JVS_BTN_START,   GenericInputBinding::Start},
+	{"P1_Service", TRANSLATE_NOOP("JVS", "P1 Service"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_SERVICE, GenericInputBinding::Select}, // Coins
+}};
+
+static constexpr const std::array<InputBindingInfo, 12> s_jvs_p2_button_bindings = {{
+	{"P2_Up",      TRANSLATE_NOOP("JVS", "P2 Up"),       nullptr, InputBindingInfo::Type::Button, JVS_BTN_UP,      GenericInputBinding::DPadUp},
+	{"P2_Down",    TRANSLATE_NOOP("JVS", "P2 Down"),     nullptr, InputBindingInfo::Type::Button, JVS_BTN_DOWN,    GenericInputBinding::DPadDown},
+	{"P2_Left",    TRANSLATE_NOOP("JVS", "P2 Left"),     nullptr, InputBindingInfo::Type::Button, JVS_BTN_LEFT,    GenericInputBinding::DPadLeft},
+	{"P2_Right",   TRANSLATE_NOOP("JVS", "P2 Right"),    nullptr, InputBindingInfo::Type::Button, JVS_BTN_RIGHT,   GenericInputBinding::DPadRight},
+	{"P2_Button1", TRANSLATE_NOOP("JVS", "P2 Button 1"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_1,       GenericInputBinding::Square},
+	{"P2_Button2", TRANSLATE_NOOP("JVS", "P2 Button 2"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_2,       GenericInputBinding::Triangle},
+	{"P2_Button3", TRANSLATE_NOOP("JVS", "P2 Button 3"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_3,       GenericInputBinding::Unknown},
+	{"P2_Button4", TRANSLATE_NOOP("JVS", "P2 Button 4"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_4,       GenericInputBinding::Cross},
+	{"P2_Button5", TRANSLATE_NOOP("JVS", "P2 Button 5"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_5,       GenericInputBinding::Circle},
+	{"P2_Button6", TRANSLATE_NOOP("JVS", "P2 Button 6"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_6,       GenericInputBinding::Unknown},
+	{"P2_Start",   TRANSLATE_NOOP("JVS", "P2 Start"),    nullptr, InputBindingInfo::Type::Button, JVS_BTN_START,   GenericInputBinding::Start},
+	{"P2_Service", TRANSLATE_NOOP("JVS", "P2 Service"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_SERVICE, GenericInputBinding::Select},
+}};
+
+static constexpr const std::array<InputBindingInfo, 2> s_jvs_coin_bindings = {{
+	{"Coin1", TRANSLATE_NOOP("JVS", "Insert Coin P1"), nullptr, InputBindingInfo::Type::Button, 0, GenericInputBinding::Unknown},
+	{"Coin2", TRANSLATE_NOOP("JVS", "Insert Coin P2"), nullptr, InputBindingInfo::Type::Button, 1, GenericInputBinding::Unknown},
 }};
 
 static u16 s_dip_switch_state = DEFAULT_DIP_SWITCH_STATE;
@@ -102,6 +137,21 @@ const ACJV::DIPSwitchInfo& ACJV::GetVideoSyncSplitDIPSwitch()
 std::span<const InputBindingInfo> ACJV::GetDIPSwitchBindings()
 {
 	return s_dip_switch_bindings;
+}
+
+std::span<const InputBindingInfo> ACJV::GetButtonBindings()
+{
+	return s_jvs_p1_button_bindings;
+}
+
+std::span<const InputBindingInfo> ACJV::GetP2ButtonBindings()
+{
+	return s_jvs_p2_button_bindings;
+}
+
+std::span<const InputBindingInfo> ACJV::GetCoinBindings()
+{
+	return s_jvs_coin_bindings;
 }
 
 bool ACJV::GetDIPSwitchState(u32 index)
@@ -154,6 +204,12 @@ void ACJV::CopyConfiguration(SettingsInterface* dest_si, const SettingsInterface
 	{
 		for (const DIPSwitchInfo& dip_switch : s_dip_switch_info)
 			dest_si->CopyStringListValue(src_si, CONFIG_SECTION, dip_switch.toggle_bind_name);
+		for (const InputBindingInfo& bi : s_jvs_p1_button_bindings)
+			dest_si->CopyStringListValue(src_si, CONFIG_SECTION, bi.name);
+		for (const InputBindingInfo& bi : s_jvs_p2_button_bindings)
+			dest_si->CopyStringListValue(src_si, CONFIG_SECTION, bi.name);
+		for (const InputBindingInfo& bi : s_jvs_coin_bindings)
+			dest_si->CopyStringListValue(src_si, CONFIG_SECTION, bi.name);
 	}
 }
 
@@ -162,6 +218,18 @@ void ACJV::SetDefaultConfiguration(SettingsInterface& si)
 	si.ClearSection(CONFIG_SECTION);
 	for (const DIPSwitchInfo& dip_switch : s_dip_switch_info)
 		si.SetBoolValue(CONFIG_SECTION, dip_switch.name, dip_switch.default_value);
+
+	si.SetStringValue(CONFIG_SECTION, "P1_Up",      "Keyboard/Up");
+	si.SetStringValue(CONFIG_SECTION, "P1_Down",    "Keyboard/Down");
+	si.SetStringValue(CONFIG_SECTION, "P1_Left",    "Keyboard/Left");
+	si.SetStringValue(CONFIG_SECTION, "P1_Right",   "Keyboard/Right");
+	si.SetStringValue(CONFIG_SECTION, "P1_Button1", "Keyboard/J");
+	si.SetStringValue(CONFIG_SECTION, "P1_Button2", "Keyboard/I");
+	si.SetStringValue(CONFIG_SECTION, "P1_Button3", "Keyboard/K");
+	si.SetStringValue(CONFIG_SECTION, "P1_Button4", "Keyboard/L");
+	si.SetStringValue(CONFIG_SECTION, "P1_Start",   "Keyboard/Return");
+	si.SetStringValue(CONFIG_SECTION, "P1_Service", "Keyboard/Backspace");
+	si.SetStringValue(CONFIG_SECTION, "Coin1",      "Keyboard/5");
 }
 
 u16 ACJV::Read16(u32 addr) {
@@ -193,6 +261,26 @@ u16 m_jvsButtonState[JVS_PLAYER_COUNT] = {};
 u8 m_testButtonState = 0;
 u16 m_coin1 = 0;
 u16 m_coin2 = 0;
+
+// Gamepad input -> JVS button state: set or clear a button bit for a player
+void ACJV::SetButtonState(u32 player, u16 mask, bool pressed)
+{
+	if (player >= JVS_PLAYER_COUNT)
+		return;
+	if (pressed)
+		m_jvsButtonState[player] |= mask;
+	else
+		m_jvsButtonState[player] &= ~mask;
+}
+
+// Gamepad coin button -> increment JVS coin counter for P1 (slot 0) or P2 (slot 1)
+void ACJV::InsertCoin(u32 slot)
+{
+	if (slot == 0)
+		m_coin1++;
+	else if (slot == 1)
+		m_coin2++;
+}
 
 void do_jvs_packet(const u8* input, u8* output) {
 	if (input[0] != JVS_SYNC) {
@@ -374,6 +462,8 @@ void do_jvs_packet(const u8* input, u8* output) {
 			(*output++) = static_cast<u8>(m_jvsButtonState[0]);      //Player 1
 			(*output++) = static_cast<u8>(m_jvsButtonState[0] >> 8); //Player 1
 			(*dstSize) += 4;
+			//if (m_jvsButtonState[0])
+			//	Console.WriteLn("JVS P1 buttons: %04X coin:%d", m_jvsButtonState[0], m_coin1);
 
 			if(playerCount == 2)
 			{

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -107,6 +107,7 @@ static constexpr const std::array<InputBindingInfo, 2> s_jvs_coin_bindings = {{
 }};
 
 static u16 s_dip_switch_state = DEFAULT_DIP_SWITCH_STATE;
+static bool s_suppress_daemon = true;
 u32 lastRead = 0x0;
 
 std::span<const ACJV::DIPSwitchInfo> ACJV::GetDIPSwitches()
@@ -132,6 +133,11 @@ const ACJV::DIPSwitchInfo& ACJV::GetMonitorSyncFrequencyDIPSwitch()
 const ACJV::DIPSwitchInfo& ACJV::GetVideoSyncSplitDIPSwitch()
 {
 	return s_dip_switch_info[3];
+}
+
+bool ACJV::IsSuppressDaemonEnabled()
+{
+	return s_suppress_daemon;
 }
 
 std::span<const InputBindingInfo> ACJV::GetDIPSwitchBindings()
@@ -190,6 +196,7 @@ void ACJV::LoadConfig(const SettingsInterface& si)
 			state |= s_dip_switch_masks[i];
 	}
 	s_dip_switch_state = state;
+	s_suppress_daemon = si.GetBoolValue(CONFIG_SECTION, "SuppressDaemon", true);
 }
 
 void ACJV::CopyConfiguration(SettingsInterface* dest_si, const SettingsInterface& src_si, bool copy_settings, bool copy_bindings)
@@ -198,6 +205,7 @@ void ACJV::CopyConfiguration(SettingsInterface* dest_si, const SettingsInterface
 	{
 		for (const DIPSwitchInfo& dip_switch : s_dip_switch_info)
 			dest_si->CopyBoolValue(src_si, CONFIG_SECTION, dip_switch.name);
+		dest_si->CopyBoolValue(src_si, CONFIG_SECTION, "SuppressDaemon");
 	}
 
 	if (copy_bindings)
@@ -218,6 +226,7 @@ void ACJV::SetDefaultConfiguration(SettingsInterface& si)
 	si.ClearSection(CONFIG_SECTION);
 	for (const DIPSwitchInfo& dip_switch : s_dip_switch_info)
 		si.SetBoolValue(CONFIG_SECTION, dip_switch.name, dip_switch.default_value);
+	si.SetBoolValue(CONFIG_SECTION, "SuppressDaemon", true);
 
 	si.SetStringValue(CONFIG_SECTION, "P1_Up",      "Keyboard/Up");
 	si.SetStringValue(CONFIG_SECTION, "P1_Down",    "Keyboard/Down");

--- a/pcsx2/DEV9/ACJV.h
+++ b/pcsx2/DEV9/ACJV.h
@@ -65,6 +65,11 @@ namespace ACJV {
     const DIPSwitchInfo& GetMonitorSyncFrequencyDIPSwitch();
     const DIPSwitchInfo& GetVideoSyncSplitDIPSwitch();
     std::span<const InputBindingInfo> GetDIPSwitchBindings();
+    std::span<const InputBindingInfo> GetButtonBindings();
+    std::span<const InputBindingInfo> GetP2ButtonBindings();
+    std::span<const InputBindingInfo> GetCoinBindings();
+    void SetButtonState(u32 player, u16 mask, bool pressed);
+    void InsertCoin(u32 slot);
 
     bool GetDIPSwitchState(u32 index);
     void SetDIPSwitchState(u32 index, bool enabled);
@@ -122,6 +127,22 @@ enum DIPS {
     VIDEO_VOLTAGE = 0x40,
     MONITOR_SYNCFREQ = 0x20,
     VIDEO_SYNC_SPLIT = 0x10,
+};
+
+// To improve and correct when adding more JVS controls from games
+enum JVSButton : u16 {
+    JVS_BTN_START   = 0x80,
+    JVS_BTN_SERVICE = 0x40,
+    JVS_BTN_UP      = 0x20,
+    JVS_BTN_DOWN    = 0x10,
+    JVS_BTN_LEFT    = 0x08,
+    JVS_BTN_RIGHT   = 0x04,
+    JVS_BTN_1       = 0x02,
+    JVS_BTN_2       = 0x01,
+    JVS_BTN_3       = 0x8000,
+    JVS_BTN_4       = 0x4000,
+    JVS_BTN_5       = 0x2000,
+    JVS_BTN_6       = 0x1000,
 };
 
 

--- a/pcsx2/DEV9/ACJV.h
+++ b/pcsx2/DEV9/ACJV.h
@@ -77,6 +77,8 @@ namespace ACJV {
     void LoadConfig(const SettingsInterface& si);
     void CopyConfiguration(SettingsInterface* dest_si, const SettingsInterface& src_si, bool copy_settings = true, bool copy_bindings = true);
     void SetDefaultConfiguration(SettingsInterface& si);
+
+    bool IsSuppressDaemonEnabled();
 }
 
 

--- a/pcsx2/DEV9/ACRAM.cpp
+++ b/pcsx2/DEV9/ACRAM.cpp
@@ -28,10 +28,15 @@ void ACRAM::Write16(u32 addr, u16 val) {
     u32 reg = offset & ACRAM_REG_MASK;
     u32 bank_base = bank * ACRAM_BANK_SIZE;
 
-    if (reg >= ACRAM_REG_READ && reg < ACRAM_REG_WRITE)
+    if (reg >= ACRAM_REG_READ && reg < ACRAM_REG_WRITE) {
         banks[bank].read_addr = bank_base + ((u32)val << 11); // val is a page number, <<11 = 2KB granularity
-    else if (reg >= ACRAM_REG_WRITE && reg < 0x80000)
+        return;
+    } else if (reg >= ACRAM_REG_WRITE && reg < 0x80000) {
         banks[bank].write_addr = bank_base + ((u32)val << 11);
+        return;
+    } else if (reg >= 0x20000 && reg < ACRAM_REG_READ) {
+        return; // size/config registers — control only, don't touch SDRAM
+    }
 
     u32 off = GET_RAM_OFF(addr);
     if (off < ACRAM_MAX_SIZE)

--- a/pcsx2/HwWrite.cpp
+++ b/pcsx2/HwWrite.cpp
@@ -178,7 +178,6 @@ void _hwWrite32( u32 mem, u32 value )
 						u64 cycle = psxRegs.cycle;
 						//pgifInit();
 						psxReset();
-						PSXCLK =  33868800;
 						SPU2::Reset(true);
 						setPs1CDVDSpeed(cdvd.Speed);
 						psxHu32(HW_ICFG) = 0x8;

--- a/pcsx2/HwWrite.cpp
+++ b/pcsx2/HwWrite.cpp
@@ -13,6 +13,7 @@
 #include "ps2/pgif.h"
 #include "SPU2/spu2.h"
 #include "R3000A.h"
+#include "VMManager.h"
 
 #include "CDVD/Ps1CD.h"
 #include "CDVD/CDVD.h"
@@ -178,9 +179,7 @@ void _hwWrite32( u32 mem, u32 value )
 						u64 cycle = psxRegs.cycle;
 						//pgifInit();
 						psxReset();
-						SPU2::Reset(true);
-						setPs1CDVDSpeed(cdvd.Speed);
-						psxHu32(HW_ICFG) = 0x8;
+						// No PS1 mode on arcade — skip ICFG and PS1 CD speed
 						psxHu32(HW_ICTRL) = 1;
 						psxRegs.cycle = cycle;
 					}

--- a/pcsx2/Input/InputManager.cpp
+++ b/pcsx2/Input/InputManager.cpp
@@ -868,6 +868,84 @@ void InputManager::AddJVSBindings(SettingsInterface& si, bool is_profile)
 				ACJV::ToggleDIPSwitchState(dip_switch_index);
 		}}, InputBindingInfo::Type::Button, si, ACJV::CONFIG_SECTION, bi.name, is_profile);
 	}
+
+	// P1 and P2 button bindings + auto-mirror from Pad1/Pad2
+	const std::span<const InputBindingInfo> player_bindings[] = {
+		ACJV::GetButtonBindings(),
+		ACJV::GetP2ButtonBindings(),
+	};
+
+	for (u32 player = 0; player < 2; player++)
+	{
+		for (const InputBindingInfo& bi : player_bindings[player])
+		{
+			const std::vector<std::string> bindings(si.GetStringList(ACJV::CONFIG_SECTION, bi.name));
+			if (bindings.empty())
+				continue;
+
+			AddBindings(bindings, InputAxisEventHandler{[player, mask = static_cast<u16>(bi.bind_index)](InputBindingKey key, float value) {
+				ACJV::SetButtonState(player, mask, value > 0.5f);
+			}}, bi.bind_type, si, ACJV::CONFIG_SECTION, bi.name, is_profile);
+		}
+
+		// Auto-mirror PadN gamepad bindings to JVS player N via matching GenericInputBinding.
+		// Select is excluded — on real cabs Service is a separate physical button; Select maps to Coin instead.
+		const Pad::ControllerInfo* pad_ci = Pad::GetControllerInfo(EmuConfig.Pad.Ports[player].Type);
+		if (!pad_ci)
+			continue;
+
+		const std::string pad_section = Pad::GetConfigSection(player);
+		for (const InputBindingInfo& jvs_bi : player_bindings[player])
+		{
+			if (jvs_bi.generic_mapping == GenericInputBinding::Unknown ||
+				jvs_bi.generic_mapping == GenericInputBinding::Select)
+				continue;
+
+			for (const InputBindingInfo& pad_bi : pad_ci->bindings)
+			{
+				if (pad_bi.generic_mapping != jvs_bi.generic_mapping)
+					continue;
+
+				const std::vector<std::string> pad_bindings(si.GetStringList(pad_section.c_str(), pad_bi.name));
+				for (const std::string& pb : pad_bindings)
+				{
+					AddBinding(pb, InputAxisEventHandler{[player, mask = static_cast<u16>(jvs_bi.bind_index)](InputBindingKey key, float value) {
+						ACJV::SetButtonState(player, mask, value > 0.5f);
+					}});
+				}
+				break;
+			}
+		}
+
+		// Auto-mirror PadN Select -> Coin insert for player N
+		for (const InputBindingInfo& pad_bi : pad_ci->bindings)
+		{
+			if (pad_bi.generic_mapping != GenericInputBinding::Select)
+				continue;
+
+			const std::vector<std::string> pad_bindings(si.GetStringList(pad_section.c_str(), pad_bi.name));
+			for (const std::string& pb : pad_bindings)
+			{
+				AddBinding(pb, InputButtonEventHandler{[player](s32 pressed) {
+					if (pressed > 0)
+						ACJV::InsertCoin(player);
+				}});
+			}
+			break;
+		}
+	}
+
+	for (const InputBindingInfo& bi : ACJV::GetCoinBindings())
+	{
+		const std::vector<std::string> bindings(si.GetStringList(ACJV::CONFIG_SECTION, bi.name));
+		if (bindings.empty())
+			continue;
+
+		AddBindings(bindings, InputButtonEventHandler{[slot = static_cast<u32>(bi.bind_index)](s32 pressed) {
+			if (pressed > 0)
+				ACJV::InsertCoin(slot);
+		}}, InputBindingInfo::Type::Button, si, ACJV::CONFIG_SECTION, bi.name, is_profile);
+	}
 }
 
 void InputManager::AddPadBindings(SettingsInterface& si, u32 pad_index, bool is_profile)

--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -9,6 +9,7 @@
 #include "R5900.h"
 #include "ps2/BiosTools.h"
 #include "VMManager.h"
+#include "DEV9/ACJV.h"
 
 #include <ctype.h>
 #include <fmt/format.h>
@@ -1229,6 +1230,40 @@ namespace R3000A
 		}
 	} // namespace loadcore
 
+	// HLE workaround: suppress the DAEMON module's sec_checker thread on S246/S256 arcade.
+	// sec_checker (priority 126) races with mcman for the mcman_io_sema during card detection,
+	// causing dongle file opens (mc0:ACCORE etc.) to fail with fd=-6.
+	// On real hardware the race doesn't manifest due to different IOP scheduling granularity.
+	// This should be revisited if IOP thread scheduling accuracy improves.
+	// Toggled via JVS > Extra > "Suppress DAEMON security thread" (ON by default).
+	namespace thbase
+	{
+		static bool s_suppress_next_start = false;
+
+		int CreateThread_HLE()
+		{
+			if (ACJV::IsSuppressDaemonEnabled())
+			{
+				u32 priority = iopMemRead32(a0 + 16);
+				if (priority >= 126)
+					s_suppress_next_start = true;
+			}
+			return 0;
+		}
+
+		int StartThread_HLE()
+		{
+			if (s_suppress_next_start)
+			{
+				s_suppress_next_start = false;
+				v0 = 0;
+				pc = ra;
+				return 1;
+			}
+			return 0;
+		}
+	} // namespace thbase
+
 	namespace intrman
 	{
 		// clang-format off
@@ -1352,6 +1387,10 @@ namespace R3000A
 		END_MODULE
 		MODULE(sysmem)
 			EXPORT_H( 14, Kprintf)
+		END_MODULE
+		MODULE(thbase)
+			EXPORT_H(  4, CreateThread)
+			EXPORT_H(  6, StartThread)
 		END_MODULE
 
 		// Special case with ioman and iomanX

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -48,8 +48,8 @@ void psxReset()
 	psxRegs.iopCycleEECarry = 0;
 	psxRegs.iopNextEventCycle = psxRegs.cycle + 4;
 
+	PSXCLK = (PS2CLK == PS2CLK_S256) ? 49152000 : 36864000;
 	psxHwReset();
-	PSXCLK = 36864000;
 	ioman::reset();
 	psxBiosReset();
 }

--- a/pcsx2/SIO/Sio.cpp
+++ b/pcsx2/SIO/Sio.cpp
@@ -3,9 +3,11 @@
 
 #include "SIO/Sio.h"
 
+#include "Common.h"
 #include "SIO/SioTypes.h"
 #include "SIO/Memcard/MemoryCardProtocol.h"
 #include "Counters.h"
+#include "VMManager.h"
 
 #include "Host.h"
 #include "IconsPromptFont.h"
@@ -24,11 +26,10 @@ void sioNextFrame() {
 }
 
 void sioSetGameSerial( const std::string& serial ) {
+	// Arcade dongles are always physically present — skip AutoEject
 	for ( uint port = 0; port < 2; ++port ) {
 		for ( uint slot = 0; slot < 4; ++slot ) {
-			if ( mcds[port][slot].ReIndex( serial ) ) {
-				AutoEject::Set( port, slot );
-			}
+			mcds[port][slot].ReIndex( serial );
 		}
 	}
 }

--- a/pcsx2/SIO/Sio.h
+++ b/pcsx2/SIO/Sio.h
@@ -55,7 +55,7 @@ struct _mcd
 	void Write(u8 *src, int size)
 	{
 		//DevCon.WriteLn("Memcard Write (sectorAddr = %08X)", sectorAddr);
-		FileMcd_Save(port, slot, src,transferAddr, size);
+		FileMcd_Save(port, slot, src, transferAddr, size);
 	}
 
 	bool IsPresent()

--- a/pcsx2/SIO/Sio2.cpp
+++ b/pcsx2/SIO/Sio2.cpp
@@ -127,7 +127,15 @@ void Sio2::SetCtrl(u32 value)
 		const u32 baudDiv = useBaud1 ? (send1 >> 24) : ((send1 >> 16) & 0xFF);
 		const u32 interBytePer = (send2 >> 16) & 0xFF;
 		const u32 cyclesPerByte = 8 * (baudDiv + 1) + interBytePer;
-		const u32 delay = static_cast<u32>(transferBytes) * cyclesPerByte + 64;
+
+		// Compute byte count from queued command lengths (more accurate than DMA transfer size)
+		u32 serialBytes = 0;
+		for (size_t i = 0; i < queuePosition; i++)
+			serialBytes += (CmdQueue[i] >> 8) & Sio2Cmd::COMMAND_LENGTH_MASK;
+		if (serialBytes == 0)
+			serialBytes = static_cast<u32>(transferBytes);
+
+		const u32 delay = serialBytes * cyclesPerByte + 64;
 		PSX_INT(IopEvt_SIO2, delay);
 	}
 }
@@ -286,13 +294,15 @@ void Sio2::Memcard()
 		return;
 	}
 
+	const u8 commandByte = g_Sio2FifoIn.front();
+
 	SetCmdStat(mcd->IsPresent() ? CmdStat::CONNECTED : CmdStat::DISCONNECTED);
 
-	const u8 commandByte = g_Sio2FifoIn.front();
 	g_Sio2FifoIn.pop_front();
 	const u8 responseByte = mcd->IsPresent() ? 0x00 : 0xff;
 	g_Sio2FifoOut.push_back(responseByte);
 	g_Sio2FifoOut.push_back(responseByte);
+
 	u8 ps1Input = 0;
 	u8 ps1Output = 0;
 
@@ -300,6 +310,12 @@ void Sio2::Memcard()
 	{
 		case MemcardCommand::PROBE:
 			g_MemoryCardProtocol.Probe();
+			break;
+		case MemcardCommand::GET_TERMINATOR:
+			g_MemoryCardProtocol.GetTerminator();
+			break;
+		case MemcardCommand::SET_TERMINATOR:
+			g_MemoryCardProtocol.SetTerminator();
 			break;
 		case MemcardCommand::UNKNOWN_WRITE_DELETE_END:
 			g_MemoryCardProtocol.UnknownWriteDeleteEnd();
@@ -311,12 +327,6 @@ void Sio2::Memcard()
 			break;
 		case MemcardCommand::GET_SPECS:
 			g_MemoryCardProtocol.GetSpecs();
-			break;
-		case MemcardCommand::SET_TERMINATOR:
-			g_MemoryCardProtocol.SetTerminator();
-			break;
-		case MemcardCommand::GET_TERMINATOR:
-			g_MemoryCardProtocol.GetTerminator();
 			break;
 		case MemcardCommand::WRITE_DATA:
 			g_MemoryCardProtocol.WriteData();

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -192,6 +192,7 @@ static bool s_fast_boot_requested = false;
 static bool s_gs_open_on_initialize = false;
 static bool s_thread_affinities_set = false;
 static bool s_acgame_sys246 = false;
+static bool s_acgame_sys256 = false;
 
 static LimiterModeType s_limiter_mode = LimiterModeType::Nominal;
 static s64 s_limiter_ticks_per_frame = 0;
@@ -1300,6 +1301,9 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				s_disc_serial = s_serial = INI.GetStringValue("game", "gameid");
 				std::string platform = INI.GetStringValue("game", "platform", "");
 				s_acgame_sys246 = (platform == "246" || platform == "256");
+				s_acgame_sys256 = (platform == "256");
+				if (s_acgame_sys256)
+					PS2CLK = PS2CLK_S256;
 				if (s_acgame_sys246)
 				{
 					Console.WriteLnFmt(Color_Green, "ACGAME: System {} detected — extended IOP RAM", platform);
@@ -1597,6 +1601,11 @@ VMBootResult VMManager::Initialize(const VMBootParameters& boot_params, Error* e
 	mmap_ResetBlockTracking();
 	if (s_acgame_sys246)
 		EmuConfig.Cpu.ExtraMemory = true;
+	if (s_acgame_sys256)
+	{
+		s_sys256_mode = true;
+		Console.WriteLnFmt(Color_Green, "S256: bus clock 393MHz, IOP 49MHz");
+	}
 	memSetExtraMemMode(EmuConfig.Cpu.ExtraMemory);
 	Internal::ClearCPUExecutionCaches();
 	FPControlRegister::SetCurrent(EmuConfig.Cpu.FPUFPCR);
@@ -1757,6 +1766,9 @@ void VMManager::Shutdown(bool save_resume_state)
 	SaveSessionTime(s_disc_serial);
 	s_elf_override = {};
 	s_acgame = {};
+	PS2CLK = PS2CLK_DEFAULT;
+	PSXCLK = 36864000;
+	s_sys256_mode = false;
 	ClearELFInfo();
 	CDVDsys_ClearFiles();
 

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1310,13 +1310,16 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				}
 
 				std::string card;
+				// Slot 1 (mc0:) = dongle (boot modules only, no save data).
+				// Always overwrite — DONGLEMAN corrupts this file at runtime.
 				if ((card = INI.GetStringValue("data", "dongle", "")) != "") {
 					std::string src = Path::Combine(basedir, card);
 					std::string dst = Path::Combine(EmuFolders::MemoryCards, card);
-					if (FileSystem::FileExists(src.c_str()) && !FileSystem::FileExists(dst.c_str()))
-						FileSystem::CopyFilePath(src.c_str(), dst.c_str(), false);
+					if (FileSystem::FileExists(src.c_str()))
+						FileSystem::CopyFilePath(src.c_str(), dst.c_str(), true);
 					Host::SetBaseStringSettingValue("MemoryCards", "Slot1_Filename", card.c_str());
 				}
+				// Slot 2 (mc1:) = save card (e.g. SC2 conquest). Never overwrite existing saves.
 				if ((card = INI.GetStringValue("data", "card", "")) != "") {
 					std::string src = Path::Combine(basedir, card);
 					std::string dst = Path::Combine(EmuFolders::MemoryCards, card);


### PR DESCRIPTION
The DAEMON module's sec_checker thread (priority 126) races with mcman for mcman_io_sema during memory card detection, causing dongle file opens (mc0:ACCORE etc.) to fail on S246/S256 arcade games. Symptoms vary: fd=-6 on mcOpen, fd=-2 on auth, or OSDSYS blue screen on boot.

On real hardware the race doesn't manifest due to different IOP scheduling granularity. As a workaround, intercept thbase CreateThread/StartThread via existing IOP HLE hooks to keep sec_checker dormant. Toggled in JVS > Extra (ON by default).

Also includes some minor fixes:
- Skip PS1 mode (ICFG) on IOP reset for arcade (no PS1 hw on S246/S256 afaik)
- Skip AutoEject for arcade (dongles are always physically present afaik)
- SIO2 interrupt delay from actual command lengths, not DMA size
- Fresh dongle copy every boot (DONGLEMAN corrupts the memcard file which is frustrating, could be readonly tho, your call)