### PR TITLE
Initial light gun support, SS256 clock support, JVS mode, some clean up

### DIFF
--- a/pcsx2-qt/Settings/USBBindingWidget_GunCon2.ui
+++ b/pcsx2-qt/Settings/USBBindingWidget_GunCon2.ui
@@ -32,7 +32,7 @@
       <item row="0" column="0">
        <widget class="QGroupBox" name="groupBox_19">
         <property name="title">
-         <string>A</string>
+         <string>Foot Pedal</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_19">
          <property name="leftMargin">
@@ -49,46 +49,6 @@
          </property>
          <item row="0" column="0">
           <widget class="InputBindingWidget" name="A">
-           <property name="minimumSize">
-            <size>
-             <width>200</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>200</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true">PushButton</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="0" column="3">
-       <widget class="QGroupBox" name="groupBox_20">
-        <property name="title">
-         <string>C</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_20">
-         <property name="leftMargin">
-          <number>6</number>
-         </property>
-         <property name="topMargin">
-          <number>6</number>
-         </property>
-         <property name="rightMargin">
-          <number>6</number>
-         </property>
-         <property name="bottomMargin">
-          <number>6</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="InputBindingWidget" name="C">
            <property name="minimumSize">
             <size>
              <width>200</width>
@@ -158,7 +118,7 @@
       <item row="1" column="2" colspan="2">
        <widget class="QGroupBox" name="groupBox_35">
         <property name="title">
-         <string>Select</string>
+         <string>Coins</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_35">
          <item row="0" column="0">
@@ -169,46 +129,6 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <property name="minimumSize">
-            <size>
-             <width>200</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>200</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true">PushButton</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="0" column="1" colspan="2">
-       <widget class="QGroupBox" name="groupBox_18">
-        <property name="title">
-         <string>B</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_18">
-         <property name="leftMargin">
-          <number>6</number>
-         </property>
-         <property name="topMargin">
-          <number>6</number>
-         </property>
-         <property name="rightMargin">
-          <number>6</number>
-         </property>
-         <property name="bottomMargin">
-          <number>6</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="InputBindingWidget" name="B">
            <property name="minimumSize">
             <size>
              <width>200</width>
@@ -410,7 +330,7 @@
       <item>
        <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>&lt;p&gt;By default, GunCon2 will use the mouse pointer. To use the mouse, you &lt;strong&gt;do not&lt;/strong&gt; need to configure any bindings apart from the trigger and buttons.&lt;/p&gt;
+         <string>&lt;p&gt;By default, the light gun uses the mouse pointer. You &lt;strong&gt;do not&lt;/strong&gt; need to configure any bindings apart from the trigger and buttons.&lt;/p&gt;
 
 &lt;p&gt;If you want to use a controller, or lightgun which simulates a controller instead of a mouse, then you should bind it to Relative Aiming. Otherwise, Relative Aiming should be &lt;strong&gt;left unbound&lt;/strong&gt;.&lt;/p&gt;</string>
         </property>
@@ -666,84 +586,6 @@
         </layout>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QGroupBox" name="groupBox_8">
-        <property name="title">
-         <string>Shoot Offscreen</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_7">
-         <property name="leftMargin">
-          <number>6</number>
-         </property>
-         <property name="topMargin">
-          <number>6</number>
-         </property>
-         <property name="rightMargin">
-          <number>6</number>
-         </property>
-         <property name="bottomMargin">
-          <number>6</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="InputBindingWidget" name="ShootOffscreen">
-           <property name="minimumSize">
-            <size>
-             <width>125</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>125</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true">PushButton</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QGroupBox" name="groupBox_9">
-        <property name="title">
-         <string>Calibration Shot</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_8">
-         <item row="0" column="1">
-          <widget class="InputBindingWidget" name="Recalibrate">
-           <property name="minimumSize">
-            <size>
-             <width>125</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>125</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true">PushButton</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0" colspan="3">
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Calibration shot is required to pass the setup screen in some games.</string>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
      </layout>
     </widget>
    </item>
@@ -771,8 +613,6 @@
  </customwidgets>
  <tabstops>
   <tabstop>Trigger</tabstop>
-  <tabstop>ShootOffscreen</tabstop>
-  <tabstop>Recalibrate</tabstop>
   <tabstop>RelativeUp</tabstop>
   <tabstop>RelativeDown</tabstop>
   <tabstop>RelativeLeft</tabstop>
@@ -782,8 +622,6 @@
   <tabstop>Left</tabstop>
   <tabstop>Right</tabstop>
   <tabstop>A</tabstop>
-  <tabstop>B</tabstop>
-  <tabstop>C</tabstop>
   <tabstop>Start</tabstop>
   <tabstop>Select</tabstop>
  </tabstops>

--- a/pcsx2/Common.h
+++ b/pcsx2/Common.h
@@ -6,11 +6,12 @@
 #include "common/Pcsx2Defs.h"
 
 static const u32 BIAS = 2;				// Bus is half of the actual ps2 speed
-// EE bus clock: S246 runs at console speed (294.912 MHz), S256 runs 4/3 faster (393.216 MHz)
+// EE bus clock: S246 runs at console speed, S256 at 4/3, Super S256 at 3/2
 static const u32 PS2CLK_DEFAULT = 294912000;	//hz	/* 294.912 mhz — PS2 console / S246 */
 static const u32 PS2CLK_S256    = 393216000;	//hz	/* 393.216 mhz — S256 (294.912 * 4/3) */
+static const u32 PS2CLK_SS256   = 442368000;	//hz	/* 442.368 mhz — Super S256 (294.912 * 3/2) */
 extern u32 PS2CLK;
-extern u32 PSXCLK;	/* 36.864 Mhz (S246) or 49.152 Mhz (S256) */
+extern u32 PSXCLK;	/* 36.864 Mhz (S246), 49.152 (S256), 55.296 (SS256) */
 
 
 #include "Memory.h"

