### PR TITLE
JVS: jvsmode=fighting with per-game layouts, fix double input

### DIFF
--- a/pcsx2-qt/Settings/ControllerBindingWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerBindingWidget.cpp
@@ -67,7 +67,11 @@ QIcon ControllerBindingWidget::getIcon() const
 void ControllerBindingWidget::populateControllerTypes()
 {
 	for (const auto& [name, display_name] : Pad::GetControllerTypeNames())
-		m_ui.controllerType->addItem(QString::fromUtf8(display_name), QString::fromUtf8(name));
+	{
+		const std::string_view sv(name);
+		if (sv == "None" || sv == "DualShock2")
+			m_ui.controllerType->addItem(QString::fromUtf8(display_name), QString::fromUtf8(name));
+	}
 }
 
 void ControllerBindingWidget::onTypeChanged()

--- a/pcsx2-qt/Settings/JVSControlsWidget.cpp
+++ b/pcsx2-qt/Settings/JVSControlsWidget.cpp
@@ -73,7 +73,8 @@ void JVSControlsWidget::bindSystemButtonWidgets()
 		const char* config_key;
 	};
 	static constexpr ButtonEntry entries[] = {
-		{"Service", "P1_Service"},
+		{"P1 Service", "P1_Service"},
+		{"P2 Service", "P2_Service"},
 		{"Insert Coin P1", "Coin1"},
 		{"Insert Coin P2", "Coin2"},
 	};

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -108,6 +108,33 @@ static constexpr const std::array<InputBindingInfo, 12> s_jvs_p2_button_bindings
 	{"P2_Service", TRANSLATE_NOOP("JVS", "P2 Service"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_SERVICE, GenericInputBinding::Select},
 }};
 
