### PR TITLE
CHD: fix crash on PIO reads, remove dead code, small cleanups

### DIFF
--- a/pcsx2/DEV9/ACATA.cpp
+++ b/pcsx2/DEV9/ACATA.cpp
@@ -408,10 +408,6 @@ void ACATA::handle_cmd(u16 val) {
     }
 }
 
-void ACATA_SETUP() {
-    ACATA::TH::readBuffer = new u8[ACATA::TH::readBufferLen];
-}
-
 #include "common/Path.h"
 
 void ACATA::SetImgPath(const char* S) {

--- a/pcsx2/DEV9/ACATA.h
+++ b/pcsx2/DEV9/ACATA.h
@@ -82,8 +82,6 @@ namespace ACATA
 	    extern std::condition_variable Idle_cv, ioReady;
         extern FILE* IMAGE;
         extern s64 IMAGESIZE;
-	    extern int readBufferLen;
-	    extern u8* readBuffer;
         extern u32 sectorsize; //512 for hdd and 2048 for Disc (?) check it
         extern u32 nsector;
         extern s64 LBA;

--- a/pcsx2/DEV9/ACATAPI.cpp
+++ b/pcsx2/DEV9/ACATAPI.cpp
@@ -1,6 +1,7 @@
 #include "ACCORE.h"
 #include "ACATAPI.h"
 #include "ACATA.h"
+#include "ACATA_IO_CHD.h"
 #include "common/Console.h"
 #include "common/FileSystem.h"
 
@@ -190,13 +191,19 @@ void ACATAPI::handle_cmd(atapi_packet_t P) {
                 atapi_complete_nodata();
                 break;
             }
-            s64 offset = (s64)transf_lba * ACATAPI::CONSTANTS::DVD_SECTORSIZE;
-            FileSystem::FSeek64(ACATA::TH::IMAGE, offset, SEEK_SET);
-            size_t rd = fread(atapi_pio_buf, 1, total, ACATA::TH::IMAGE);
-            if (rd == total) {
+            bool ok = false;
+            if (ACATA::TH::isCHD) {
+                u32 scale = ACATAPI::CONSTANTS::DVD_SECTORSIZE / CHD.GetSectorSize();
+                ok = CHD.ReadSectors((u64)transf_lba * scale, nsec * scale, atapi_pio_buf);
+            } else {
+                s64 offset = (s64)transf_lba * ACATAPI::CONSTANTS::DVD_SECTORSIZE;
+                FileSystem::FSeek64(ACATA::TH::IMAGE, offset, SEEK_SET);
+                ok = (fread(atapi_pio_buf, 1, total, ACATA::TH::IMAGE) == total);
+            }
+            if (ok) {
                 atapi_pio_setup(total);
             } else {
-                Console.Error("ACATAPI:READ_10: short read (%zu/%u)", rd, total);
+                Console.Error("ACATAPI:READ_10: read failed at lba %u, %u sectors", transf_lba, nsec);
                 ACATA::R_STATUS |= ATA_STAT_ERR;
                 ACATA::R_ERROR = ATA_ERR_ABORT;
                 atapi_complete_nodata();

--- a/pcsx2/DEV9/ACATA_IO.cpp
+++ b/pcsx2/DEV9/ACATA_IO.cpp
@@ -24,8 +24,6 @@ bool ACATA::TH::b_isIdle,
 std::condition_variable ACATA::TH::Idle_cv, ACATA::TH::ioReady;
 FILE* ACATA::TH::IMAGE;
 s64 ACATA::TH::IMAGESIZE;
-int ACATA::TH::readBufferLen;
-u8* ACATA::TH::readBuffer = nullptr;
 u32 ACATA::TH::sectorsize = ACATAPI::CONSTANTS::DVD_SECTORSIZE; //TODO: remove hardcode before testing HDD/CD games !
 u32 ACATA::TH::nsector;
 s64 ACATA::TH::LBA;
@@ -41,8 +39,11 @@ void ACATA::TH::IO_Read(u32* addr, u32 size) {
 			 size, (size2), sectorsize, nsector);
 	
 	if (isCHD) {
-		if (!CHD.ReadSectors(LBA, nsector, (void*)addr)) {
-			Console.ErrorFmt("ACATA:IO_ReadCHD: lba:{} nsector:{} failed", LBA, nsector);
+		u32 scale = sectorsize / CHD.GetSectorSize();
+		u64 chd_lba = LBA * scale;
+		u32 chd_count = nsector * scale;
+		if (!CHD.ReadSectors(chd_lba, chd_count, (void*)addr)) {
+			Console.ErrorFmt("ACATA:IO_ReadCHD: lba:{} nsector:{} failed", chd_lba, chd_count);
 			pxAssert(false);
 			abort();
 		}
@@ -83,7 +84,7 @@ void ACATA::TH::IO_Write(u32* addr, u32 size) {
 			return;
 		}
 		std::fflush(IMAGE);
-	} else Console.ErrorFmt("{}: skipping write due to CHD media", __FUNCTION__, size);
+	} else Console.ErrorFmt("{}: skipping write due to CHD media", __FUNCTION__);
 }
 
 int ACATA::TH::IO_OpenImage() {
@@ -123,6 +124,7 @@ int ACATA::TH::IO_CloseImage() {
 	if (isCHD) {
 		Console.WriteLn("%s CHD", __FUNCTION__);
 		CHD.Close();
+		isCHD = false;
 		return 0;
 	} else if (ACATA::TH::IMAGE) {
 		Console.WriteLn("%s", __FUNCTION__);

--- a/pcsx2/DEV9/ACATA_IO_CHD.cpp
+++ b/pcsx2/DEV9/ACATA_IO_CHD.cpp
@@ -154,5 +154,5 @@ bool ChdImage::ReadSectors(u64 lba,
 
 bool ChdImage::IsChdFileName(const std::string& path)
 {
-	return StringUtil::EndsWithNoCase(Path::GetExtension(path), "chd");
+	return StringUtil::compareNoCase(Path::GetExtension(path), "chd");
 }

--- a/pcsx2/DEV9/ACATA_IO_CHD.h
+++ b/pcsx2/DEV9/ACATA_IO_CHD.h
@@ -51,3 +51,5 @@ private:
 
     u32 m_cachedHunk = UINT32_MAX;
 };
+
+extern ChdImage CHD;


### PR DESCRIPTION
- Fix ATAPI PIO READ_10 crash when using CHD images (was using NULL file handle)
- Remove unused readBuffer/readBufferLen left over from deleted IO_Thread
- Use exact extension match for .chd detection instead of suffix match
- Fix unused argument in CHD write error message
- Reset CHD flag when closing image

(need more testing first before merge)

TC4, CBR, TK4 working with MAME CHDs.