### PR TITLE
AlignSpriteX per game ID + Kinnikuman MGP 2 fighting layout

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -30,6 +30,8 @@ NM00007:
   name: Soul Calibur II
   region: System246
   bootprog: SCSLOAD
+  gsHWFixes:
+    alignSprite: 1
 NM00008:
   name: Wangan Midnight
   region: System246
@@ -106,6 +108,8 @@ NM00026:
   name: Tekken 5 - Dark Resurrection
   region: System256
   bootprog: T55LOAD
+  gsHWFixes:
+    alignSprite: 1
 NM00027:
   name: Super Dragon Ball Z
   region: System256
@@ -126,6 +130,8 @@ NM00031:
   name: Soul Calibur III - Arcade Edition
   region: System246
   bootprog: SC3LOAD
+  gsHWFixes:
+    alignSprite: 1
 NM00032:
   name: Time Crisis 4
   region: System256

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -142,6 +142,7 @@ static constexpr const std::array<InputBindingInfo, 2> s_jvs_coin_bindings = {{
 
 static u16 s_dip_switch_state = DEFAULT_DIP_SWITCH_STATE;
 static bool s_suppress_daemon = true;
+static std::string s_gameid;
 
 std::span<const ACJV::DIPSwitchInfo> ACJV::GetDIPSwitches()
 {
@@ -338,6 +339,7 @@ static const std::map<std::string, FightingLayout> s_fighting_layouts = {
 	{"NM00002", FightingLayout::STANDARD},   // Bloody Roar 3
 	{"NM00048", FightingLayout::STANDARD},   // Fate Unlimited Codes
 	{"NM00029", FightingLayout::STANDARD},   // Kinnikuman MGP
+	{"NM00040", FightingLayout::STANDARD},   // Kinnikuman MGP 2
 	{"NM00018", FightingLayout::SIX_BUTTON}, // Capcom Fighting Jam
 	{"NM00042", FightingLayout::SIX_BUTTON}, // Sengoku Basara X
 };
@@ -374,8 +376,11 @@ void ACJV::SetScreenPos(u16 x, u16 y)
 }
 
 // Called from VMManager on game boot. Resets all JVS state and selects per-game I/O config.
+const std::string& ACJV::GetGameId() { return s_gameid; }
+
 void ACJV::SetGameId(const std::string& gameid)
 {
+	s_gameid = gameid;
 	// Clean slate: zero all input state on game switch within the emulator
 	m_coin1 = 0;
 	m_coin2 = 0;

--- a/pcsx2/DEV9/ACJV.h
+++ b/pcsx2/DEV9/ACJV.h
@@ -111,6 +111,7 @@ namespace ACJV {
     void SetMode(JVS_MODE mode);
     void SetScreenPos(u16 x, u16 y);
     void SetGameId(const std::string& gameid);
+    const std::string& GetGameId();
     const GunMapping& GetGunMapping();
 }
 

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -732,6 +732,14 @@ void VMManager::WarnAboutUnconfiguredController()
 
 void VMManager::ApplyGameFixes()
 {
+	// Arcade games: HasBootedELF() stays false during proverb.elf boot, but the
+	// game serial is already set. Apply GameDB fixes early so gsHWFixes work.
+	if (!s_acgame.empty())
+	{
+		if (const auto* game = GameDatabase::findGame(ACJV::GetGameId()))
+			game->applyGSHardwareFixes(EmuConfig.GS);
+	}
+
 	if (!HasBootedELF() && !GSDumpReplayer::IsReplayingDump())
 	{
 		// Instant DMA needs to be on for this BIOS (font rendering is broken without it, possible cache issues).


### PR DESCRIPTION
- Enable _AlignSpriteX_ (Align Sprite rendering hack from PCSX2) for Namco fighting games (SC2, SC3, TK5DR) to fix vertical lines at above 1x upscaling.

- Add Kinnikuman Muscle Grand Prix 2 (NM00040) to fighting layouts. Game is playable.