+// Per-layout face button GenericInputBinding overrides (BTN3-6 only).
+// BTN1=Square, BTN2=Triangle are universal. Indexed by (FightingLayout - 1).
+static constexpr GenericInputBinding s_fighting_face_buttons[][4] = {
+	// BTN3,                        BTN4,                       BTN5,                       BTN6
+	{GenericInputBinding::Unknown, GenericInputBinding::Cross,  GenericInputBinding::Circle, GenericInputBinding::Unknown}, // TEKKEN
+	{GenericInputBinding::Cross,   GenericInputBinding::Circle, GenericInputBinding::Unknown,GenericInputBinding::Unknown}, // STANDARD
+	{GenericInputBinding::Cross,   GenericInputBinding::Circle, GenericInputBinding::L1,     GenericInputBinding::R1},      // SIX_BUTTON
+};
+
+static std::array<InputBindingInfo, 12> s_active_p1_bindings;
+static std::array<InputBindingInfo, 12> s_active_p2_bindings;
+
+// Copy base P1/P2 tables, select BTN3-6 face buttons from the layout.
+// Table indices: [0-3]=dpad, [4]=BTN1, [5]=BTN2, [6]=BTN3, [7]=BTN4, [8]=BTN5, [9]=BTN6, [10]=start, [11]=service
+static void UpdateFightingBindings(FightingLayout layout)
+{
+	s_active_p1_bindings = s_jvs_p1_button_bindings;
+	s_active_p2_bindings = s_jvs_p2_button_bindings;
+	const auto& face = s_fighting_face_buttons[static_cast<int>(layout)];
+	constexpr int BTN3_INDEX = 6;
+	for (int i = 0; i < 4; i++)
+	{
+		s_active_p1_bindings[BTN3_INDEX + i].generic_mapping = face[i];
+		s_active_p2_bindings[BTN3_INDEX + i].generic_mapping = face[i];
+	}
+}
+
 static constexpr const std::array<InputBindingInfo, 2> s_jvs_coin_bindings = {{
 	{"Coin1", TRANSLATE_NOOP("JVS", "Insert Coin P1"), nullptr, InputBindingInfo::Type::Button, 0, GenericInputBinding::Unknown},
 	{"Coin2", TRANSLATE_NOOP("JVS", "Insert Coin P2"), nullptr, InputBindingInfo::Type::Button, 1, GenericInputBinding::Unknown},
@@ -163,13 +190,19 @@ std::span<const InputBindingInfo> ACJV::GetDIPSwitchBindings()
 	return s_dip_switch_bindings;
 }
 
+static JVS_MODE m_jvsMode = JVS_MODE::DEFAULT;
+
 std::span<const InputBindingInfo> ACJV::GetButtonBindings()
 {
+	if (m_jvsMode == JVS_MODE::FIGHTING)
+		return s_active_p1_bindings;
 	return s_jvs_p1_button_bindings;
 }
 
 std::span<const InputBindingInfo> ACJV::GetP2ButtonBindings()
 {
+	if (m_jvsMode == JVS_MODE::FIGHTING)
+		return s_active_p2_bindings;
 	return s_jvs_p2_button_bindings;
 }
 
@@ -276,7 +309,6 @@ static u16 m_jvsButtonState[JVS_PLAYER_COUNT] = {};
 static u8 m_testButtonState = 0;
 static u16 m_coin1 = 0;
 static u16 m_coin2 = 0;
-static JVS_MODE m_jvsMode = JVS_MODE::DEFAULT;
 static u16 m_jvsScreenPosX = 0;
 static u16 m_jvsScreenPosY = 0;
 static float m_jvsLightgunDX = -1.0f;  // normalized display X (-1 = off-screen)
@@ -296,6 +328,19 @@ static const std::map<std::string, GunMapping> s_gun_mappings = {
 	{"NM00032", {JVS_BTN_3,    JVS_BTN_RIGHT, false, 0,          0,          JVS_BTN_LEFT, 0}},          // Time Crisis 4
 };
 static const GunMapping* m_gunMapping = &s_default_gun_mapping;
+
+static const std::map<std::string, FightingLayout> s_fighting_layouts = {
+	{"NM00004", FightingLayout::TEKKEN},     // Tekken 4
+	{"NM00019", FightingLayout::TEKKEN},     // Tekken 5 / 5.1
+	{"NM00026", FightingLayout::TEKKEN},     // Tekken 5 DR
+	{"NM00007", FightingLayout::STANDARD},   // Soul Calibur II
+	{"NM00031", FightingLayout::STANDARD},   // Soul Calibur III
+	{"NM00002", FightingLayout::STANDARD},   // Bloody Roar 3
+	{"NM00048", FightingLayout::STANDARD},   // Fate Unlimited Codes
+	{"NM00029", FightingLayout::STANDARD},   // Kinnikuman MGP
+	{"NM00018", FightingLayout::SIX_BUTTON}, // Capcom Fighting Jam
+	{"NM00042", FightingLayout::SIX_BUTTON}, // Sengoku Basara X
+};
 
 // Gamepad input -> JVS button state: set or clear a button bit for a player
 void ACJV::SetButtonState(u32 player, u16 mask, bool pressed)
@@ -354,6 +399,14 @@ void ACJV::SetGameId(const std::string& gameid)
 	}
 	else
 		m_gunMapping = &s_default_gun_mapping;
+
+	auto fit = s_fighting_layouts.find(gameid);
+	if (fit != s_fighting_layouts.end())
+	{
+		constexpr const char* layout_names[] = {"tekken", "standard", "6-button"};
+		Console.WriteLn("ACJV: fighting layout for %s: %s", gameid.c_str(), layout_names[static_cast<int>(fit->second)]);
+		UpdateFightingBindings(fit->second);
+	}
 
 	// TC3 has 3 I/O boards: TSS-I/O (white flash), MIU-I/O (640x224), RAYS PCB (0xFFFF).
 	// MIU-I/O chosen: no flash artifact, calibration uses JVS trigger debounce directly.

