### PR TITLE
Add sinden lightgun border support and fix weird crosshair bug

### DIFF
--- a/pcsx2-qt/Settings/ControllerBindingWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerBindingWidget.cpp
@@ -14,6 +14,7 @@
 
 #include "pcsx2/Host.h"
 #include "pcsx2/SIO/Pad/Pad.h"
+#include "pcsx2/DEV9/ACJV.h"
 
 #include "Settings/ControllerBindingWidget.h"
 #include "Settings/ControllerSettingsWindow.h"
@@ -1488,6 +1489,46 @@ USBBindingWidget* USBBindingWidget::createInstance(
 			// Insert crosshair group before the vertical spacer (last item)
 			int spacerRow = mainLayout->rowCount();
 			mainLayout->addWidget(crosshairGroup, spacerRow, 0, 1, mainLayout->columnCount());
+
+			// Sinden Lightgun Border — only on USB Port 1
+			if (parent->getPortNumber() == 0)
+			{
+				QGroupBox* sindenGroup = new QGroupBox(qApp->translate("USB", "Light Gun Border (Sinden)"), widget);
+				QGridLayout* sindenLayout = new QGridLayout(sindenGroup);
+				sindenLayout->setColumnStretch(0, 0);
+				sindenLayout->setColumnStretch(1, 1);
+
+				QCheckBox* sindenEnabled = new QCheckBox(qApp->translate("USB", "Enable white border"), sindenGroup);
+				sindenEnabled->setToolTip(qApp->translate("USB",
+					"Display a white border around the screen for Sinden Lightgun tracking. Only active for lightgun games."));
+				ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(
+					sif, sindenEnabled, ACJV::CONFIG_SECTION, "SindenBorderEnabled", false);
+				sindenLayout->addWidget(sindenEnabled, 0, 0, 1, 2);
+
+				QComboBox* sindenMode = new QComboBox(sindenGroup);
+				sindenMode->addItem(qApp->translate("USB", "4:3 (Game Surface)"));
+				sindenMode->addItem(qApp->translate("USB", "Fullscreen (Entire Window)"));
+				sindenMode->setToolTip(qApp->translate("USB",
+					"4:3 frames the rendered game surface. Fullscreen fills the entire emulator window."));
+				ControllerSettingWidgetBinder::BindWidgetToInputProfileInt(
+					sif, sindenMode, ACJV::CONFIG_SECTION, "SindenBorderMode", 0);
+				sindenLayout->addWidget(new QLabel(qApp->translate("USB", "Border Mode"), sindenGroup), 1, 0);
+				sindenLayout->addWidget(sindenMode, 1, 1);
+
+				QSpinBox* sindenThickness = new QSpinBox(sindenGroup);
+				sindenThickness->setMinimum(1);
+				sindenThickness->setMaximum(100);
+				sindenThickness->setValue(10);
+				sindenThickness->setSuffix(QStringLiteral(" px"));
+				sindenThickness->setToolTip(qApp->translate("USB", "Border thickness in pixels (1-100)"));
+				ControllerSettingWidgetBinder::BindWidgetToInputProfileInt(
+					sif, sindenThickness, ACJV::CONFIG_SECTION, "SindenBorderThickness", 10);
+				sindenLayout->addWidget(new QLabel(qApp->translate("USB", "Border Thickness"), sindenGroup), 2, 0);
+				sindenLayout->addWidget(sindenThickness, 2, 1);
+
+				int sindenRow = mainLayout->rowCount();
+				mainLayout->addWidget(sindenGroup, sindenRow, 0, 1, mainLayout->columnCount());
+			}
 		}
 	}
 	else if (type == "RealPlay")

--- a/pcsx2-qt/Settings/USBBindingWidget_GunCon2.ui
+++ b/pcsx2-qt/Settings/USBBindingWidget_GunCon2.ui
@@ -23,7 +23,7 @@
    </size>
   </property>
   <layout class="QGridLayout" name="gridLayout_16">
-   <item row="0" column="0" rowspan="3">
+   <item row="0" column="0" rowspan="2">
     <spacer name="horizontalSpacer_2">
      <property name="orientation">
       <enum>Qt::Orientation::Horizontal</enum>
@@ -36,31 +36,7 @@
      </property>
     </spacer>
    </item>
-   <item row="0" column="1">
-    <widget class="QGroupBox" name="groupBox_15">
-     <property name="title">
-      <string>Pointer Setup</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>&lt;p&gt;By default, the light gun uses the mouse pointer. You &lt;strong&gt;do not&lt;/strong&gt; need to configure any bindings apart from the trigger and buttons.&lt;/p&gt;
-
-&lt;p&gt;If you want to use a controller, or lightgun which simulates a controller instead of a mouse, then you should bind it to Relative Aiming. Otherwise, Relative Aiming should be &lt;strong&gt;left unbound&lt;/strong&gt;.&lt;/p&gt;</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="0" column="2" rowspan="2">
+   <item row="0" column="2">
     <widget class="QGroupBox" name="groupBox_10">
      <property name="title">
       <string extracomment="Try to use Sony's official terminology for this. A good place to start would be in the console or the DualShock 2's manual. If this element was officially translated to your language by Sony in later DualShocks, you may use that term.">Relative Aiming</string>
