### PR TITLE
JVS/GunCon2 UI cleanup + CD CHD fix + media path fix

### DIFF
--- a/pcsx2-qt/Settings/ControllerBindingWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerBindingWidget.cpp
@@ -1430,6 +1430,61 @@ USBBindingWidget* USBBindingWidget::createInstance(
 	{
 		Ui::USBBindingWidget_GunCon2().setupUi(widget);
 		has_template = true;
+
+		// Embed crosshair settings directly on the bindings page (no Settings subtab).
+		QGridLayout* mainLayout = qobject_cast<QGridLayout*>(widget->layout());
+		if (mainLayout)
+		{
+			QGroupBox* crosshairGroup = new QGroupBox(qApp->translate("USB", "Crosshair"), widget);
+			QGridLayout* chLayout = new QGridLayout(crosshairGroup);
+			chLayout->setColumnStretch(0, 0);
+			chLayout->setColumnStretch(1, 1);
+			SettingsInterface* sif = parent->getDialog()->getProfileSettingsInterface();
+			const std::string& config_section = parent->getConfigSection();
+			const std::string prefix = std::string(parent->getDeviceType()) + "_";
+
+			// Cursor Path
+			QLineEdit* cursorPath = new QLineEdit(crosshairGroup);
+			cursorPath->setObjectName(QStringLiteral("cursor_path"));
+			QPushButton* browseBtn = new QPushButton(qApp->translate("USB", "Browse..."), crosshairGroup);
+			ControllerSettingWidgetBinder::BindWidgetToInputProfileString(
+				sif, cursorPath, config_section, prefix + "cursor_path", "");
+			QObject::connect(browseBtn, &QPushButton::clicked, [widget, cursorPath]() {
+				const QString path(QDir::toNativeSeparators(QFileDialog::getOpenFileName(widget, qApp->translate("USB", "Select File"))));
+				if (!path.isEmpty())
+					cursorPath->setText(path);
+			});
+			QHBoxLayout* pathHBox = new QHBoxLayout();
+			pathHBox->addWidget(cursorPath, 1);
+			pathHBox->addWidget(browseBtn);
+			chLayout->addWidget(new QLabel(qApp->translate("USB", "Cursor Path"), crosshairGroup), 0, 0);
+			chLayout->addLayout(pathHBox, 0, 1);
+
+			// Cursor Scale
+			QDoubleSpinBox* cursorScale = new QDoubleSpinBox(crosshairGroup);
+			cursorScale->setObjectName(QStringLiteral("cursor_scale"));
+			cursorScale->setMinimum(1);
+			cursorScale->setMaximum(1000);
+			cursorScale->setSingleStep(1);
+			cursorScale->setSuffix(QStringLiteral("%"));
+			cursorScale->setDecimals(0);
+			ControllerSettingWidgetBinder::BindWidgetToInputProfileFloat(
+				sif, cursorScale, config_section, prefix + "cursor_scale", 1.0f, 100.0f);
+			chLayout->addWidget(new QLabel(qApp->translate("USB", "Cursor Scale"), crosshairGroup), 1, 0);
+			chLayout->addWidget(cursorScale, 1, 1);
+
+			// Cursor Color
+			QLineEdit* cursorColor = new QLineEdit(crosshairGroup);
+			cursorColor->setObjectName(QStringLiteral("cursor_color"));
+			ControllerSettingWidgetBinder::BindWidgetToInputProfileString(
+				sif, cursorColor, config_section, prefix + "cursor_color", "#ffffff");
+			chLayout->addWidget(new QLabel(qApp->translate("USB", "Cursor Color"), crosshairGroup), 2, 0);
+			chLayout->addWidget(cursorColor, 2, 1);
+
+			// Insert crosshair group before the vertical spacer (last item)
+			int spacerRow = mainLayout->rowCount();
+			mainLayout->addWidget(crosshairGroup, spacerRow, 0, 1, mainLayout->columnCount());
+		}
 	}
 	else if (type == "RealPlay")
 	{

--- a/pcsx2-qt/Settings/JVSControlsWidget.cpp
+++ b/pcsx2-qt/Settings/JVSControlsWidget.cpp
@@ -10,13 +10,24 @@
 #include "pcsx2/DEV9/ACJV.h"
 
 #include <QtCore/QCoreApplication>
+#include <QtWidgets/QGridLayout>
+#include <QtWidgets/QLabel>
 
 JVSControlsWidget::JVSControlsWidget(QWidget* parent, ControllerSettingsWindow* dialog)
 	: QWidget(parent)
 	, m_dialog(dialog)
 {
 	m_ui.setupUi(this);
+
+	for (int i = RAYS_PCB; i <= MIU_IO_JPN_GUN_EXTENTI; i++)
+		m_ui.boardType->addItem(QString::fromUtf8(ACJV::GetBoardDisplayName(static_cast<BOARDID>(i))));
+	m_ui.boardType->setCurrentIndex(static_cast<int>(ACJV::GetCurrentBoardID()));
+
 	bindDIPSwitchWidgets();
+	bindSystemButtonWidgets();
+
+	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(m_dialog->getProfileSettingsInterface(), m_ui.suppressDaemon,
+		ACJV::CONFIG_SECTION, "SuppressDaemon", true);
 }
 
 JVSControlsWidget::~JVSControlsWidget() = default;
@@ -50,9 +61,34 @@ void JVSControlsWidget::bindDIPSwitchWidgets()
 		ACJV::CONFIG_SECTION, video_sync_split.name, video_sync_split.default_value);
 	m_ui.toggleVideoSyncSplit->initialize(m_dialog->getProfileSettingsInterface(),
 		InputBindingInfo::Type::Button, ACJV::CONFIG_SECTION, video_sync_split.toggle_bind_name);
+}
 