--- a/pcsx2/DEV9/ACATA.cpp
+++ b/pcsx2/DEV9/ACATA.cpp
@@ -226,6 +226,8 @@ void ACATA::handle_cmd(u16 val) {
         ACATA::cmd_handled = val;
         ACATA::cmd_handledc = 0;
         R_STATUS |= ATA_STAT_DRQ;
+        CLRB(R_STATUS, ATA_STAT_BUSY);
+        ACCORE::intr(ACCORE::INTRN_ATA);
     break;
     case ATA_C_PACKET:
         ACATA::cmd_handled = val;

--- a/pcsx2/DEV9/ACATAPI.cpp
+++ b/pcsx2/DEV9/ACATAPI.cpp
@@ -222,6 +222,10 @@ void ACATAPI::handle_cmd(atapi_packet_t P) {
         break;
     }
 
+    case ATAPICMD::SET_CD_SPEED:
+        atapi_complete_nodata();
+        break;
+
     default:
         Console.Error("ACATAPI: UNK_CMD %02X, lba:%08X, nsec:%04X", P.raw8[0], transf_lba, nsec);
         break;

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -3,6 +3,8 @@
 #include "ACJV.h"
 #include "Config.h"
 #include "Host.h"
+#include "Input/InputManager.h"
+#include "GS/GS.h"
 #include "common/SettingsInterface.h"
 #include <array>
 #include <string>
@@ -17,7 +19,6 @@ enum ACJVCMD {
 
 bool ACJV::enabled = false;
 #define JVS_PKTINDX_TO_ADDR(index) ((2 * (index & 0x3FFF)) + 0x12400000)
-// u16 ACJV::JVBUF[ACJV_ADDR_CAP];
 
 #define ANS(addr, what) case addr: return what
 #define JVS_CHECK_ADDR_JVSPACKET(addr) ((addr & 0x00000F00) == 0x00000600) // when ACJV writes to 0x12406???.
@@ -44,8 +45,6 @@ std::string BOARDS[] = {
 	"namco ltd.;MIU-I/O;Ver2.05;JPN,GUN-EXTENTION",
 };
 enum BOARDID ACJV::CurrentBoardID = RAYS_PCB;
-
-extern u16 ACJV::ButtonState[JVS_PLAYER_COUNT] = {0,0};
 
 static constexpr u16 DEFAULT_DIP_SWITCH_STATE =
     (DIPS::VIDEO_VOLTAGE | DIPS::MONITOR_SYNCFREQ | DIPS::VIDEO_SYNC_SPLIT);
@@ -83,7 +82,7 @@ static constexpr const std::array<InputBindingInfo, 12> s_jvs_p1_button_bindings
 	{"P1_Button5", TRANSLATE_NOOP("JVS", "P1 Button 5"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_5,       GenericInputBinding::Circle},
 	{"P1_Button6", TRANSLATE_NOOP("JVS", "P1 Button 6"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_6,       GenericInputBinding::Unknown},
 	{"P1_Start",   TRANSLATE_NOOP("JVS", "P1 Start"),    nullptr, InputBindingInfo::Type::Button, JVS_BTN_START,   GenericInputBinding::Start},
-	{"P1_Service", TRANSLATE_NOOP("JVS", "P1 Service"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_SERVICE, GenericInputBinding::Select}, // Coins
+	{"P1_Service", TRANSLATE_NOOP("JVS", "P1 Service"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_SERVICE, GenericInputBinding::Select},
 }};
 
 static constexpr const std::array<InputBindingInfo, 12> s_jvs_p2_button_bindings = {{
@@ -108,7 +107,6 @@ static constexpr const std::array<InputBindingInfo, 2> s_jvs_coin_bindings = {{
 
 static u16 s_dip_switch_state = DEFAULT_DIP_SWITCH_STATE;
 static bool s_suppress_daemon = true;
-u32 lastRead = 0x0;
 
 std::span<const ACJV::DIPSwitchInfo> ACJV::GetDIPSwitches()
 {
@@ -227,18 +225,6 @@ void ACJV::SetDefaultConfiguration(SettingsInterface& si)
 	for (const DIPSwitchInfo& dip_switch : s_dip_switch_info)
 		si.SetBoolValue(CONFIG_SECTION, dip_switch.name, dip_switch.default_value);
 	si.SetBoolValue(CONFIG_SECTION, "SuppressDaemon", true);
-
-	si.SetStringValue(CONFIG_SECTION, "P1_Up",      "Keyboard/Up");
-	si.SetStringValue(CONFIG_SECTION, "P1_Down",    "Keyboard/Down");
-	si.SetStringValue(CONFIG_SECTION, "P1_Left",    "Keyboard/Left");
-	si.SetStringValue(CONFIG_SECTION, "P1_Right",   "Keyboard/Right");
-	si.SetStringValue(CONFIG_SECTION, "P1_Button1", "Keyboard/J");
-	si.SetStringValue(CONFIG_SECTION, "P1_Button2", "Keyboard/I");
-	si.SetStringValue(CONFIG_SECTION, "P1_Button3", "Keyboard/K");
-	si.SetStringValue(CONFIG_SECTION, "P1_Button4", "Keyboard/L");
-	si.SetStringValue(CONFIG_SECTION, "P1_Start",   "Keyboard/Return");
-	si.SetStringValue(CONFIG_SECTION, "P1_Service", "Keyboard/Backspace");
-	si.SetStringValue(CONFIG_SECTION, "Coin1",      "Keyboard/5");
 }
 
 u16 ACJV::Read16(u32 addr) {
@@ -262,14 +248,34 @@ void ACJV::Write16(u32 addr, u16 val) {
 	}
 }
 
-#define assert(x) if (!(x)) Console.WriteLn("## ASSERT ## %s:%s:%d %s", __FILE__, __FUNCTION__, __LINE__, #x);
+#define JVS_ASSERT(x) if (!(x)) Console.WriteLn("## ASSERT ## %s:%s:%d %s", __FILE__, __FUNCTION__, __LINE__, #x);
 
-u8 m_counter;
-u16 m_jvsSystemButtonState = 0;
-u16 m_jvsButtonState[JVS_PLAYER_COUNT] = {};
-u8 m_testButtonState = 0;
-u16 m_coin1 = 0;
-u16 m_coin2 = 0;
+// JVS bus state — volatile runtime values, reset on game switch (see SetGameId)
+static u16 m_jvsSystemButtonState = 0;
+static u16 m_jvsButtonState[JVS_PLAYER_COUNT] = {};
+static u8 m_testButtonState = 0;
+static u16 m_coin1 = 0;
+static u16 m_coin2 = 0;
+static JVS_MODE m_jvsMode = JVS_MODE::DEFAULT;
+static u16 m_jvsScreenPosX = 0;
+static u16 m_jvsScreenPosY = 0;
+static float m_jvsLightgunDX = -1.0f;  // normalized display X (-1 = off-screen)
+static float m_jvsLightgunDY = -1.0f;  // normalized display Y (-1 = off-screen)
+static u16 m_jvsWheelChannels[JVS_WHEEL_CHANNEL_MAX] = {};
+static u16 m_jvsDrumChannels[JVS_DRUM_CHANNEL_MAX] = {};
+
+// Per-game JVS button mapping for lightgun games, keyed by NM game ID (see issue #9).
+// Field order: pedal, sensor, sensor_active_high, p1_start, p2_start, p1_trigger, p2_trigger
+// Each value is a JVS bit from JVSButton enum. 0 = not used for this game.
+// This table serves as template for future per-game configs (fighting, driving, drum, etc).
+static const GunMapping s_default_gun_mapping = {JVS_BTN_3, JVS_BTN_RIGHT, false, 0, 0, JVS_BTN_2, 0};
+static const std::map<std::string, GunMapping> s_gun_mappings = {
+	{"NM00003", {0,            0x200,         true,  JVS_BTN_3,  JVS_BTN_6, JVS_BTN_2,    JVS_BTN_5}}, // Vampire Night
+	{"NM00012", {JVS_BTN_6,    0,             false, 0,          0,          JVS_BTN_2,    0}},          // Time Crisis 3
+	{"NM00021", {JVS_BTN_3,    JVS_BTN_RIGHT, false, 0,          0,          JVS_BTN_LEFT, 0}},          // Cobra The Arcade
+	{"NM00032", {JVS_BTN_3,    JVS_BTN_RIGHT, false, 0,          0,          JVS_BTN_LEFT, 0}},          // Time Crisis 4
+};
+static const GunMapping* m_gunMapping = &s_default_gun_mapping;
 
 // Gamepad input -> JVS button state: set or clear a button bit for a player
 void ACJV::SetButtonState(u32 player, u16 mask, bool pressed)
@@ -291,11 +297,85 @@ void ACJV::InsertCoin(u32 slot)
 		m_coin2++;
 }
 
-void do_jvs_packet(const u8* input, u8* output) {
-	if (input[0] != JVS_SYNC) {
-		//Console.Error("ACJV::%s: Error: input does not begin with E0, (%02X, %02X)", __FUNCTION__, input[0], input[1]);
-		//return;
+void ACJV::SetMode(JVS_MODE mode)
+{
+	m_jvsMode = mode;
+}
+
+void ACJV::SetScreenPos(u16 x, u16 y)
+{
+	m_jvsScreenPosX = x;
+	m_jvsScreenPosY = y;
+}
+
+// Called from VMManager on game boot. Resets all JVS state and selects per-game I/O config.
+void ACJV::SetGameId(const std::string& gameid)
+{
+	// Clean slate: zero all input state on game switch within the emulator
+	m_coin1 = 0;
+	m_coin2 = 0;
+	m_jvsButtonState[0] = 0;
+	m_jvsButtonState[1] = 0;
+	m_jvsSystemButtonState = 0;
+	m_testButtonState = 0;
+	m_jvsScreenPosX = 0;
+	m_jvsScreenPosY = 0;
+	m_jvsLightgunDX = -1.0f;
+	m_jvsLightgunDY = -1.0f;
+	std::memset(m_jvsWheelChannels, 0, sizeof(m_jvsWheelChannels));
+	std::memset(m_jvsDrumChannels, 0, sizeof(m_jvsDrumChannels));
+
+	// Select per-game gun mapping, or fall back to default
+	auto it = s_gun_mappings.find(gameid);
+	if (it != s_gun_mappings.end())
+	{
+		m_gunMapping = &it->second;
+		Console.WriteLn("ACJV: gun mapping for %s: p1_trigger=0x%04X pedal=0x%04X sensor=0x%04X", gameid.c_str(), it->second.p1_trigger, it->second.pedal, it->second.sensor);
 	}
+	else
+		m_gunMapping = &s_default_gun_mapping;
+
+	// TC3 has 3 I/O boards: TSS-I/O (white flash), MIU-I/O (640x224), RAYS PCB (0xFFFF).
+	// MIU-I/O chosen: no flash artifact, calibration uses JVS trigger debounce directly.
+	// RAYS PCB calibration uses DMA protocol (cmd 0x70) that bypasses our JVS handler.
+	if (gameid == "NM00012")
+		CurrentBoardID = MIU_IO_JPN_GUN_EXTENTI;
+	else
+		CurrentBoardID = RAYS_PCB;
+}
+
+const GunMapping& ACJV::GetGunMapping()
+{
+	return *m_gunMapping;
+}
+
+static void UpdateLightgunFromMouse()
+{
+	const auto& [mx, my] = InputManager::GetPointerAbsolutePosition(0);
+	float dx, dy;
+	GSTranslateWindowToDisplayCoordinates(mx, my, &dx, &dy);
+	constexpr float edge_margin = 0.01f;
+	bool on_screen = (dx >= 0.0f && dy >= 0.0f && dx < (1.0f - edge_margin) && dy < (1.0f - edge_margin));
+	if (on_screen)
+	{
+		m_jvsLightgunDX = dx;
+		m_jvsLightgunDY = dy;
+		m_jvsScreenPosX = static_cast<u16>((1.0f - dx) * 0xFFFF);
+		m_jvsScreenPosY = static_cast<u16>(dy * 0xFFFF);
+	}
+	else
+	{
+		m_jvsLightgunDX = -1.0f;
+		m_jvsLightgunDY = -1.0f;
+		m_jvsScreenPosX = 0;
+		m_jvsScreenPosY = 0;
+	}
+	const auto& gm = ACJV::GetGunMapping();
+	if (gm.sensor)
+		ACJV::SetButtonState(0, gm.sensor, gm.sensor_active_high ? on_screen : !on_screen);
+}
+
+void do_jvs_packet(const u8* input, u8* output) {
 	input++;
 	u8 inDest = *input++;
 	u8 inSize = *input++;
@@ -310,14 +390,13 @@ void do_jvs_packet(const u8* input, u8* output) {
 	(*output++) = JVS_CMD_SUCCESS;
 	while(inSize != 0) {
 		u8 cmd = (*input++);
-		// Console.WriteLn("jvs_cmd:0x%02X", cmd);
 		inSize--;
 		inWorkChecksum += cmd;
 		switch(cmd) {
 		case JVS::RESET: {
-			assert(inSize != 0);
+			JVS_ASSERT(inSize != 0);
 			u8 param = (*input++);
-			assert(param == 0xD9);
+			JVS_ASSERT(param == 0xD9);
 			inSize--;
 			inWorkChecksum += param;
 		}
@@ -336,7 +415,7 @@ void do_jvs_packet(const u8* input, u8* output) {
 		}
 		break;
 		case JVS::SET_NODE_ADDRESS: {
-			assert(inSize != 0);
+			JVS_ASSERT(inSize != 0);
 			u8 param = (*input++);
 			inSize--;
 			inWorkChecksum += param;
@@ -374,6 +453,7 @@ void do_jvs_packet(const u8* input, u8* output) {
 			(*output++) = JVS_PLAYER_COUNT; //2 players
 			(*output++) = 0x10;             //16 switches
 			(*output++) = 0x00;
+			// TODO: driving games (e.g. Wangan Midnight)
 #if 0
 			if(m_jvsMode == JVS_MODE::DRIVE)
 			{
@@ -383,12 +463,14 @@ void do_jvs_packet(const u8* input, u8* output) {
 				(*output++) = 0x00;
 				(*dstSize) += 4;
 			}
-			else if(m_jvsMode == JVS_MODE::LIGHTGUN)
+			else
+#endif
+			if(m_jvsMode == JVS_MODE::LIGHTGUN)
 			{
 				(*output++) = 0x06; //Screen Pos Input
 				(*output++) = 0x10; //X pos bits
 				(*output++) = 0x10; //Y pos bits
-				(*output++) = 0x01; //channels
+				(*output++) = m_gunMapping->p2_trigger ? 0x02 : 0x01; // gun count: 2 if P2 trigger defined (Vampire Night), else 1
 
 				//GPIO for recoil
 				(*output++) = 0x12; //GPIO output
@@ -404,6 +486,8 @@ void do_jvs_packet(const u8* input, u8* output) {
 
 				(*dstSize) += 12;
 			}
+			// TODO: drum games (e.g. Taiko no Tatsujin)
+#if 0
 			else if(m_jvsMode == JVS_MODE::DRUM)
 			{
 				(*output++) = 0x03;                 //Analog Input
@@ -413,6 +497,9 @@ void do_jvs_packet(const u8* input, u8* output) {
 
 				(*dstSize) += 4;
 			}
+#endif
+			// TODO: touch panel games
+#if 0
 			else if(m_jvsMode == JVS_MODE::TOUCH)
 			{
 				(*output++) = 0x06; //Screen Pos Input
@@ -433,7 +520,7 @@ void do_jvs_packet(const u8* input, u8* output) {
 			while(1)
 			{
 				u8 value = (*input++);
-				assert(inSize != 0);
+				JVS_ASSERT(inSize != 0);
 				inSize--;
 				inWorkChecksum += value;
 				if(value == 0) break;
@@ -442,35 +529,24 @@ void do_jvs_packet(const u8* input, u8* output) {
 		break;
 		case JVS::READ_INP_SWITCH:
 		{
-			assert(inSize >= 2);
+			JVS_ASSERT(inSize >= 2);
 			u8 playerCount = (*input++);
 			u8 byteCount = (*input++);
-			assert(playerCount >= 1);
-			assert(playerCount <= JVS_PLAYER_COUNT);
-			assert(byteCount == 2);
+			JVS_ASSERT(playerCount >= 1);
+			JVS_ASSERT(playerCount <= JVS_PLAYER_COUNT);
+			JVS_ASSERT(byteCount == 2);
 			inWorkChecksum += playerCount;
 			inWorkChecksum += byteCount;
 			inSize -= 2;
 
 			(*output++) = JVS_CMD_SUCCESS;
-
-			/*m_counter++;
-			if(m_testButtonState == 0 && m_jvsSystemButtonState == 0x03 && m_counter > 16)
-			{
-				m_testButtonState = 0x80;
-				m_counter = 0;
-			}
-			else if(m_testButtonState == 0x80 && m_jvsSystemButtonState == 0x03 && m_counter > 16)
-			{
-				m_testButtonState = 0;
-				m_counter = 0;
-			}*/
 			(*output++) = m_testButtonState|(s_dip_switch_state & TESTMODE);
-
 			//(*output++) = (m_jvsSystemButtonState == 0x03) ? 0x80 : 0;  //Test
+
 			(*output++) = static_cast<u8>(m_jvsButtonState[0]);      //Player 1
 			(*output++) = static_cast<u8>(m_jvsButtonState[0] >> 8); //Player 1
 			(*dstSize) += 4;
+
 			//if (m_jvsButtonState[0])
 			//	Console.WriteLn("JVS P1 buttons: %04X coin:%d", m_jvsButtonState[0], m_coin1);
 
@@ -484,10 +560,10 @@ void do_jvs_packet(const u8* input, u8* output) {
 		break;
 		case JVS::READ_INP_COIN:
 		{
-			assert(inSize != 0);
+			JVS_ASSERT(inSize != 0);
 			u8 slotCount = (*input++);
-			assert(slotCount >= 1);
-			assert(slotCount <= 2);
+			JVS_ASSERT(slotCount >= 1);
+			JVS_ASSERT(slotCount <= 2);
 			inWorkChecksum += slotCount;
 			inSize--;
 			u8 slot1Condition = COIN_NORMAL; // see enum COINCOND
@@ -511,13 +587,13 @@ void do_jvs_packet(const u8* input, u8* output) {
 		break;
 		case JVS::OUTPUT_COIN_NUM: // actually never received this jvs cmd
 		{
-			assert(inSize != 3);
+			JVS_ASSERT(inSize >= 3);
 			u8 slotCount = (*input++);
 			u8 amountMSB = (*input++);
 			u8 amountLSB = (*input++);
 
-			assert(slotCount >= 1);
-			assert(slotCount <= 2);
+			JVS_ASSERT(slotCount >= 1);
+			JVS_ASSERT(slotCount <= 2);
 			//inWorkChecksum += slotCount;
 			inSize -= 3;
 
@@ -531,13 +607,13 @@ void do_jvs_packet(const u8* input, u8* output) {
 		break;
 		case JVS::DECREASE_COIN_NUM: // actually never received this jvs cmd
 		{
-			assert(inSize != 3);
+			JVS_ASSERT(inSize >= 3);
 			u8 slotCount = (*input++);
 			u8 amountMSB = (*input++);
 			u8 amountLSB = (*input++);
 
-			assert(slotCount >= 1);
-			assert(slotCount <= 2);
+			JVS_ASSERT(slotCount >= 1);
+			JVS_ASSERT(slotCount <= 2);
 			//inWorkChecksum += slotCount;
 			inSize -= 3;
 
@@ -551,17 +627,18 @@ void do_jvs_packet(const u8* input, u8* output) {
 		break;
 		case JVS::READ_INP_ANALOG:
 		{
-			assert(inSize != 0);
+			JVS_ASSERT(inSize != 0);
 			u8 channel = (*input++);
 			inWorkChecksum += channel;
 			inSize--;
 
 			(*output++) = JVS_CMD_SUCCESS;
 
-#if 0
+			// TC4 reads screen position from analog channels instead of SCREENPOS
 			if(m_jvsMode == JVS_MODE::LIGHTGUN)
 			{
-				assert(channel == 2);
+				JVS_ASSERT(channel == 2);
+				UpdateLightgunFromMouse();
 				(*output++) = static_cast<u8>(m_jvsScreenPosX >> 8); //Pos X MSB
 				(*output++) = static_cast<u8>(m_jvsScreenPosX);      //Pos X LSB
 				(*output++) = static_cast<u8>(m_jvsScreenPosY >> 8); //Pos Y MSB
@@ -569,7 +646,7 @@ void do_jvs_packet(const u8* input, u8* output) {
 			}
 			else if(m_jvsMode == JVS_MODE::DRUM)
 			{
-				assert(channel == JVS_DRUM_CHANNEL_MAX);
+				JVS_ASSERT(channel == JVS_DRUM_CHANNEL_MAX);
 				for(int i = 0; i < JVS_DRUM_CHANNEL_MAX; i++)
 				{
 					(*output++) = static_cast<u8>(m_jvsDrumChannels[i] >> 8);
@@ -584,39 +661,56 @@ void do_jvs_packet(const u8* input, u8* output) {
 					(*output++) = static_cast<u8>(m_jvsWheelChannels[i]);
 				}
 			}
-			else
-#endif
-			{
-				assert(false);
-			}
 
 			(*dstSize) += (2 * channel) + 1;
 		}
 		break;
-#if 0
 		case JVS::READ_INP_SCREENPOS:
 		{
-			assert(inSize != 0);
+			JVS_ASSERT(inSize != 0);
 			u8 channel = (*input++);
-			assert(channel == 1);
 			inWorkChecksum += channel;
 			inSize--;
 
+			if(m_jvsMode == JVS_MODE::LIGHTGUN)
+				UpdateLightgunFromMouse();
+
 			(*output++) = JVS_CMD_SUCCESS;
 
-			(*output++) = static_cast<u8>(m_jvsScreenPosX >> 8); //Pos X MSB
-			(*output++) = static_cast<u8>(m_jvsScreenPosX);      //Pos X LSB
-			(*output++) = static_cast<u8>(m_jvsScreenPosY >> 8); //Pos Y MSB
-			(*output++) = static_cast<u8>(m_jvsScreenPosY);      //Pos Y LSB
+			// Screen position scaling depends on I/O board:
+			// - MIU-I/O (TC3): native 640x224, Y inverted (bottom-up)
+			// - RAYS PCB (TC4, Cobra, VPN): full 16-bit range 0xFFFF, Y inverted (bottom-up)
+			// pos=0 means off-screen in JVS, so on-screen values are clamped to minimum 1
+			u16 posX = 0, posY = 0;
+			if(m_jvsMode == JVS_MODE::LIGHTGUN && m_jvsLightgunDX >= 0.0f)
+			{
+				const float scaleX = (ACJV::CurrentBoardID == MIU_IO_JPN_GUN_EXTENTI) ? 640.0f : 0xFFFF;
+				const float scaleY = (ACJV::CurrentBoardID == MIU_IO_JPN_GUN_EXTENTI) ? 224.0f : 0xFFFF;
+				posX = static_cast<u16>(m_jvsLightgunDX * scaleX);
+				if (ACJV::CurrentBoardID == RAYS_PCB || ACJV::CurrentBoardID == MIU_IO_JPN_GUN_EXTENTI)
+					posY = static_cast<u16>((1.0f - m_jvsLightgunDY) * scaleY);
+				else
+					posY = static_cast<u16>(m_jvsLightgunDY * scaleY);
+				if (posX == 0) posX = 1;
+				if (posY == 0) posY = 1;
+			}
+			for (u8 ch = 0; ch < channel; ch++)
+			{
+				(*output++) = static_cast<u8>(posX >> 8);
+				(*output++) = static_cast<u8>(posX);
+				(*output++) = static_cast<u8>(posY >> 8);
+				(*output++) = static_cast<u8>(posY);
+			}
 
-			(*dstSize) += 5;
+			(*dstSize) += 1 + (4 * channel);
 		}
-#endif
 		break;
-		// GPIO output
+		// GPIO output — game sends byte values to control physical outputs (e.g. gun recoil solenoids).
+		// Byte 1 = P1 recoil: value >= 0x50 means recoil triggered, value 0xC0 observed during fire.
+		// TODO: forward p1Recoil to serial port / USB for real lightgun recoil hardware
 		case JVS::OUTPUT_GENERAL:
 		{
-			assert(inSize >= 2);
+			JVS_ASSERT(inSize >= 2);
 
 			u8 bytecount = (*input++);
 			inWorkChecksum += bytecount;
@@ -630,16 +724,8 @@ void do_jvs_packet(const u8* input, u8* output) {
 
 				if(i == 1)
 				{
-					// value1 0xC0 indicates P1 recoil triggered
 					int p1Recoil = (gpvalue >= 0x50) ? 1 : 0;
-					/*if(p1Recoil != m_p1RecoilLast)
-					{
-						// TODOx6
-						//m_p1RecoilLast = p1Recoil;
-#ifdef _WIN32
-						m_mameCompatOutput->SendRecoil(p1Recoil);
-#endif
-					}*/
+					(void)p1Recoil;
 				}
 			}
 
@@ -654,8 +740,8 @@ void do_jvs_packet(const u8* input, u8* output) {
 		}
 	}
 	u8 inChecksum = (*input);
-	// if (inChecksum != (inWorkChecksum & 0xFF)) 
-		// Console.Warning("ACJV::%s: checksum mismatch: %02X | %02X", __FUNCTION__, inChecksum, inWorkChecksum&0xFF);
+	// if (inChecksum != (inWorkChecksum & 0xFF))
+	//     Console.Warning("ACJV::%s: checksum mismatch: %02X | %02X", __FUNCTION__, inChecksum, inWorkChecksum&0xFF);
 }
 
 
@@ -672,7 +758,6 @@ void do_acjv_packet() {
 		rd16[0x30]  = s_dip_switch_state; // here the game polls the dip switch values?
 		u16 PacketID = wr16[0x0C];
 		if(PacketID != 0) {
-			// Console.WriteLn("ACJV::JVS: Packet ID 0x%04X", PacketID);
 			if(wrbuf[0x122] == JVS_SYNC) {
 				do_jvs_packet(&wrbuf[0x122], &rdbuf[0x15A]);
 			} else {

--- a/pcsx2/DEV9/ACJV.h
+++ b/pcsx2/DEV9/ACJV.h
@@ -11,7 +11,7 @@ struct InputBindingInfo;
 #define ACJV_BASE_ADDDR 0x12400000
 #define ACJV_RANGE      0x1240
 #define ACJV_ADDR_CAP   0x8000 // ACJV.IRX r/w fun will do `(2 * (addr & 0x3FFF)`, meaning available range is `0x12400000` - `0x12407FFE`
-#define ACJV_PACKETSIZE 0x300 // seems to be the ammount of bytes that's always read/written by the game
+#define ACJV_PACKETSIZE 0x300 // seems to be the amount of bytes that's always read/written by the game
 
 #define ACJV_RDBASE 0x12404000 // acmeme access addr 0x2300
 #define ACJV_WRBASE 0x12404600 // acmeme access addr 0x2000
@@ -33,6 +33,27 @@ enum BOARDID {
 	FCB_JPN_TOUCHPANEL,
 	TSS_GUN_EXTENTION,
 	MIU_IO_JPN_GUN_EXTENTI
+};
+
+enum class JVS_MODE {
+	DEFAULT,
+	LIGHTGUN,
+	DRIVE,
+	DRUM,
+	TOUCH,
+};
+
+#define JVS_WHEEL_CHANNEL_MAX 3
+#define JVS_DRUM_CHANNEL_MAX 8
+
+struct GunMapping {
+    u16 pedal;
+    u16 sensor;
+    bool sensor_active_high;
+    u16 p1_start;
+    u16 p2_start;
+    u16 p1_trigger;
+    u16 p2_trigger;
 };
 
 namespace ACJV {
@@ -57,7 +78,6 @@ namespace ACJV {
     u16 Read16(u32 addr);
     void Write16(u32 addr, u16 val);
     extern enum BOARDID CurrentBoardID;
-    extern u16 ButtonState[JVS_PLAYER_COUNT];
 
     std::span<const DIPSwitchInfo> GetDIPSwitches();
     const DIPSwitchInfo& GetTestModeDIPSwitch();
@@ -79,6 +99,10 @@ namespace ACJV {
     void SetDefaultConfiguration(SettingsInterface& si);
 
     bool IsSuppressDaemonEnabled();
+    void SetMode(JVS_MODE mode);
+    void SetScreenPos(u16 x, u16 y);
+    void SetGameId(const std::string& gameid);
+    const GunMapping& GetGunMapping();
 }
 
 

--- a/pcsx2/R3000A.cpp
+++ b/pcsx2/R3000A.cpp
@@ -48,7 +48,8 @@ void psxReset()
 	psxRegs.iopCycleEECarry = 0;
 	psxRegs.iopNextEventCycle = psxRegs.cycle + 4;
 
-	PSXCLK = (PS2CLK == PS2CLK_S256) ? 49152000 : 36864000;
+	PSXCLK = (PS2CLK == PS2CLK_SS256) ? 55296000 :
+	         (PS2CLK == PS2CLK_S256)  ? 49152000 : 36864000;
 	psxHwReset();
 	ioman::reset();
 	psxBiosReset();

--- a/pcsx2/SPU2/Mixer.cpp
+++ b/pcsx2/SPU2/Mixer.cpp
@@ -522,13 +522,29 @@ static __forceinline StereoOut32 MixCore(const uint coreidx, const VoiceMixSet& 
 void spu2Mix()
 {
 	// Note: Playmode 4 is SPDIF, which overrides other inputs.
+	// When SPDIF is active (e.g. Time Crisis 4 EXSOUND board), read core 0
+	// input at HiFi rate (2x) since the S/PDIF transmitter consumes data at
+	// double the normal ADMA rate.
+	// ReadInput_HiFi returns packed 32-bit values; split into two 16-bit
+	// samples for left and right channels.
+	StereoOut32 RawInput0;
+	if (PlayMode & 4)
+	{
+		StereoOut32 hifi = Cores[0].ReadInput_HiFi();
+		RawInput0.Left = (s16)(hifi.Left & 0xFFFF);
+		RawInput0.Right = (s16)(hifi.Left >> 16);
+	}
+	else
+	{
+		RawInput0 = Cores[0].ReadInput();
+	}
 	StereoOut32 InputData[2] =
 		{
 			// SPDIF is on Core 0:
 			// Fixme:
 			// 1. We do not have an AC3 decoder for the bitstream.
 			// 2. Games usually provide a normal ADMA stream as well and want to see it getting read!
-			/*(PlayMode&4) ? StereoOut32::Empty : */ ApplyVolume(Cores[0].ReadInput(), Cores[0].InpVol),
+			/*(PlayMode&4) ? StereoOut32::Empty : */ ApplyVolume(RawInput0, Cores[0].InpVol),
 
 			// CDDA is on Core 1:
 			(PlayMode & 8) ? StereoOut32::Empty : ApplyVolume(Cores[1].ReadInput(), Cores[1].InpVol)};
@@ -546,7 +562,17 @@ void spu2Mix()
 
 	StereoOut32 Ext(MixCore(0, VoiceData[0], InputData[0], StereoOut32::Empty));
 
-	if ((PlayMode & 4) || (Cores[0].Mute != 0))
+	// When PlayMode=4 (SPDIF), the game routes ADMA input to the S/PDIF
+	// transmitter (e.g. Time Crisis 4 EXSOUND board). Since we don't emulate S/PDIF
+	// output, mix the raw ADMA input directly (bypassing InpVol/MMIX, as
+	// real SPDIF output is a direct digital stream).
+	if (PlayMode & 4)
+	{
+		Ext.Left += RawInput0.Left;
+		Ext.Right += RawInput0.Right;
+	}
+
+	if (Cores[0].Mute != 0)
 		Ext = StereoOut32::Empty;
 	else
 	{

--- a/pcsx2/USB/usb-lightgun/guncon2.cpp
+++ b/pcsx2/USB/usb-lightgun/guncon2.cpp
@@ -13,6 +13,7 @@
 #include "USB/qemu-usb/desc.h"
 #include "USB/usb-lightgun/guncon2.h"
 #include "VMManager.h"
+#include "DEV9/ACJV.h"
 
 #include "common/Console.h"
 #include "common/StringUtil.h"
@@ -269,6 +270,23 @@ namespace usb_lightgun
 				{
 					const auto [pos_x, pos_y] = us->CalculatePosition();
 
+					// Forward mouse position to JVS: on-screen = coords, off-screen = (0,0), update sensor bit
+					// TODO: use CalculatePosition() result instead of raw mouse, so Relative Aiming (joystick) works for S246
+					if (ACJV::enabled)
+					{
+						const auto& [mx, my] = InputManager::GetPointerAbsolutePosition(0);
+						float dx, dy;
+						GSTranslateWindowToDisplayCoordinates(mx, my, &dx, &dy);
+						bool on_screen = (dx >= 0.0f && dy >= 0.0f);
+						if (on_screen)
+							ACJV::SetScreenPos(static_cast<u16>((1.0f - dx) * 0xFFFF), static_cast<u16>(dy * 0xFFFF));
+						else
+							ACJV::SetScreenPos(0, 0);
+						const auto& gm = ACJV::GetGunMapping();
+						if (gm.sensor)
+							ACJV::SetButtonState(0, gm.sensor, gm.sensor_active_high ? on_screen : !on_screen);
+					}
+
 					// Time Crisis games do a "calibration" by displaying a black frame for a single frame,
 					// waiting for the gun to report (0, 0), and then computing an offset on the first non-zero
 					// value. So, after the trigger is pulled, we wait for a few frames, then send the (0, 0)
@@ -437,7 +455,7 @@ namespace usb_lightgun
 
 	const char* GunCon2Device::Name() const
 	{
-		return TRANSLATE_NOOP("USB", "GunCon 2");
+		return TRANSLATE_NOOP("USB", "Light Gun");
 	}
 
 	const char* GunCon2Device::TypeName() const
@@ -559,10 +577,50 @@ namespace usb_lightgun
 		if (bind_index < BID_RELATIVE_LEFT)
 		{
 			const u32 bit = 1u << bind_index;
+			const bool was_pressed = (s->button_state & bit) != 0;
 			if (value >= 0.5f)
 				s->button_state |= bit;
 			else
 				s->button_state &= ~bit;
+
+			// Forward GunCon2 USB buttons to JVS per-game mapping
+			if (ACJV::enabled)
+			{
+				const bool pressed = (value >= 0.5f);
+				const u32 player = s->port;
+				switch (bind_index)
+				{
+				// Trigger: P1 uses p1_trigger, P2 uses p2_trigger if defined (Vampire Night 2P)
+				case BID_TRIGGER:
+				{
+					const auto& mapping = ACJV::GetGunMapping();
+					if (player == 0)
+						ACJV::SetButtonState(0, mapping.p1_trigger, pressed);
+					else if (mapping.p2_trigger)
+						ACJV::SetButtonState(0, mapping.p2_trigger, pressed);
+					else
+						ACJV::SetButtonState(player, mapping.p1_trigger, pressed);
+					break;
+				}
+				// Foot pedal (cover/reload system: TC3, TC4, Cobra)
+				case BID_A:       ACJV::SetButtonState(player, ACJV::GetGunMapping().pedal, pressed); break;
+				// Start: P1 uses p1_start, P2 uses p2_start if defined (Vampire Night 2P)
+				case BID_START:
+				{
+					const auto& mapping = ACJV::GetGunMapping();
+					u16 startBit = mapping.p1_start ? mapping.p1_start : JVS_BTN_START;
+					if (player == 0)
+						ACJV::SetButtonState(0, startBit, pressed);
+					else if (mapping.p2_start)
+						ACJV::SetButtonState(0, mapping.p2_start, pressed);
+					else
+						ACJV::SetButtonState(player, startBit, pressed);
+					break;
+				}
+				// Coin insert (rising edge only — prevent double-count from repeated press events)
+				case BID_SELECT:  if (pressed && !was_pressed) ACJV::InsertCoin(player); break;
+				}
+			}
 		}
 		else if (bind_index <= BID_RELATIVE_DOWN)
 		{
@@ -585,15 +643,9 @@ namespace usb_lightgun
 			{"Right", TRANSLATE_NOOP("USB", "D-Pad Right"), nullptr, InputBindingInfo::Type::Button, BID_DPAD_RIGHT,
 				GenericInputBinding::DPadRight},
 			{"Trigger", TRANSLATE_NOOP("USB", "Trigger"), nullptr, InputBindingInfo::Type::Button, BID_TRIGGER, GenericInputBinding::R2},
-			{"ShootOffscreen", TRANSLATE_NOOP("USB", "Shoot Offscreen"), nullptr, InputBindingInfo::Type::Button, BID_SHOOT_OFFSCREEN,
-				GenericInputBinding::R1},
-			{"Recalibrate", TRANSLATE_NOOP("USB", "Calibration Shot"), nullptr, InputBindingInfo::Type::Button, BID_RECALIBRATE,
-				GenericInputBinding::Unknown},
-			{"A", TRANSLATE_NOOP("USB", "A"), nullptr, InputBindingInfo::Type::Button, BID_A, GenericInputBinding::Cross},
-			{"B", TRANSLATE_NOOP("USB", "B"), nullptr, InputBindingInfo::Type::Button, BID_B, GenericInputBinding::Circle},
-			{"C", TRANSLATE_NOOP("USB", "C"), nullptr, InputBindingInfo::Type::Button, BID_C, GenericInputBinding::Triangle},
-			{"Select", TRANSLATE_NOOP("USB", "Select"), nullptr, InputBindingInfo::Type::Button, BID_SELECT, GenericInputBinding::Select},
+			{"A", TRANSLATE_NOOP("USB", "Foot Pedal"), nullptr, InputBindingInfo::Type::Button, BID_A, GenericInputBinding::Cross},
 			{"Start", TRANSLATE_NOOP("USB", "Start"), nullptr, InputBindingInfo::Type::Button, BID_START, GenericInputBinding::Start},
+			{"Select", TRANSLATE_NOOP("USB", "Coins"), nullptr, InputBindingInfo::Type::Button, BID_SELECT, GenericInputBinding::Select},
 			{"RelativeLeft", TRANSLATE_NOOP("USB", "Relative Left"), nullptr, InputBindingInfo::Type::HalfAxis, BID_RELATIVE_LEFT, GenericInputBinding::Unknown},
 			{"RelativeRight", TRANSLATE_NOOP("USB", "Relative Right"), nullptr, InputBindingInfo::Type::HalfAxis, BID_RELATIVE_RIGHT, GenericInputBinding::Unknown},
 			{"RelativeUp", TRANSLATE_NOOP("USB", "Relative Up"), nullptr, InputBindingInfo::Type::HalfAxis, BID_RELATIVE_UP, GenericInputBinding::Unknown},

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1301,10 +1301,13 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				s_imgname = INI.GetStringValue("data", "mediasrc");
 				s_title = s_serial = INI.GetStringValue("game", "name");
 				s_disc_serial = s_serial = INI.GetStringValue("game", "gameid");
+				ACJV::SetGameId(s_serial); // Adapt JVS input to detected GAMEID
 				std::string platform = INI.GetStringValue("game", "platform", "");
-				s_acgame_sys246 = (platform == "246" || platform == "256");
-				s_acgame_sys256 = (platform == "256");
-				if (s_acgame_sys256)
+				s_acgame_sys246 = (platform == "246" || platform == "256" || platform == "super256");
+				s_acgame_sys256 = (platform == "256" || platform == "super256");
+				if (platform == "super256")
+					PS2CLK = PS2CLK_SS256;
+				else if (s_acgame_sys256)
 					PS2CLK = PS2CLK_S256;
 				if (s_acgame_sys246)
 				{
@@ -1338,6 +1341,21 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				s_elf_override = Path::Combine(basedir, INI.GetStringValue("data", "elf"));
 				EmuConfig.CurrentGameArgs = INI.GetStringValue("data", "args");
 				ACSRAM::filepath = Path::Combine(basedir, INI.GetStringValue("data", "sram", "sram.bin"));
+				std::string jvsmode = INI.GetStringValue("data", "jvsmode", "");
+				if (jvsmode == "lightgun")
+				{
+					Host::SetBaseStringSettingValue("USB1", "Type", "guncon2");
+					Host::SetBaseStringSettingValue("USB2", "Type", "guncon2");
+					ACJV::SetMode(JVS_MODE::LIGHTGUN);
+					Console.WriteLn(Color_Green, "ACGAME: jvsmode=lightgun -> GunCon2 on USB1+USB2");
+				}
+				else
+				{
+					Host::SetBaseStringSettingValue("USB1", "Type", "None");
+					Host::SetBaseStringSettingValue("USB2", "Type", "None");
+					ACJV::SetMode(JVS_MODE::DEFAULT);
+				}
+
 				ACATA::SetEnv(basedir, s_imgname, s_acmedia);
 				int R;
 				if ((R = ACATA::TH::IO_OpenImage())!=0) {


### PR DESCRIPTION
Now boots : Time Crisis 3, Time Crisis 4, Vampire Night, Cobra: The Arcade

**IMPORTANT NOTE: Time Crisis 3 and Vampire Night must be calibrated in test menu. You must bind trigger P2 button on Vampire Night to complete calibration.** Bind controls in Light gun tab under "USB Port" tab (to be renamed).

- add Super System 256 clock support (Time Crisis 4 system)
  - Add `platform=super256` in .acgame file under `[game]` section to emulate proper speed
- add full light gun support and initial jvs mode support
  - Add `jvsmode=lightgun` in .acgame file under `[data]` section to emulate light gun inputs (1 player only for now, need to add 2nd mouse pointer). Light gun has its own per-game basis specifics for inputs. If not specified, JVS mode is on default (standard JVS input layout [fighting game]).
  - Slightly change light gun UI controller tab for easy binding

Some minors additions and fixes:

- code clean up
- remove hardcoded keyboard default layout
- add basic BUSY, ATA interrupt and ATAPI command for CD speed (needed for VPN game and probably more)