### PR TITLE
Add Tekken 5 games support

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -80,6 +80,8 @@ NM00019:
   name: Tekken 5
   region: System256
   bootprog: TK5LOAD
+  gsHWFixes:
+    alignSprite: 1
 NM00020:
   name: Dragon Chronicle Online - Great Sky Battle
   region: System246

--- a/pcsx2/DEV9/ACATAPI.cpp
+++ b/pcsx2/DEV9/ACATAPI.cpp
@@ -17,6 +17,12 @@ static u32 atapi_pio_pos = 0;
 static u8 atapi_pio_write_buf[65536];
 static u32 atapi_pio_write_len = 0;
 static u32 atapi_pio_write_pos = 0;
+
+// Instant DMA buffer: read sectors into memory immediately instead of deferring to
+// the DMA callback. Avoids a race where SPU2 DMA completes before disc data is ready.
+static u8 atapi_dma_buf[2048 * 128];
+static u32 atapi_dma_len = 0;
+
 static u8 mode_page_01[12] = {};
 static bool mode_page_01_set = false;
 
@@ -51,6 +57,20 @@ static void atapi_complete_nodata() {
     ACATA::R_NSECTOR = 0x03;
     CLRB(ACATA::R_STATUS, ATA_STAT_DRQ);
     CLRB(ACATA::R_STATUS, ATA_STAT_ERR);
+    CLRB(ACATA::R_STATUS, ATA_STAT_BUSY);
+    ACATA::R_STATUS |= ATA_STAT_READY;
+    ACATA::R_LCYL = 0;
+    ACATA::R_HCYL = 0;
+    ACCORE::intr(ACCORE::INTRN_ATA);
+}
+
+// Signal command error: clears transfer state and sets R_NSECTOR=0x03 (I/O=1, C/D=1)
+// to indicate the device is ready for a new command after an error.
+static void atapi_complete_error() {
+    atapi_pio_len = 0;
+    atapi_pio_pos = 0;
+    ACATA::R_NSECTOR = 0x03;
+    CLRB(ACATA::R_STATUS, ATA_STAT_DRQ);
     CLRB(ACATA::R_STATUS, ATA_STAT_BUSY);
     ACATA::R_STATUS |= ATA_STAT_READY;
     ACATA::R_LCYL = 0;
@@ -100,6 +120,15 @@ void ACATAPI::pio_write_word(u16 val) {
 
 bool ACATAPI::has_pio_write() {
     return atapi_pio_write_len > 0 && atapi_pio_write_pos * 2 < atapi_pio_write_len;
+}
+
+bool ACATAPI::dma_read(u32* pMem, int size) {
+    if (atapi_dma_len == 0)
+        return false;
+    u32 copy = std::min(atapi_dma_len, (u32)size);
+    memcpy(pMem, atapi_dma_buf, copy);
+    atapi_dma_len = 0;
+    return true;
 }
 
 void ACATAPI::handle_cmd(atapi_packet_t P) {
@@ -177,21 +206,34 @@ void ACATAPI::handle_cmd(atapi_packet_t P) {
             break;
         }
         if (ACATA_ISDMA) {
-            ACATA::TH::LBA = transf_lba;
-            ACATA::TH::nsector = nsec;
-            ACATA::TH::sectorsize = ACATAPI::CONSTANTS::DVD_SECTORSIZE;
-            ACCORE::DMA::PendTrasnfType = ACCORE::DMA::ATAPI;
-            ACATA::R_NSECTOR = 0x02;
-            CLRB(ACATA::R_STATUS, ATA_STAT_DRQ);
-            CLRB(ACATA::R_STATUS, ATA_STAT_ERR);
-            ACCORE::intr(ACCORE::INTRN_ATA);
+            u32 total = nsec * ACATAPI::CONSTANTS::DVD_SECTORSIZE;
+            bool ok = false;
+            if (total <= sizeof(atapi_dma_buf)) {
+                if (ACATA::TH::isCHD) {
+                    u32 scale = ACATAPI::CONSTANTS::DVD_SECTORSIZE / CHD.GetSectorSize();
+                    ok = CHD.ReadSectors((u64)transf_lba * scale, nsec * scale, atapi_dma_buf);
+                } else {
+                    s64 offset = (s64)transf_lba * ACATAPI::CONSTANTS::DVD_SECTORSIZE;
+                    FileSystem::FSeek64(ACATA::TH::IMAGE, offset, SEEK_SET);
+                    ok = (fread(atapi_dma_buf, 1, total, ACATA::TH::IMAGE) == total);
+                }
+            }
+            if (ok) {
+                atapi_dma_len = total;
+                atapi_complete_nodata();
+            } else {
+                Console.Error("ACATAPI:READ_10 DMA: read failed lba %u, %u sectors", transf_lba, nsec);
+                ACATA::R_STATUS |= ATA_STAT_ERR;
+                ACATA::R_ERROR = ATA_ERR_ABORT;
+                atapi_complete_error();
+            }
         } else {
             u32 total = nsec * ACATAPI::CONSTANTS::DVD_SECTORSIZE;
             if (total > sizeof(atapi_pio_buf)) {
                 Console.Error("ACATAPI:READ_10: transfer too large (%u bytes)", total);
                 ACATA::R_STATUS |= ATA_STAT_ERR;
                 ACATA::R_ERROR = ATA_ERR_ABORT;
-                atapi_complete_nodata();
+                atapi_complete_error();
                 break;
             }
             bool ok = false;
@@ -209,7 +251,7 @@ void ACATAPI::handle_cmd(atapi_packet_t P) {
                 Console.Error("ACATAPI:READ_10: read failed at lba %u, %u sectors", transf_lba, nsec);
                 ACATA::R_STATUS |= ATA_STAT_ERR;
                 ACATA::R_ERROR = ATA_ERR_ABORT;
-                atapi_complete_nodata();
+                atapi_complete_error();
             }
         }
         break;

--- a/pcsx2/DEV9/ACATAPI.h
+++ b/pcsx2/DEV9/ACATAPI.h
@@ -36,6 +36,7 @@ namespace ACATAPI
     bool has_pio_data();
     void pio_write_word(u16 val);
     bool has_pio_write();
+    bool dma_read(u32* pMem, int size);
 
     enum CONSTANTS {
         DVD_SECTORSIZE = 0x800,

--- a/pcsx2/DEV9/ACRAM.cpp
+++ b/pcsx2/DEV9/ACRAM.cpp
@@ -12,6 +12,11 @@
 ACRAM::BankState ACRAM::banks[ACRAM_NUM_BANKS] = {};
 
 u16 ACRAM::Read16(u32 addr) {
+    u32 offset = addr - ACRAM_ADDR_BASE;
+    u32 reg = offset & ACRAM_REG_MASK;
+    // FPGA status registers: TK5DR polls reg 0x00-0x1F during boot, expecting 0x50 (ready).
+    if (reg < 0x20)
+        return 0x50;
     u32 off = GET_RAM_OFF(addr);
     if (off < ACRAM_MAX_SIZE)
         return iopMem->ACRAM[off];

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -1073,16 +1073,21 @@ void DEV9readDMA8Mem(u32* pMem, int size)
 	size >>= 1;
 
 	//DevCon.WriteLn("DEV9: *%s: size %x", __FUNCTION__, size);
-	if (ACCORE::DMA::PendTrasnfType == ACCORE::DMA::ATAPI) {
+	// Instant ATAPI DMA: data was pre-read into a buffer during the ATAPI command.
+	if (ACATAPI::dma_read(pMem, size)) {
+		psxDMA8Interrupt();
+	} else if (ACCORE::DMA::PendTrasnfType == ACCORE::DMA::ATAPI) {
 		ACATA::TH::IO_Read(pMem, size);
 		ACCORE::DMA::PendTrasnfType = ACCORE::DMA::NONE;
 		ACATA::R_STATUS = ATA_STAT_READY;
+		ACATA::R_NSECTOR = 0x03;
 		psxDMA8Interrupt();
 		ACCORE::intr(ACCORE::INTRN_ATA);
 	} else if (ACCORE::DMA::PendTrasnfType == ACCORE::DMA::ATA) {
 		ACATA::TH::IO_Read(pMem, size);
 		ACCORE::DMA::PendTrasnfType = ACCORE::DMA::NONE;
 		ACATA::R_STATUS = ATA_STAT_READY;
+		ACATA::R_NSECTOR = 0x03;
 		psxDMA8Interrupt();
 		ACCORE::intr(ACCORE::INTRN_ATA);
 	} else {
@@ -1093,6 +1098,7 @@ void DEV9readDMA8Mem(u32* pMem, int size)
 			psxDMA8Interrupt();
 		} else {
 			Console.Error("%s: requested DMA transfer of 0x%-8X bytes while no pending transfer (%d)", __FUNCTION__, size, ACCORE::DMA::PendTrasnfType);
+			psxDMA8Interrupt();
 		}
 	}
 
@@ -1121,7 +1127,6 @@ void DEV9readDMA8Mem(u32* pMem, int size)
 void DEV9writeDMA8Mem(u32* pMem, int size)
 {
 	size >>= 1;
-
 	if (ACCORE::DMA::PendTrasnfType == ACCORE::DMA::ATA_WRITE) {
 		ACATA::TH::IO_Write(pMem, size);
 		ACCORE::DMA::PendTrasnfType = ACCORE::DMA::NONE;

--- a/pcsx2/IopBios.cpp
+++ b/pcsx2/IopBios.cpp
@@ -1213,9 +1213,9 @@ namespace R3000A
 			LoadFuncs(a0);
 
 			const std::string modname = iopMemReadString(a0 + 12);
+			const u32 version = iopMemRead32(a0 + 8);
 			if (modname == "thbase")
 			{
-				const u32 version = iopMemRead32(a0 + 8);
 				CurrentBiosInformation.iopThreadListAddr = GetThreadList(a0, version);
 			}
 
@@ -1242,11 +1242,14 @@ namespace R3000A
 
 		int CreateThread_HLE()
 		{
+			u32 priority = iopMemRead32(a0 + 16);
 			if (ACJV::IsSuppressDaemonEnabled())
 			{
-				u32 priority = iopMemRead32(a0 + 16);
 				if (priority >= 126)
+				{
+					Console.WriteLn("IOP: SUPPRESSING thread (pri=%d >= 126)", priority);
 					s_suppress_next_start = true;
+				}
 			}
 			return 0;
 		}
@@ -1305,7 +1308,7 @@ namespace R3000A
 	{
 		void sceSifRegisterRpc_DEBUG()
 		{
-			DevCon.WriteLn(Color_Gray, "sifcmd sceSifRegisterRpc: rpc_id %x", a1);
+			DevCon.WriteLn(Color_Gray, "IOP: sceSifRegisterRpc server_id=%08X", a1);
 		}
 	} // namespace sifcmd
 

--- a/pcsx2/IopMem.cpp
+++ b/pcsx2/IopMem.cpp
@@ -119,6 +119,20 @@ u8 iopMemRead8(u32 mem)
 		}
 	} else if (t == ACSRAM_RANGE) {
 		return ACSRAM::Read16(mem);
+	// Arcade HW 8-bit dispatch: IOP firmware does byte reads on 16-bit MMIO.
+	// Without this, byte reads to ACRAM/ATA/JVS/ACCORE returned 0.
+	} else if ((t & 0xFF00) == ACRAM_RANGE) {
+		u16 val16 = ACRAM::Read16(mem & ~1);
+		return (mem & 1) ? (u8)(val16 >> 8) : (u8)val16;
+	} else if ((t & 0xFF00) == ACATA_RANGE) {
+		u16 val16 = ACATA::read16(mem & ~1);
+		return (mem & 1) ? (u8)(val16 >> 8) : (u8)val16;
+	} else if (t == ACJV_RANGE) {
+		u16 val16 = ACJV::Read16(mem & ~1);
+		return (mem & 1) ? (u8)(val16 >> 8) : (u8)val16;
+	} else if (t == 0x1241) {
+		u16 val16 = ACCORE::Read16(mem & ~1);
+		return (mem & 1) ? (u8)(val16 >> 8) : (u8)val16;
 	} else if (t == 0x1f40) {
 		return psxHw4Read8(mem);
 	}
@@ -304,7 +318,28 @@ void iopMemWrite8(u32 mem, u8 value)
 	else if (t == 0x1f40)
 	{
 		psxHw4Write8(mem, value);
-	
+	}
+	else if ((t & 0xFF00) == ACRAM_RANGE)
+	{
+		u16 cur = ACRAM::Read16(mem & ~1);
+		if (mem & 1) cur = (cur & 0x00FF) | ((u16)value << 8);
+		else         cur = (cur & 0xFF00) | value;
+		ACRAM::Write16(mem & ~1, cur);
+	}
+	else if ((t & 0xFF00) == ACATA_RANGE)
+	{
+		u16 cur = ACATA::read16(mem & ~1);
+		if (mem & 1) cur = (cur & 0x00FF) | ((u16)value << 8);
+		else         cur = (cur & 0xFF00) | value;
+		ACATA::write16(mem & ~1, cur);
+	}
+	else if (t == ACJV_RANGE)
+	{
+		if (ACJV::enabled) ACJV::Write16(mem & ~1, value);
+	}
+	else if (t == 0x1241)
+	{
+		ACCORE::Write16(mem & ~1, value);
 	}
 	else
 	{

--- a/pcsx2/SPU2/Dma.cpp
+++ b/pcsx2/SPU2/Dma.cpp
@@ -8,6 +8,7 @@
 #include "R3000A.h"
 #include "IopHw.h"
 #include "Config.h"
+#include "common/Console.h"
 
 static constexpr int CYCLES_PER_WORD = 24;
 
@@ -214,6 +215,12 @@ void V_Core::PlainDMAWrite(u16* pMem, u32 size)
 		}
 	}
 
+	if (ReadSize > 0)
+	{
+		Console.WriteLn("SPU2 DMA%c WARNING: new DMA while old pending! ReadSize=%x ActiveTSA=%x newTSA=%x newSize=%x",
+			Index ? '7' : '4', ReadSize, ActiveTSA, TSA, size);
+	}
+
 	TimeUpdate(psxRegs.cycle);
 
 	ReadSize = size;
@@ -250,7 +257,10 @@ void V_Core::FinishDMAwrite()
 		DMA7LogWrite(DMAPtr, ReadSize << 1);
 #endif
 
-	u32 buff1end = ActiveTSA + std::min(ReadSize, (u32)0x100 + std::abs(DMAICounter / CYCLES_PER_WORD));
+	// Transfer all data in one shot. The original deferred partial transfer caused a
+	// ~170ms delay on S246/S256 where real hardware completes in <0.1ms, producing
+	// audio corruption during streaming transitions (e.g. TK5DR attract mode).
+	u32 buff1end = ActiveTSA + ReadSize;
 	u32 buff2end = 0;
 	if (buff1end > 0x100000)
 	{
@@ -346,6 +356,10 @@ void V_Core::FinishDMAwrite()
 	ReadSize -= TDA - ActiveTSA;
 
 	DMAICounter = (DMAICounter - ReadSize) * CYCLES_PER_WORD;
+
+	// After a full transfer, don't leave a large stale counter that delays the IRQ.
+	if (ReadSize == 0 && DMAICounter > CYCLES_PER_WORD)
+		DMAICounter = CYCLES_PER_WORD;
 
 	CounterUpdate(DMAICounter);
 


### PR DESCRIPTION
- fix SPU2 DMA timing by writing data instantly instead of deferring to callback, preventing a race where audio DMA completes before disc data is ready. Also add 8-bit IOP memory dispatch and ATAPI error paths.
- add Tekken 5 and 5.1 to AlignSpriteX hack to fix vertical lines when upscaling