-	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(m_dialog->getProfileSettingsInterface(), m_ui.suppressDaemon,
-		ACJV::CONFIG_SECTION, "SuppressDaemon", true);
+void JVSControlsWidget::bindSystemButtonWidgets()
+{
+	QGridLayout* layout = m_ui.systemButtonsLayout;
+	SettingsInterface* sif = m_dialog->getProfileSettingsInterface();
+
+	struct ButtonEntry {
+		const char* label;
+		const char* config_key;
+	};
+	static constexpr ButtonEntry entries[] = {
+		{"Service", "P1_Service"},
+		{"Insert Coin P1", "Coin1"},
+		{"Insert Coin P2", "Coin2"},
+	};
+
+	for (int i = 0; i < static_cast<int>(std::size(entries)); i++)
+	{
+		QLabel* label = new QLabel(tr(entries[i].label), this);
+		layout->addWidget(label, i, 0);
+
+		InputBindingWidget* bind = new InputBindingWidget(
+			this, sif, InputBindingInfo::Type::Button, ACJV::CONFIG_SECTION, entries[i].config_key);
+		bind->setMinimumWidth(225);
+		bind->setMaximumWidth(225);
+		layout->addWidget(bind, i, 1);
+	}
 }
 
 #include "moc_JVSControlsWidget.cpp"

--- a/pcsx2-qt/Settings/JVSControlsWidget.h
+++ b/pcsx2-qt/Settings/JVSControlsWidget.h
@@ -19,6 +19,7 @@ public:
 
 private:
 	void bindDIPSwitchWidgets();
+	void bindSystemButtonWidgets();
 
 	Ui::JVSControlsWidget m_ui;
 	ControllerSettingsWindow* m_dialog;

--- a/pcsx2-qt/Settings/JVSControlsWidget.ui
+++ b/pcsx2-qt/Settings/JVSControlsWidget.ui
@@ -3,206 +3,140 @@
  <class>JVSControlsWidget</class>
  <widget class="QWidget" name="JVSControlsWidget">
   <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>1100</width>
-    <height>620</height>
-   </rect>
+   <rect><x>0</x><y>0</y><width>1100</width><height>620</height></rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
-    <number>0</number>
-   </property>
+   <property name="leftMargin"><number>0</number></property>
+   <property name="topMargin"><number>0</number></property>
+   <property name="rightMargin"><number>0</number></property>
+   <property name="bottomMargin"><number>0</number></property>
    <item row="0" column="0">
     <widget class="QScrollArea" name="scrollArea">
-     <property name="frameShape">
-      <enum>QFrame::Shape::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Shadow::Sunken</enum>
-     </property>
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
+     <property name="frameShape"><enum>QFrame::Shape::StyledPanel</enum></property>
+     <property name="frameShadow"><enum>QFrame::Shadow::Sunken</enum></property>
+     <property name="widgetResizable"><bool>true</bool></property>
      <widget class="QWidget" name="scrollAreaWidgetContents">
       <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>1098</width>
-        <height>618</height>
-       </rect>
+       <rect><x>0</x><y>0</y><width>1098</width><height>618</height></rect>
       </property>
       <layout class="QVBoxLayout" name="scrollLayout">
+
+       <!-- Hardware (full width) -->
        <item>
-        <widget class="QGroupBox" name="dipSwitchGroup">
-         <property name="title">
-          <string>DIP Switches</string>
-         </property>
-         <layout class="QGridLayout" name="dipSwitchLayout" columnstretch="1,0">
+        <widget class="QGroupBox" name="hardwareGroup">
+         <property name="title"><string>Hardware</string></property>
+         <layout class="QGridLayout" name="hardwareLayout" columnstretch="0,1">
           <item row="0" column="0">
