### PR TITLE
Gamelist: only list ELF and ACGAME files

### DIFF
--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -234,7 +234,9 @@ const char* GameList::EntryCompatibilityRatingToString(CompatibilityRating ratin
 
 bool GameList::IsScannableFilename(const std::string_view path)
 {
-	return VMManager::IsDiscFileName(path) || VMManager::IsElfFileName(path) || VMManager::isArcadeManifest(path);
+	return // VMManager::IsDiscFileName(path) || 
+		VMManager::IsElfFileName(path) || 
+		VMManager::isArcadeManifest(path);
 }
 
 void GameList::FillBootParametersForEntry(VMBootParameters* params, const Entry* entry)


### PR DESCRIPTION
avoids emulator picking up media images from games (eg: game.iso, sram.bin and whatever)

### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation as to how you used it. Please see the Large Language Model (LLM) Usage Policy for more information: https://pcsx2.net/docs/contributing/#large-language-model-llm-usage-policy -->