--- a/pcsx2/DEV9/ACJV.h
+++ b/pcsx2/DEV9/ACJV.h
@@ -38,9 +38,16 @@ enum BOARDID {
 enum class JVS_MODE {
 	DEFAULT,
 	LIGHTGUN,
+	FIGHTING,
 	DRIVE,
 	DRUM,
 	TOUCH,
+};
+
+enum class FightingLayout {
+	TEKKEN,     // Sw1,2,4,5 (skip Sw3) — TK4, TK5, TK5DR
+	STANDARD,   // Sw1,2,3,4 (sequential) — SC2, SC3, BRT, FUD, KN
+	SIX_BUTTON, // Sw1-6 — JAM, BAX
 };
 
 #define JVS_WHEEL_CHANNEL_MAX 3

--- a/pcsx2/Input/InputManager.cpp
+++ b/pcsx2/Input/InputManager.cpp
@@ -888,8 +888,9 @@ void InputManager::AddJVSBindings(SettingsInterface& si, bool is_profile)
 			}}, bi.bind_type, si, ACJV::CONFIG_SECTION, bi.name, is_profile);
 		}
 
-		// Auto-mirror PadN gamepad bindings to JVS player N via matching GenericInputBinding.
-		// Select is excluded — on real cabs Service is a separate physical button; Select maps to Coin instead.
+		// Mirror PadN gamepad bindings to JVS player N via matching GenericInputBinding.
+		// Real S246 cabinets have no DS2 — the arcade panel wires directly to JVS.
+		// We read the user's Pad bindings and route them to JVS as the sole input path.
 		const Pad::ControllerInfo* pad_ci = Pad::GetControllerInfo(EmuConfig.Pad.Ports[player].Type);
 		if (!pad_ci)
 			continue;
@@ -917,7 +918,7 @@ void InputManager::AddJVSBindings(SettingsInterface& si, bool is_profile)
 			}
 		}
 
-		// Auto-mirror PadN Select -> Coin insert for player N
+		// Mirror PadN Select -> Coin insert for player N
 		for (const InputBindingInfo& pad_bi : pad_ci->bindings)
 		{
 			if (pad_bi.generic_mapping != GenericInputBinding::Select)
@@ -1644,10 +1645,11 @@ void InputManager::ReloadBindings(SettingsInterface& si, SettingsInterface& bind
 	AddHotkeyBindings(hotkey_binding_si, is_hotkey_profile);
 	AddJVSBindings(binding_si, is_binding_profile);
 
-	// If there's an input profile, we load pad bindings from it alone, rather than
-	// falling back to the base configuration.
-	for (u32 pad = 0; pad < Pad::NUM_CONTROLLER_PORTS; pad++)
-		AddPadBindings(binding_si, pad, is_binding_profile);
+	// S246/S256 cabinets have no DS2 controller — pad bindings are mirrored to JVS above.
+	// AddPadBindings is not called: the emulated DualShock2 receives no input,
+	// matching real hardware where the controller ports are empty.
+	// for (u32 pad = 0; pad < Pad::NUM_CONTROLLER_PORTS; pad++)
+	// 	AddPadBindings(binding_si, pad, is_binding_profile);
 
 	constexpr float ui_ctrl_range = 100.0f;
 	constexpr float pointer_sensitivity = 0.05f;

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1353,7 +1353,13 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				{
 					Host::SetBaseStringSettingValue("USB1", "Type", "None");
 					Host::SetBaseStringSettingValue("USB2", "Type", "None");
-					ACJV::SetMode(JVS_MODE::DEFAULT);
+					if (jvsmode == "fighting")
+					{
+						ACJV::SetMode(JVS_MODE::FIGHTING);
+						Console.WriteLn(Color_Green, "ACGAME: jvsmode=fighting");
+					}
+					else
+						ACJV::SetMode(JVS_MODE::DEFAULT);
 				}
 
 				ACATA::SetEnv(basedir, s_imgname, s_acmedia);


### PR DESCRIPTION
- Add Fighting buttons layout (TEKKEN/STANDARD/SIX_BUTTON) with per-game map.
  - Parse `jvsmode=fighting` from `.acgame` files
- Map BTN3-6 GenericInputBinding layout based on game ID
- Disable AddPadBindings to prevent double input via PADMAN
- Filter controller type dropdown to None + DualShock 2 only (already mirrored to JVS)
- Add missing P2 Service button to JVS Controls tab
- Remove other controller types and only keep NONE/DUALSHOCK 2 (they are not used anyway)