-           <widget class="QLabel" name="switchHeaderLabel">
-            <property name="text">
-             <string>Switch</string>
-            </property>
+           <widget class="QLabel" name="boardTypeLabel">
+            <property name="text"><string>JVS Board Type:</string></property>
+            <property name="buddy"><cstring>boardType</cstring></property>
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLabel" name="bindingHeaderLabel">
-            <property name="text">
-             <string>Toggle Binding</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="testMode">
-            <property name="text">
-             <string>Test Mode</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="InputBindingWidget" name="toggleTestMode">
-            <property name="minimumSize">
-             <size>
-              <width>225</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>225</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QCheckBox" name="videoVoltage">
-            <property name="text">
-             <string>Video Voltage</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="InputBindingWidget" name="toggleVideoVoltage">
-            <property name="minimumSize">
-             <size>
-              <width>225</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>225</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QCheckBox" name="monitorSyncFrequency">
-            <property name="text">
-             <string>Monitor Sync Frequency</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="InputBindingWidget" name="toggleMonitorSyncFrequency">
-            <property name="minimumSize">
-             <size>
-              <width>225</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>225</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QCheckBox" name="videoSyncSplit">
-            <property name="text">
-             <string>Video Sync Split</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="InputBindingWidget" name="toggleVideoSyncSplit">
-            <property name="minimumSize">
-             <size>
-              <width>225</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>225</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
+           <widget class="QComboBox" name="boardType">
+            <property name="enabled"><bool>false</bool></property>
+            <property name="toolTip"><string>Auto-detected from the game. Manual selection is not yet supported.</string></property>
            </widget>
           </item>
          </layout>
         </widget>
        </item>
+
+       <!-- DIP Switches (left) + System Buttons (right) -->
        <item>
-        <widget class="QGroupBox" name="extraGroup">
-         <property name="title">
-          <string>Extra</string>
-         </property>
-         <layout class="QVBoxLayout" name="extraLayout">
-          <item>
+        <layout class="QHBoxLayout" name="middleRow">
+         <item>
+          <widget class="QGroupBox" name="dipSwitchGroup">
+           <property name="title"><string>DIP Switches</string></property>
+           <layout class="QGridLayout" name="dipSwitchLayout" columnstretch="1,0">
+            <item row="0" column="0">
+             <widget class="QCheckBox" name="testMode">
+              <property name="text"><string>Test Mode</string></property>
+              <property name="toolTip"><string>Enter the machine's diagnostic test menu</string></property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="InputBindingWidget" name="toggleTestMode">
+              <property name="minimumSize"><size><width>225</width><height>0</height></size></property>
+              <property name="maximumSize"><size><width>225</width><height>16777215</height></size></property>
+              <property name="text"><string/></property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QCheckBox" name="videoVoltage">
+              <property name="text"><string>Video Voltage</string></property>
+              <property name="toolTip"><string>Video output voltage level (3.3V when ON, 5V when OFF)</string></property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="InputBindingWidget" name="toggleVideoVoltage">
+              <property name="minimumSize"><size><width>225</width><height>0</height></size></property>
+              <property name="maximumSize"><size><width>225</width><height>16777215</height></size></property>
+              <property name="text"><string/></property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QCheckBox" name="monitorSyncFrequency">
+              <property name="text"><string>Monitor Sync Frequency</string></property>
+              <property name="toolTip"><string>Monitor sync frequency (31kHz when ON, 15kHz when OFF)</string></property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="InputBindingWidget" name="toggleMonitorSyncFrequency">
+              <property name="minimumSize"><size><width>225</width><height>0</height></size></property>
+              <property name="maximumSize"><size><width>225</width><height>16777215</height></size></property>
+              <property name="text"><string/></property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QCheckBox" name="videoSyncSplit">
+              <property name="text"><string>Video Sync Split</string></property>
+              <property name="toolTip"><string>Video sync signal mode (separate H/V sync when ON, composite sync when OFF)</string></property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="InputBindingWidget" name="toggleVideoSyncSplit">
+              <property name="minimumSize"><size><width>225</width><height>0</height></size></property>
+              <property name="maximumSize"><size><width>225</width><height>16777215</height></size></property>
+              <property name="text"><string/></property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="systemButtonsGroup">
+           <property name="title"><string>System Buttons</string></property>
+           <layout class="QGridLayout" name="systemButtonsLayout" columnstretch="1,0">
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </item>
+
+       <!-- System Settings (full width) -->
+       <item>
+        <widget class="QGroupBox" name="systemSettingsGroup">
+         <property name="title"><string>System Settings</string></property>
+         <layout class="QGridLayout" name="systemSettingsLayout" columnstretch="1,0">
+          <item row="0" column="0" colspan="2">
            <widget class="QCheckBox" name="suppressDaemon">
-            <property name="toolTip">
-             <string>Avoids dongle I/O errors by suppresing the DAEMON driver security dongle check routine</string>
-            </property>
-            <property name="text">
-             <string>Suppress DAEMON security thread</string>
-            </property>
+            <property name="text"><string>Suppress DAEMON security thread</string></property>
+            <property name="toolTip"><string>Avoids dongle I/O errors by suppressing the DAEMON driver security dongle check routine</string></property>
            </widget>
           </item>
          </layout>
         </widget>
        </item>
