### PR TITLE
add YuYu Hakusho (working) and Pride GP (doesn't boot) fighting layouts

### DIFF
--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -353,7 +353,9 @@ static const std::map<std::string, FightingLayout> s_fighting_layouts = {
 	{"NM00048", FightingLayout::STANDARD},   // Fate Unlimited Codes
 	{"NM00027", FightingLayout::TEKKEN},     // Super Dragon Ball Z
 	{"NM00029", FightingLayout::STANDARD},   // Kinnikuman MGP
+	{"NM00035", FightingLayout::STANDARD},   // YuYu Hakusho
 	{"NM00040", FightingLayout::STANDARD},   // Kinnikuman MGP 2
+	{"NM00011", FightingLayout::SIX_BUTTON}, // Pride GP 2003
 	{"NM00018", FightingLayout::SIX_BUTTON}, // Capcom Fighting Jam
 	{"NM00042", FightingLayout::SIX_BUTTON}, // Sengoku Basara X
 };


### PR DESCRIPTION
Kinnikuman MGP (NM00029) HDD works (PLAYABLE)
YuYu Hakusho (NM00035) HDD works (PLAYABLE)
Pride GP 2003 (NM00011)  HDD doesn't boot (BROKEN)
Sengoku Basara X (NM00042) HDD doesn't boot (BROKEN)

However this is needed to be able to play YuYu Hakusho (3 buttons only : Triangle, Square, Cross)