### PR TITLE
Add support for Pride GP 2003 and Sengoku Basara X

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -176,7 +176,7 @@ NM00041:
   bootprog: T10LOAD
 NM00042:
   name: Sengoku Basara X
-  region: System256
+  region: System246
   bootprog: BASLOAD
 NM00043:
   name: Mobile Suit Gundam - Gundam vs. Gundam

--- a/pcsx2/DEV9/ACATAPI.cpp
+++ b/pcsx2/DEV9/ACATAPI.cpp
@@ -271,8 +271,19 @@ void ACATAPI::handle_cmd(atapi_packet_t P) {
         atapi_complete_nodata();
         break;
 
+    case ATAPICMD::SET_STREAMING: {
+        u16 param_len = (P.raw8[9] << 8) | P.raw8[10];
+        if (param_len > 0) {
+            atapi_pio_write_setup(param_len);
+        } else {
+            atapi_complete_nodata();
+        }
+        break;
+    }
+
     default:
         Console.Error("ACATAPI: UNK_CMD %02X, lba:%08X, nsec:%04X", P.raw8[0], transf_lba, nsec);
+        atapi_complete_nodata();
         break;
     }
 }

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -355,9 +355,9 @@ static const std::map<std::string, FightingLayout> s_fighting_layouts = {
 	{"NM00029", FightingLayout::STANDARD},   // Kinnikuman MGP
 	{"NM00035", FightingLayout::STANDARD},   // YuYu Hakusho
 	{"NM00040", FightingLayout::STANDARD},   // Kinnikuman MGP 2
-	{"NM00011", FightingLayout::SIX_BUTTON}, // Pride GP 2003
+	{"NM00011", FightingLayout::STANDARD},   // Pride GP 2003
 	{"NM00018", FightingLayout::SIX_BUTTON}, // Capcom Fighting Jam
-	{"NM00042", FightingLayout::SIX_BUTTON}, // Sengoku Basara X
+	{"NM00042", FightingLayout::STANDARD},   // Sengoku Basara X
 };
 
 // Gamepad input -> JVS button state: set or clear a button bit for a player


### PR DESCRIPTION
- Handle SET_STREAMING (0xB6) ATAPI command and complete unknown commands instead of hanging (needed to boot Pride GP 2003).
- Fix Basara X fighting layout (4-button) and GameIndex region (game is 246, NOT 256).

Both are DVD. Promote to working.