+
+       <!-- Spacer -->
        <item>
         <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
+         <property name="orientation"><enum>Qt::Orientation::Vertical</enum></property>
+         <property name="sizeHint" stdset="0"><size><width>20</width><height>40</height></size></property>
         </spacer>
        </item>
+
       </layout>
      </widget>
     </widget>
@@ -217,6 +151,7 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>boardType</tabstop>
   <tabstop>testMode</tabstop>
   <tabstop>toggleTestMode</tabstop>
   <tabstop>videoVoltage</tabstop>
@@ -225,6 +160,7 @@
   <tabstop>toggleMonitorSyncFrequency</tabstop>
   <tabstop>videoSyncSplit</tabstop>
   <tabstop>toggleVideoSyncSplit</tabstop>
+  <tabstop>suppressDaemon</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/pcsx2-qt/Settings/USBBindingWidget_GunCon2.ui
+++ b/pcsx2-qt/Settings/USBBindingWidget_GunCon2.ui
@@ -23,303 +23,18 @@
    </size>
   </property>
   <layout class="QGridLayout" name="gridLayout_16">
-   <item row="2" column="2" colspan="2">
-    <widget class="QGroupBox" name="groupBox_16">
-     <property name="title">
-      <string>Buttons</string>
+   <item row="0" column="0" rowspan="3">
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
-     <layout class="QGridLayout" name="gridLayout_10">
-      <item row="0" column="0">
-       <widget class="QGroupBox" name="groupBox_19">
-        <property name="title">
-         <string>Foot Pedal</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_19">
-         <property name="leftMargin">
-          <number>6</number>
-         </property>
-         <property name="topMargin">
-          <number>6</number>
-         </property>
-         <property name="rightMargin">
-          <number>6</number>
-         </property>
-         <property name="bottomMargin">
-          <number>6</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="InputBindingWidget" name="A">
-           <property name="minimumSize">
-            <size>
-             <width>200</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>200</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true">PushButton</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QGroupBox" name="groupBox_23">
-        <property name="title">
-         <string>Start</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_23">
-         <property name="leftMargin">
-          <number>6</number>
-         </property>
-         <property name="topMargin">
-          <number>6</number>
-         </property>
-         <property name="rightMargin">
-          <number>6</number>
-         </property>
-         <property name="bottomMargin">
-          <number>6</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="InputBindingWidget" name="Start">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>200</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>200</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true">PushButton</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="1" column="2" colspan="2">
-       <widget class="QGroupBox" name="groupBox_35">
-        <property name="title">
-         <string>Coins</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_35">
-         <item row="0" column="0">
-          <widget class="InputBindingWidget" name="Select">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>200</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>200</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true">PushButton</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="0" column="3" rowspan="2">
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>D-Pad</string>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
      </property>
-     <layout class="QGridLayout" name="gridLayout_5">
-      <item row="3" column="1" colspan="2">
-       <widget class="QGroupBox" name="groupBox_5">
-        <property name="title">
-         <string>Down</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_4">
-         <property name="leftMargin">
-          <number>6</number>
-         </property>
-         <property name="topMargin">
-          <number>6</number>
-         </property>
-         <property name="rightMargin">
-          <number>6</number>
-         </property>
-         <property name="bottomMargin">
-          <number>6</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="InputBindingWidget" name="Down">
-           <property name="minimumSize">
-            <size>
-             <width>125</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>125</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true">PushButton</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QGroupBox" name="groupBox_3">
-        <property name="title">
-         <string>Left</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_2">
-         <property name="leftMargin">
-          <number>6</number>
-         </property>
-         <property name="topMargin">
-          <number>6</number>
-         </property>
-         <property name="rightMargin">
-          <number>6</number>
-         </property>
-         <property name="bottomMargin">
-          <number>6</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="InputBindingWidget" name="Left">
-           <property name="minimumSize">
-            <size>
-             <width>125</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>125</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true">PushButton</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="0" column="1" colspan="2">
-       <widget class="QGroupBox" name="groupBox_2">
-        <property name="title">
-         <string>Up</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout">
-         <property name="leftMargin">
-          <number>6</number>
-         </property>
-         <property name="topMargin">
-          <number>6</number>
-         </property>
-         <property name="rightMargin">
-          <number>6</number>
-         </property>
-         <property name="bottomMargin">
-          <number>6</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="InputBindingWidget" name="Up">
-           <property name="minimumSize">
-            <size>
-             <width>125</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>125</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true">PushButton</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="2" column="2" colspan="2">
-       <widget class="QGroupBox" name="groupBox_4">
-        <property name="title">
-         <string>Right</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_3">
-         <property name="leftMargin">
-          <number>6</number>
-         </property>
-         <property name="topMargin">
-          <number>6</number>
-         </property>
-         <property name="rightMargin">
-          <number>6</number>
-         </property>
-         <property name="bottomMargin">
-          <number>6</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="InputBindingWidget" name="Right">
-           <property name="minimumSize">
-            <size>
-             <width>125</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>125</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true">PushButton</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+    </spacer>
    </item>
    <item row="0" column="1">
     <widget class="QGroupBox" name="groupBox_15">