@@ -149,7 +125,7 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="1" rowspan="2">
+   <item row="0" column="1">
     <widget class="QGroupBox" name="groupBox_16">
      <property name="title">
       <string>Buttons</string>
@@ -246,7 +222,7 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="3" rowspan="3">
+   <item row="0" column="3" rowspan="2">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Orientation::Horizontal</enum>
@@ -259,7 +235,7 @@
      </property>
     </spacer>
    </item>
-   <item row="3" column="0" colspan="4">
+   <item row="1" column="0" colspan="4">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Orientation::Vertical</enum>

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -7,6 +7,7 @@
 #include "GS/GS.h"
 #include "common/SettingsInterface.h"
 #include <array>
+#include <atomic>
 #include <string>
 
 enum ACJVCMD {
@@ -142,6 +143,9 @@ static constexpr const std::array<InputBindingInfo, 2> s_jvs_coin_bindings = {{
 
 static u16 s_dip_switch_state = DEFAULT_DIP_SWITCH_STATE;
 static bool s_suppress_daemon = true;
+static std::atomic<bool> s_sinden_border_enabled{false};
+static std::atomic<int> s_sinden_border_mode{0};
+static std::atomic<int> s_sinden_border_thickness{10};
 static std::string s_gameid;
 
 std::span<const ACJV::DIPSwitchInfo> ACJV::GetDIPSwitches()
@@ -249,6 +253,9 @@ void ACJV::LoadConfig(const SettingsInterface& si)
 	}
 	s_dip_switch_state = state;
 	s_suppress_daemon = si.GetBoolValue(CONFIG_SECTION, "SuppressDaemon", true);
+	s_sinden_border_enabled = si.GetBoolValue(CONFIG_SECTION, "SindenBorderEnabled", false);
+	s_sinden_border_mode = si.GetIntValue(CONFIG_SECTION, "SindenBorderMode", 0);
+	s_sinden_border_thickness = si.GetIntValue(CONFIG_SECTION, "SindenBorderThickness", 10);
 }
 
 void ACJV::CopyConfiguration(SettingsInterface* dest_si, const SettingsInterface& src_si, bool copy_settings, bool copy_bindings)
@@ -258,6 +265,9 @@ void ACJV::CopyConfiguration(SettingsInterface* dest_si, const SettingsInterface
 		for (const DIPSwitchInfo& dip_switch : s_dip_switch_info)
 			dest_si->CopyBoolValue(src_si, CONFIG_SECTION, dip_switch.name);
 		dest_si->CopyBoolValue(src_si, CONFIG_SECTION, "SuppressDaemon");
+		dest_si->CopyBoolValue(src_si, CONFIG_SECTION, "SindenBorderEnabled");
+		dest_si->CopyIntValue(src_si, CONFIG_SECTION, "SindenBorderMode");
+		dest_si->CopyIntValue(src_si, CONFIG_SECTION, "SindenBorderThickness");
 	}
 
 	if (copy_bindings)
@@ -279,6 +289,9 @@ void ACJV::SetDefaultConfiguration(SettingsInterface& si)
 	for (const DIPSwitchInfo& dip_switch : s_dip_switch_info)
 		si.SetBoolValue(CONFIG_SECTION, dip_switch.name, dip_switch.default_value);
 	si.SetBoolValue(CONFIG_SECTION, "SuppressDaemon", true);
+	si.SetBoolValue(CONFIG_SECTION, "SindenBorderEnabled", false);
+	si.SetIntValue(CONFIG_SECTION, "SindenBorderMode", 0);
+	si.SetIntValue(CONFIG_SECTION, "SindenBorderThickness", 10);
 }
 
 u16 ACJV::Read16(u32 addr) {
@@ -367,6 +380,26 @@ void ACJV::InsertCoin(u32 slot)
 void ACJV::SetMode(JVS_MODE mode)
 {
 	m_jvsMode = mode;
+}
+
+JVS_MODE ACJV::GetMode()
+{
+	return m_jvsMode;
+}
+
+bool ACJV::IsSindenBorderEnabled()
+{
+	return s_sinden_border_enabled;
+}
+
+int ACJV::GetSindenBorderMode()
+{
+	return s_sinden_border_mode;
+}
+
+int ACJV::GetSindenBorderThickness()
+{
+	return s_sinden_border_thickness;
 }
 
 void ACJV::SetScreenPos(u16 x, u16 y)

--- a/pcsx2/DEV9/ACJV.h
+++ b/pcsx2/DEV9/ACJV.h
@@ -109,10 +109,15 @@ namespace ACJV {
     const char* GetBoardDisplayName(BOARDID id);
     BOARDID GetCurrentBoardID();
     void SetMode(JVS_MODE mode);
+    JVS_MODE GetMode();
     void SetScreenPos(u16 x, u16 y);
     void SetGameId(const std::string& gameid);
     const std::string& GetGameId();
     const GunMapping& GetGunMapping();
+
+    bool IsSindenBorderEnabled();
+    int GetSindenBorderMode();
+    int GetSindenBorderThickness();
 }
 
 

--- a/pcsx2/GS/Renderers/Common/GSRenderer.cpp
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.cpp
@@ -61,6 +61,11 @@ GSRenderer::GSRenderer()
 
 GSRenderer::~GSRenderer() = default;
 
+GSVector4 GSRenderer::GetLastDrawRect()
+{
+	return s_last_draw_rect;
+}
+
 void GSRenderer::Reset(bool hardware_reset)
 {
 	// Clear the current display texture.

--- a/pcsx2/GS/Renderers/Common/GSRenderer.h
+++ b/pcsx2/GS/Renderers/Common/GSRenderer.h
@@ -57,6 +57,7 @@ public:
 	void QueueSnapshot(const std::string& path, const u32 gsdump_frames);
 	void StopGSDump();
 	void PresentCurrentFrame();
+	static GSVector4 GetLastDrawRect();
 	bool BeginCapture(std::string filename, const GSVector2i& size = GSVector2i(0, 0));
 	void EndCapture();
 };

--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -277,6 +277,16 @@ void ImGuiManager::UpdateScale()
 	s_global_scale = scale;
 	SetStyle();
 
+	for (u32 i = 0; i < std::size(s_software_cursors); i++)
+	{
+		SoftwareCursor& sc = s_software_cursors[i];
+		if (sc.texture)
+		{
+			sc.extent_x = std::ceil(static_cast<float>(sc.texture->GetWidth()) * sc.scale * s_global_scale) / 2.0f;
+			sc.extent_y = std::ceil(static_cast<float>(sc.texture->GetHeight()) * sc.scale * s_global_scale) / 2.0f;
+		}
+	}
+
 	ImGuiFullscreen::UpdateFontScale();
 
 	if (FullscreenUI::IsInitialized())

--- a/pcsx2/ImGui/ImGuiOverlays.cpp
+++ b/pcsx2/ImGui/ImGuiOverlays.cpp
@@ -30,6 +30,8 @@
 #include "SIO/Pad/PadBase.h"
 #include "USB/USB.h"
 #include "VMManager.h"
+#include "DEV9/ACJV.h"
+#include "GS/Renderers/Common/GSRenderer.h"
 
 #include "common/BitUtils.h"
 #include "common/Error.h"
@@ -1767,6 +1769,43 @@ void SaveStateSelectorUI::ShowSlotOSDMessage()
 		Host::OSD_QUICK_DURATION);
 }
 