@@ -345,7 +60,193 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="4" rowspan="3">
+   <item row="0" column="2" rowspan="2">
+    <widget class="QGroupBox" name="groupBox_10">
+     <property name="title">
+      <string extracomment="Try to use Sony's official terminology for this. A good place to start would be in the console or the DualShock 2's manual. If this element was officially translated to your language by Sony in later DualShocks, you may use that term.">Relative Aiming</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_11">
+      <item row="0" column="1" colspan="2">
+       <widget class="QGroupBox" name="groupBox_13">
+        <property name="title">
+         <string>Up</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_14">
+         <property name="leftMargin"><number>6</number></property>
+         <property name="topMargin"><number>6</number></property>
+         <property name="rightMargin"><number>6</number></property>
+         <property name="bottomMargin"><number>6</number></property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="RelativeUp">
+           <property name="minimumSize"><size><width>100</width><height>0</height></size></property>
+           <property name="maximumSize"><size><width>100</width><height>16777215</height></size></property>
+           <property name="text"><string notr="true">PushButton</string></property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QGroupBox" name="groupBox_12">
+        <property name="title">
+         <string>Left</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_13">
+         <property name="leftMargin"><number>6</number></property>
+         <property name="topMargin"><number>6</number></property>
+         <property name="rightMargin"><number>6</number></property>
+         <property name="bottomMargin"><number>6</number></property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="RelativeLeft">
+           <property name="minimumSize"><size><width>100</width><height>0</height></size></property>
+           <property name="maximumSize"><size><width>100</width><height>16777215</height></size></property>
+           <property name="text"><string notr="true">PushButton</string></property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="2" column="2" colspan="2">
+       <widget class="QGroupBox" name="groupBox_14">
+        <property name="title">
+         <string>Right</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_15">
+         <property name="leftMargin"><number>6</number></property>
+         <property name="topMargin"><number>6</number></property>
+         <property name="rightMargin"><number>6</number></property>
+         <property name="bottomMargin"><number>6</number></property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="RelativeRight">
+           <property name="minimumSize"><size><width>100</width><height>0</height></size></property>
+           <property name="maximumSize"><size><width>100</width><height>16777215</height></size></property>
+           <property name="text"><string notr="true">PushButton</string></property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="3" column="1" colspan="2">
+       <widget class="QGroupBox" name="groupBox_11">
+        <property name="title">
+         <string>Down</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_12">
+         <property name="leftMargin"><number>6</number></property>
+         <property name="topMargin"><number>6</number></property>
+         <property name="rightMargin"><number>6</number></property>
+         <property name="bottomMargin"><number>6</number></property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="RelativeDown">
+           <property name="minimumSize"><size><width>100</width><height>0</height></size></property>
+           <property name="maximumSize"><size><width>100</width><height>16777215</height></size></property>
+           <property name="text"><string notr="true">PushButton</string></property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="1" rowspan="2">
+    <widget class="QGroupBox" name="groupBox_16">
+     <property name="title">
+      <string>Buttons</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_10">
+      <item row="0" column="0">
+       <widget class="QGroupBox" name="groupBox_7">
+        <property name="title">
+         <string>Trigger</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_6">
+         <property name="leftMargin"><number>6</number></property>
+         <property name="topMargin"><number>6</number></property>
+         <property name="rightMargin"><number>6</number></property>
+         <property name="bottomMargin"><number>6</number></property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="Trigger">
+           <property name="minimumSize"><size><width>200</width><height>0</height></size></property>
+           <property name="maximumSize"><size><width>200</width><height>16777215</height></size></property>
+           <property name="text"><string notr="true">PushButton</string></property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QGroupBox" name="groupBox_19">
+        <property name="title">
+         <string>Foot Pedal</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_19">
+         <property name="leftMargin"><number>6</number></property>
+         <property name="topMargin"><number>6</number></property>
+         <property name="rightMargin"><number>6</number></property>
+         <property name="bottomMargin"><number>6</number></property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="A">
+           <property name="minimumSize"><size><width>200</width><height>0</height></size></property>
+           <property name="maximumSize"><size><width>200</width><height>16777215</height></size></property>
+           <property name="text"><string notr="true">PushButton</string></property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QGroupBox" name="groupBox_23">
+        <property name="title">
+         <string>Start</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_23">
+         <property name="leftMargin"><number>6</number></property>
+         <property name="topMargin"><number>6</number></property>
+         <property name="rightMargin"><number>6</number></property>
+         <property name="bottomMargin"><number>6</number></property>
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="Start">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize"><size><width>200</width><height>0</height></size></property>
+           <property name="maximumSize"><size><width>200</width><height>16777215</height></size></property>
+           <property name="text"><string notr="true">PushButton</string></property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QGroupBox" name="groupBox_35">
+        <property name="title">
+         <string>Coins</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_35">
+         <item row="0" column="0">
+          <widget class="InputBindingWidget" name="Select">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize"><size><width>200</width><height>0</height></size></property>
+           <property name="maximumSize"><size><width>200</width><height>16777215</height></size></property>
+           <property name="text"><string notr="true">PushButton</string></property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="3" rowspan="3">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Orientation::Horizontal</enum>
@@ -358,238 +259,7 @@
      </property>
     </spacer>
    </item>
-   <item row="0" column="0" rowspan="3">
-    <spacer name="horizontalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="2" rowspan="2">
-    <widget class="QGroupBox" name="groupBox_10">
-     <property name="title">
-      <string extracomment="Try to use Sony's official terminology for this. A good place to start would be in the console or the DualShock 2's manual. If this element was officially translated to your language by Sony in later DualShocks, you may use that term.">Relative Aiming</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_11">
-      <item row="3" column="1" colspan="2">
-       <widget class="QGroupBox" name="groupBox_11">
-        <property name="title">
-         <string>Down</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_12">
-         <property name="leftMargin">
-          <number>6</number>
-         </property>
-         <property name="topMargin">
-          <number>6</number>
-         </property>
-         <property name="rightMargin">
-          <number>6</number>
-         </property>
-         <property name="bottomMargin">
-          <number>6</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="InputBindingWidget" name="RelativeDown">
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true">PushButton</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QGroupBox" name="groupBox_12">
-        <property name="title">
-         <string>Left</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_13">
-         <property name="leftMargin">
-          <number>6</number>
-         </property>
-         <property name="topMargin">
-          <number>6</number>
-         </property>
-         <property name="rightMargin">
-          <number>6</number>
-         </property>
-         <property name="bottomMargin">
-          <number>6</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="InputBindingWidget" name="RelativeLeft">
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true">PushButton</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="0" column="1" colspan="2">
-       <widget class="QGroupBox" name="groupBox_13">
-        <property name="title">
-         <string>Up</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_14">
-         <property name="leftMargin">
-          <number>6</number>
-         </property>
-         <property name="topMargin">
-          <number>6</number>
-         </property>
-         <property name="rightMargin">
-          <number>6</number>
-         </property>
-         <property name="bottomMargin">
-          <number>6</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="InputBindingWidget" name="RelativeUp">
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true">PushButton</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="2" column="2" colspan="2">
-       <widget class="QGroupBox" name="groupBox_14">
-        <property name="title">
-         <string>Right</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_15">
-         <property name="leftMargin">
-          <number>6</number>
-         </property>
-         <property name="topMargin">
-          <number>6</number>
-         </property>
-         <property name="rightMargin">
-          <number>6</number>
-         </property>
-         <property name="bottomMargin">
-          <number>6</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="InputBindingWidget" name="RelativeRight">
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true">PushButton</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="1" rowspan="2">
-    <widget class="QGroupBox" name="groupBox_6">
-     <property name="title">
-      <string>Trigger</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_9">
-      <item row="0" column="0">
-       <widget class="QGroupBox" name="groupBox_7">
-        <property name="title">
-         <string>Trigger</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_6">
-         <property name="leftMargin">
-          <number>6</number>
-         </property>
-         <property name="topMargin">
-          <number>6</number>
-         </property>
-         <property name="rightMargin">
-          <number>6</number>
-         </property>
-         <property name="bottomMargin">
-          <number>6</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="InputBindingWidget" name="Trigger">
-           <property name="minimumSize">
-            <size>
-             <width>125</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>125</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string notr="true">PushButton</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="5">
+   <item row="3" column="0" colspan="4">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Orientation::Vertical</enum>
@@ -613,17 +283,13 @@
  </customwidgets>
  <tabstops>
   <tabstop>Trigger</tabstop>
+  <tabstop>A</tabstop>
+  <tabstop>Start</tabstop>
+  <tabstop>Select</tabstop>
   <tabstop>RelativeUp</tabstop>
   <tabstop>RelativeDown</tabstop>
   <tabstop>RelativeLeft</tabstop>
   <tabstop>RelativeRight</tabstop>
-  <tabstop>Up</tabstop>
-  <tabstop>Down</tabstop>
-  <tabstop>Left</tabstop>
-  <tabstop>Right</tabstop>
-  <tabstop>A</tabstop>
-  <tabstop>Start</tabstop>
-  <tabstop>Select</tabstop>
  </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>