+static void DrawSindenBorder()
+{
+	if (ACJV::GetMode() != JVS_MODE::LIGHTGUN || !ACJV::IsSindenBorderEnabled())
+		return;
+
+	const int thickness = ACJV::GetSindenBorderThickness();
+	const int mode = ACJV::GetSindenBorderMode();
+	const u32 color = IM_COL32(0xFF, 0xFF, 0xFF, 0xFF);
+
+	ImDrawList* dl = ImGui::GetForegroundDrawList();
+	float x0, y0, x1, y1;
+
+	if (mode == 0)
+	{
+		const GSVector4 rect = GSRenderer::GetLastDrawRect();
+		x0 = rect.x;
+		y0 = rect.y;
+		x1 = rect.z;
+		y1 = rect.w;
+		if (x1 <= x0 || y1 <= y0)
+			return;
+	}
+	else
+	{
+		x0 = 0.0f;
+		y0 = 0.0f;
+		x1 = ImGuiManager::GetWindowWidth();
+		y1 = ImGuiManager::GetWindowHeight();
+	}
+
+	const float t = static_cast<float>(thickness);
+	dl->AddRectFilled(ImVec2(x0, y0), ImVec2(x1, y0 + t), color);
+	dl->AddRectFilled(ImVec2(x0, y1 - t), ImVec2(x1, y1), color);
+	dl->AddRectFilled(ImVec2(x0, y0 + t), ImVec2(x0 + t, y1 - t), color);
+	dl->AddRectFilled(ImVec2(x1 - t, y0 + t), ImVec2(x1, y1 - t), color);
+}
+
 void ImGuiManager::RenderOverlays()
 {
 	const float scale = ImGuiManager::GetGlobalScale();
@@ -1774,6 +1813,7 @@ void ImGuiManager::RenderOverlays()
 	const float spacing = std::ceil(5.0f * scale);
 	float position_y = margin;
 
+	DrawSindenBorder();
 	DrawIndicatorsOverlay(position_y, scale, margin, spacing);
 	DrawVideoCaptureOverlay(position_y, scale, margin, spacing);
 	DrawInputRecordingOverlay(position_y, scale, margin, spacing);


### PR DESCRIPTION
- add Sinden lightgun border overlay for gun games
  - Mode (4:3 or fullscreen)
  - Thickness (1 to 100 pixels thick)
- fix crosshair getting bigger after each session for no reason (very old bug from PCSX2)

<img width="1903" height="1314" alt="image" src="https://github.com/user-attachments/assets/86a47b36-a811-4f2c-a014-f50871a2db0e" />