--- a/pcsx2/DEV9/ACATA.cpp
+++ b/pcsx2/DEV9/ACATA.cpp
@@ -420,7 +420,10 @@ void ACATA::SetImgPath(const char* S) {
 void ACATA::SetEnv(std::string ata_img_path, std::string ata_img_filename, std::string Media) {
 	//ACATA::imgpath = Path::ToNativePath(Path::GetDirectory(ata_img_path));
 	Console.WarningFmt("ata_img_path '{}' | ata_img_filename '{}'", ata_img_path, ata_img_filename);
-    ACATA::imgpath = Path::Combine(ata_img_path, ata_img_filename);
+    if (Path::IsAbsolute(ata_img_filename))
+        ACATA::imgpath = ata_img_filename;
+    else
+        ACATA::imgpath = Path::Combine(ata_img_path, ata_img_filename);
     ACATA::MediaType = ACMEDIATYPE_FROM_STRING(Media);
 	Console.WarningFmt("ACENV: ata_img: '{}'", ACATA::imgpath);
 	Console.WarningFmt("mediat: '{}'", (int)ACATA::MediaType);

--- a/pcsx2/DEV9/ACATA_IO_CHD.cpp
+++ b/pcsx2/DEV9/ACATA_IO_CHD.cpp
@@ -79,6 +79,9 @@ ACMEDIATYPE ChdImage::GetType() const
 
 u32 ChdImage::GetSectorSize() const
 {
+    // MAME CD CHDs: libchdr CD codecs already extract user data (2048) from raw sectors
+    if (m_unitBytes == 2448 || m_unitBytes == 2352)
+        return 2048;
     return m_unitBytes;
 }
 
@@ -126,10 +129,14 @@ bool ChdImage::ReadSector(u64 lba, void* buffer)
     if (!ReadHunk(hunk))
         return false;
 
-    std::memcpy(
-        buffer,
-        m_hunkBuffer.data() + offset,
-        m_unitBytes);
+    if (m_unitBytes == 2448 || m_unitBytes == 2352)
+    {
+        std::memcpy(buffer, m_hunkBuffer.data() + offset, 2048);
+    }
+    else
+    {
+        std::memcpy(buffer, m_hunkBuffer.data() + offset, m_unitBytes);
+    }
 
     return true;
 }
@@ -139,11 +146,12 @@ bool ChdImage::ReadSectors(u64 lba,
                            void* buffer)
 {
     u8* dst = static_cast<u8*>(buffer);
+    const u32 outBytes = (m_unitBytes == 2448 || m_unitBytes == 2352) ? 2048 : m_unitBytes;
 
     for (u32 i = 0; i < count; i++)
     {
         if (!ReadSector(lba + i,
-                        dst + (i * m_unitBytes)))
+                        dst + (i * outBytes)))
         {
             return false;
         }

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -46,6 +46,14 @@ std::string BOARDS[] = {
 };
 enum BOARDID ACJV::CurrentBoardID = RAYS_PCB;
 
+static constexpr const char* BOARD_DISPLAY_NAMES[] = {
+	"RAYS PCB",
+	"FCA-1 (Multipurpose)",
+	"FCB (Touch Panel)",
+	"TSS-I/O (Gun Extension)",
+	"MIU-I/O (Gun Extension)",
+};
+
 static constexpr u16 DEFAULT_DIP_SWITCH_STATE =
     (DIPS::VIDEO_VOLTAGE | DIPS::MONITOR_SYNCFREQ | DIPS::VIDEO_SYNC_SPLIT);
 
@@ -136,6 +144,18 @@ const ACJV::DIPSwitchInfo& ACJV::GetVideoSyncSplitDIPSwitch()
 bool ACJV::IsSuppressDaemonEnabled()
 {
 	return s_suppress_daemon;
+}
+
+const char* ACJV::GetBoardDisplayName(BOARDID id)
+{
+	if (id >= RAYS_PCB && id <= MIU_IO_JPN_GUN_EXTENTI)
+		return BOARD_DISPLAY_NAMES[id];
+	return "Unknown";
+}
+
+BOARDID ACJV::GetCurrentBoardID()
+{
+	return CurrentBoardID;
 }
 
 std::span<const InputBindingInfo> ACJV::GetDIPSwitchBindings()

--- a/pcsx2/DEV9/ACJV.h
+++ b/pcsx2/DEV9/ACJV.h
@@ -99,6 +99,8 @@ namespace ACJV {
     void SetDefaultConfiguration(SettingsInterface& si);
 
     bool IsSuppressDaemonEnabled();
+    const char* GetBoardDisplayName(BOARDID id);
+    BOARDID GetCurrentBoardID();
     void SetMode(JVS_MODE mode);
     void SetScreenPos(u16 x, u16 y);
     void SetGameId(const std::string& gameid);

--- a/pcsx2/USB/usb-lightgun/guncon2.cpp
+++ b/pcsx2/USB/usb-lightgun/guncon2.cpp
@@ -657,42 +657,19 @@ namespace usb_lightgun
 
 	std::span<const SettingInfo> GunCon2Device::Settings(u32 subtype) const
 	{
-		static constexpr const SettingInfo info[] = {
-			{SettingInfo::Type::Path, "cursor_path", TRANSLATE_NOOP("USB", "Cursor Path"),
-				TRANSLATE_NOOP("USB", "Sets the crosshair image that this lightgun will use. Setting a crosshair image "
-									  "will disable the system cursor."),
-				""},
-			{SettingInfo::Type::Float, "cursor_scale", TRANSLATE_NOOP("USB", "Cursor Scale"),
-				TRANSLATE_NOOP("USB", "Scales the crosshair image set above."), "1", "0.01", "10", "0.01", TRANSLATE_NOOP("USB", "%.0f%%"),
-				nullptr, nullptr, 100.0f},
-			{SettingInfo::Type::String, "cursor_color", TRANSLATE_NOOP("USB", "Cursor Color"),
-				TRANSLATE_NOOP("USB", "Applies a color to the chosen crosshair images, can be used for multiple "
-									  "players. Specify in HTML/CSS format (e.g. #aabbcc)"),
-				"#ffffff"},
-			{SettingInfo::Type::Boolean, "custom_config", TRANSLATE_NOOP("USB", "Manual Screen Configuration"),
-				TRANSLATE_NOOP("USB",
-					"Forces the use of the screen parameters below, instead of automatic parameters if available."),
-				"false"},
-			{SettingInfo::Type::Float, "scale_x", TRANSLATE_NOOP("USB", "X Scale (Sensitivity)"),
-				TRANSLATE_NOOP("USB", "Scales the position to simulate CRT curvature."), "100", "0", "200", "0.1",
-				TRANSLATE_NOOP("USB", "%.2f%%"), nullptr, nullptr, 1.0f},
-			{SettingInfo::Type::Float, "scale_y", TRANSLATE_NOOP("USB", "Y Scale (Sensitivity)"),
-				TRANSLATE_NOOP("USB", "Scales the position to simulate CRT curvature."), "100", "0", "200", "0.1",
-				TRANSLATE_NOOP("USB", "%.2f%%"), nullptr, nullptr, 1.0f},
-			{SettingInfo::Type::Float, "center_x", TRANSLATE_NOOP("USB", "Center X"),
-				TRANSLATE_NOOP("USB", "Sets the horizontal center position of the simulated screen."), "320", "0",
-				"1024", "1", TRANSLATE_NOOP("USB", "%.0fpx"), nullptr, nullptr, 1.0f},
-			{SettingInfo::Type::Float, "center_y", TRANSLATE_NOOP("USB", "Center Y"),
-				TRANSLATE_NOOP("USB", "Sets the vertical center position of the simulated screen."), "120", "0", "1024",
-				"1", TRANSLATE_NOOP("USB", "%.0fpx"), nullptr, nullptr, 1.0f},
-			{SettingInfo::Type::Integer, "screen_width", TRANSLATE_NOOP("USB", "Screen Width"),
-				TRANSLATE_NOOP("USB", "Sets the width of the simulated screen."), "640", "1", "1024", "1", TRANSLATE_NOOP("USB", "%dpx"),
-				nullptr, nullptr, 1.0f},
-			{SettingInfo::Type::Integer, "screen_height", TRANSLATE_NOOP("USB", "Screen Height"),
-				TRANSLATE_NOOP("USB", "Sets the height of the simulated screen."), "240", "1", "1024", "1", TRANSLATE_NOOP("USB", "%dpx"),
-				nullptr, nullptr, 1.0f},
-		};
-		return info;
+		// Crosshair settings (cursor_path, cursor_scale, cursor_color) are rendered
+		// inline on the GunCon2 bindings page — see ControllerBindingWidget.cpp.
+		// Manual screen configuration is not exposed; calibration is handled
+		// automatically by the emulator.
+		//
+		// {SettingInfo::Type::Boolean, "custom_config", "Manual Screen Configuration", ...},
+		// {SettingInfo::Type::Float, "scale_x", "X Scale (Sensitivity)", ...},
+		// {SettingInfo::Type::Float, "scale_y", "Y Scale (Sensitivity)", ...},
+		// {SettingInfo::Type::Float, "center_x", "Center X", ...},
+		// {SettingInfo::Type::Float, "center_y", "Center Y", ...},
+		// {SettingInfo::Type::Integer, "screen_width", "Screen Width", ...},
+		// {SettingInfo::Type::Integer, "screen_height", "Screen Height", ...},
+		return {};
 	}
 
 	bool GunCon2Device::Freeze(USBDevice* dev, StateWrapper& sw) const


### PR DESCRIPTION
- Redesign JVS controls tab layout and add back Service button along with player coins.
- Simplify GunCon2 binding UI (remove D-Pad, merge Trigger into Buttons)
- Add crosshair toggle inline in GunCon2 settings
- Fix CD CHD sector reads (2352/2448 unitbytes). Because of MAME CHDs.
- Fix media path resolution for absolute paths in acgame (useful for external hard drives)