### PR TITLE
Fix ACRAM pointer decoding and all fighting game layouts; Bloody Roar 3 now playable

### DIFF
--- a/pcsx2/DEV9/ACATAPI.cpp
+++ b/pcsx2/DEV9/ACATAPI.cpp
@@ -196,7 +196,10 @@ void ACATAPI::handle_cmd(atapi_packet_t P) {
     case ATAPICMD::READ_10: {
         if ((!ACATA::TH::IMAGE && !ACATA::TH::isCHD) || nsec == 0) {
             if (nsec == 0) {
-                Console.Warning("ACATAPI:READ_10: zero sectors requested (LBA:%X)", transf_lba);
+                // Not an error per the ATAPI spec; CD games spam it while streaming, so log only the first few.
+                static int nsec0_count = 0;
+                if (nsec0_count++ < 3)
+                    Console.Warning("ACATAPI:READ_10: zero sectors requested (LBA:%X)", transf_lba);
             } else {
                 Console.Error("ACATAPI:READ_10: no image open");
                 ACATA::R_STATUS |= ATA_STAT_ERR;

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -109,30 +109,35 @@ static constexpr const std::array<InputBindingInfo, 12> s_jvs_p2_button_bindings
 	{"P2_Service", TRANSLATE_NOOP("JVS", "P2 Service"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_SERVICE, GenericInputBinding::Select},
 }};
 
-// Per-layout face button GenericInputBinding overrides (BTN3-6 only).
-// BTN1=Square, BTN2=Triangle are universal. Indexed by FightingLayout enum value.
-static constexpr GenericInputBinding s_fighting_face_buttons[][4] = {
-	// BTN3,                        BTN4,                       BTN5,                       BTN6
-	{GenericInputBinding::Unknown, GenericInputBinding::Cross,  GenericInputBinding::Circle, GenericInputBinding::Unknown}, // TEKKEN
-	{GenericInputBinding::Cross,   GenericInputBinding::Circle, GenericInputBinding::Unknown,GenericInputBinding::Unknown}, // STANDARD
-	{GenericInputBinding::L1,      GenericInputBinding::Cross,  GenericInputBinding::Circle, GenericInputBinding::R1},      // SIX_BUTTON
+// Per-layout face button default inputs (BTN1-6), mirroring each game's
+// official PS2 port pad. Some games share the same layout. Rows follow FightingLayout order.
+static constexpr GenericInputBinding s_fighting_face_buttons[][6] = {
+	// BTN1,                       BTN2,                          BTN3,                         BTN4,                          BTN5,                         BTN6
+	{GenericInputBinding::Square, GenericInputBinding::Triangle, GenericInputBinding::Unknown, GenericInputBinding::Cross,    GenericInputBinding::Circle,  GenericInputBinding::Unknown}, // TEKKEN
+	{GenericInputBinding::Square, GenericInputBinding::Triangle, GenericInputBinding::Cross,   GenericInputBinding::Circle,   GenericInputBinding::Unknown, GenericInputBinding::Unknown}, // YUYU
+	{GenericInputBinding::Square, GenericInputBinding::Triangle, GenericInputBinding::L1,      GenericInputBinding::Cross,    GenericInputBinding::Circle,  GenericInputBinding::R1},      // SIX_BUTTON
+	{GenericInputBinding::Square, GenericInputBinding::Triangle, GenericInputBinding::Circle,  GenericInputBinding::Cross,    GenericInputBinding::Unknown, GenericInputBinding::Unknown}, // SOULCAL
+	{GenericInputBinding::Square, GenericInputBinding::Cross,    GenericInputBinding::Circle,  GenericInputBinding::Triangle, GenericInputBinding::Unknown, GenericInputBinding::Unknown}, // BLOODYROAR
 };
 
 static std::array<InputBindingInfo, 12> s_active_p1_bindings;
 static std::array<InputBindingInfo, 12> s_active_p2_bindings;
 
-// Copy base P1/P2 tables, select BTN3-6 face buttons from the layout.
-// Table indices: [0-3]=dpad, [4]=BTN1, [5]=BTN2, [6]=BTN3, [7]=BTN4, [8]=BTN5, [9]=BTN6, [10]=start, [11]=service
+// Copy the base P1/P2 tables, then set the default pad button of BTN1-6 from
+// the game's layout row. Binding table indices:
+//   [0]=Up    [1]=Down  [2]=Left   [3]=Right
+//   [4]=BTN1  [5]=BTN2  [6]=BTN3   [7]=BTN4
+//   [8]=BTN5  [9]=BTN6  [10]=Start [11]=Service
 static void UpdateFightingBindings(FightingLayout layout)
 {
 	s_active_p1_bindings = s_jvs_p1_button_bindings;
 	s_active_p2_bindings = s_jvs_p2_button_bindings;
 	const auto& face = s_fighting_face_buttons[static_cast<int>(layout)];
-	constexpr int BTN3_INDEX = 6;
-	for (int i = 0; i < 4; i++)
+	constexpr int BTN1_INDEX = 4;
+	for (int i = 0; i < 6; i++)
 	{
-		s_active_p1_bindings[BTN3_INDEX + i].generic_mapping = face[i];
-		s_active_p2_bindings[BTN3_INDEX + i].generic_mapping = face[i];
+		s_active_p1_bindings[BTN1_INDEX + i].generic_mapping = face[i];
+		s_active_p2_bindings[BTN1_INDEX + i].generic_mapping = face[i];
 	}
 }
 
@@ -347,17 +352,17 @@ static const std::map<std::string, FightingLayout> s_fighting_layouts = {
 	{"NM00004", FightingLayout::TEKKEN},     // Tekken 4
 	{"NM00019", FightingLayout::TEKKEN},     // Tekken 5 / 5.1
 	{"NM00026", FightingLayout::TEKKEN},     // Tekken 5 DR
-	{"NM00007", FightingLayout::STANDARD},   // Soul Calibur II
-	{"NM00031", FightingLayout::STANDARD},   // Soul Calibur III
-	{"NM00002", FightingLayout::STANDARD},   // Bloody Roar 3
-	{"NM00048", FightingLayout::STANDARD},   // Fate Unlimited Codes
+	{"NM00007", FightingLayout::SOULCAL},    // Soul Calibur II
+	{"NM00031", FightingLayout::SOULCAL},    // Soul Calibur III
+	{"NM00002", FightingLayout::BLOODYROAR}, // Bloody Roar 3
+	{"NM00048", FightingLayout::SOULCAL},    // Fate Unlimited Codes
 	{"NM00027", FightingLayout::TEKKEN},     // Super Dragon Ball Z
-	{"NM00029", FightingLayout::STANDARD},   // Kinnikuman MGP
-	{"NM00035", FightingLayout::STANDARD},   // YuYu Hakusho
-	{"NM00040", FightingLayout::STANDARD},   // Kinnikuman MGP 2
-	{"NM00011", FightingLayout::STANDARD},   // Pride GP 2003
+	{"NM00029", FightingLayout::SOULCAL},    // Kinnikuman MGP
+	{"NM00035", FightingLayout::YUYU},       // YuYu Hakusho
+	{"NM00040", FightingLayout::SOULCAL},    // Kinnikuman MGP 2
+	{"NM00011", FightingLayout::TEKKEN},     // Pride GP 2003
 	{"NM00018", FightingLayout::SIX_BUTTON}, // Capcom Fighting Jam
-	{"NM00042", FightingLayout::STANDARD},   // Sengoku Basara X
+	{"NM00042", FightingLayout::SOULCAL},    // Sengoku Basara X
 };
 
 // Gamepad input -> JVS button state: set or clear a button bit for a player
@@ -444,7 +449,7 @@ void ACJV::SetGameId(const std::string& gameid)
 	auto fit = s_fighting_layouts.find(gameid);
 	if (fit != s_fighting_layouts.end())
 	{
-		constexpr const char* layout_names[] = {"tekken", "standard", "6-button"};
+		constexpr const char* layout_names[] = {"tekken", "yuyu", "6-button", "soulcalibur", "bloodyroar"};
 		Console.WriteLn("ACJV: fighting layout for %s: %s", gameid.c_str(), layout_names[static_cast<int>(fit->second)]);
 		UpdateFightingBindings(fit->second);
 	}

--- a/pcsx2/DEV9/ACJV.h
+++ b/pcsx2/DEV9/ACJV.h
@@ -44,10 +44,13 @@ enum class JVS_MODE {
 	TOUCH,
 };
 
+// Sw -> pad order per layout, mirroring each game's official PS2 port.
 enum class FightingLayout {
-	TEKKEN,     // Sw1,2,4,5 (skip Sw3) — TK4, TK5, TK5DR
-	STANDARD,   // Sw1,2,3,4 (sequential) — SC2, SC3, BRT, FUD, KN
-	SIX_BUTTON, // Sw1-6 — JAM, BAX
+	TEKKEN,     // Sw1,2,4,5: Square, Triangle, Cross, Circle         — TK4, TK5, TK5DR, SDBZ, PrideGP
+	YUYU,       // Sw1,2,3,4: Square, Triangle, Cross, Circle         — YuYu
+	SIX_BUTTON, // Sw1-6:     Square, Triangle, L1, Cross, Circle, R1 — JAM
+	SOULCAL,    // Sw1,2,3,4: Square, Triangle, Circle, Cross         — SC2, SC3, KN1, KN2, BAX, FUD
+	BLOODYROAR, // Sw1,2,3,4: Square, Cross, Circle, Triangle         — BR3
 };
 
 #define JVS_WHEEL_CHANNEL_MAX 3

--- a/pcsx2/DEV9/ACRAM.cpp
+++ b/pcsx2/DEV9/ACRAM.cpp
@@ -34,13 +34,20 @@ void ACRAM::Write16(u32 addr, u16 val) {
     u32 bank_base = bank * ACRAM_BANK_SIZE;
 
     if (reg >= ACRAM_REG_READ && reg < ACRAM_REG_WRITE) {
-        banks[bank].read_addr = bank_base + ((u32)val << 11); // val is a page number, <<11 = 2KB granularity
+        // One register write carries a full address, split in two:
+        //   address = (value << 11) + (register offset & 0x7FC)
+        // The value picks the 2KB page, the register offset picks the spot
+        // inside that page (that's how the driver works — ps2sdk acram ram.c).
+        // Ignore the offset and every address lands at the start of a page.
+        banks[bank].read_addr = bank_base + ((u32)val << 11) + (reg & 0x7FC);
         return;
     } else if (reg >= ACRAM_REG_WRITE && reg < 0x80000) {
-        banks[bank].write_addr = bank_base + ((u32)val << 11);
+        banks[bank].write_addr = bank_base + ((u32)val << 11) + (reg & 0x7FC);
         return;
     } else if (reg >= 0x20000 && reg < ACRAM_REG_READ) {
-        return; // size/config registers — control only, don't touch SDRAM
+        // Size/config registers: control only, nothing to store — the actual
+        // transfer size comes from the DMA8 BCR.
+        return;
     }
 
     u32 off = GET_RAM_OFF(addr);

--- a/pcsx2/IopDma.cpp
+++ b/pcsx2/IopDma.cpp
@@ -84,6 +84,10 @@ void spu2DMA4Irq()
 void psxDma7(u32 madr, u32 bcr, u32 chcr) // SPU2's Core 1
 {
 	psxDmaGeneric(madr, bcr, chcr, 1);
+	// AC sound modules (BR3, TK5DR) poll the transfer status right after the kick,
+	// so complete it now instead of on the slow deferred schedule.
+	spu2DMA7Irq();
+	SPU2finishDMA7();
 }
 
 int psxDma7Interrupt()

--- a/pcsx2/SPU2/Dma.cpp
+++ b/pcsx2/SPU2/Dma.cpp
@@ -154,6 +154,7 @@ void V_Core::StartADMAWrite(u16* pMem, u32 sz)
 	int size = sz;
 
 	TimeUpdate(psxRegs.cycle);
+	DMATransferComplete = false;
 
 	if (SPU2::MsgAutoDMA())
 	{
@@ -225,6 +226,7 @@ void V_Core::PlainDMAWrite(u16* pMem, u32 size)
 
 	ReadSize = size;
 	IsDMARead = false;
+	DMATransferComplete = false;
 	DMAICounter = 0;
 	LastClock = psxRegs.cycle;
 	Regs.STATX &= ~0x80;
@@ -366,6 +368,9 @@ void V_Core::FinishDMAwrite()
 	ActiveTSA = TDA;
 	ActiveTSA &= 0xfffff;
 	TSA = ActiveTSA;
+
+	if (ReadSize == 0)
+		DMATransferComplete = true;
 }
 
 void V_Core::FinishDMAread()
@@ -451,6 +456,9 @@ void V_Core::FinishDMAread()
 	ActiveTSA = TDA;
 	ActiveTSA &= 0xfffff;
 	TSA = ActiveTSA;
+
+	if (!ReadSize)
+		DMATransferComplete = true;
 }
 
 void V_Core::DoDMAread(u16* pMem, u32 size)
@@ -461,6 +469,7 @@ void V_Core::DoDMAread(u16* pMem, u32 size)
 	ActiveTSA = TSA & 0xfffff;
 	ReadSize = size;
 	IsDMARead = true;
+	DMATransferComplete = false;
 	LastClock = psxRegs.cycle;
 	DMAICounter = (std::min(ReadSize, (u32)0x100) * CYCLES_PER_WORD);
 	Regs.STATX &= ~0x80;
@@ -516,7 +525,5 @@ void V_Core::DoDMAwrite(u16* pMem, u32 size)
 	else
 	{
 		PlainDMAWrite(pMem, size);
-		Regs.STATX &= ~0x80;
-		Regs.STATX |= 0x400;
 	}
 }

--- a/pcsx2/SPU2/defs.h
+++ b/pcsx2/SPU2/defs.h
@@ -470,6 +470,7 @@ struct V_Core
 	u16* DMARPtr; // Mem pointer for DMA Reads
 	u32 ReadSize;
 	bool IsDMARead;
+	bool DMATransferComplete; // set when a DMA finishes, reported once on the next STATX read
 
 	u32 KeyOn;
 	u32 KeyOff;

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -69,17 +69,21 @@ void SPU2writeDMA4Mem(u16* pMem, u32 size) // size now in 16bit units
 void SPU2interruptDMA4()
 {
 	SPU2::FileLog("[%10d] SPU2 interruptDMA4\n", Cycles);
-	if (Cores[0].DmaMode)
-		Cores[0].Regs.STATX |= 0x80;
 	Cores[0].Regs.STATX &= ~0x400;
 	Cores[0].TSA = Cores[0].ActiveTSA;
+}
+
+// After an instant DMA7 completion, cancel the scheduled deferred one so it can't
+// fire late on the next transfer (that breaks TK4's back-to-back boot streams).
+void SPU2finishDMA7()
+{
+	if (Cores[1].DMATransferComplete)
+		Cores[1].DMAICounter = 0;
 }
 
 void SPU2interruptDMA7()
 {
 	SPU2::FileLog("[%10d] SPU2 interruptDMA7\n", Cycles);
-	if (Cores[1].DmaMode)
-		Cores[1].Regs.STATX |= 0x80;
 	Cores[1].Regs.STATX &= ~0x400;
 	Cores[1].TSA = Cores[1].ActiveTSA;
 }
@@ -426,6 +430,13 @@ u16 SPU2read(u32 rmem)
 			//FileLog("[%10d] SPU2 read mem %x (core %d, register %x): %x\n",Cycles, mem, core, (omem & 0x7ff), ret);
 			SPU2::WriteRegLog("read", rmem, ret);
 #endif
+		}
+
+		if ((omem & 0x3FF) == 0x344 && Cores[core].DMATransferComplete)
+		{
+			ret &= ~0x80;
+			Cores[core].Regs.STATX |= 0x80;
+			Cores[core].DMATransferComplete = false;
 		}
 	}
 

--- a/pcsx2/SPU2/spu2.h
+++ b/pcsx2/SPU2/spu2.h
@@ -75,6 +75,7 @@ void SPU2readDMA4Mem(u16* pMem, u32 size);
 void SPU2writeDMA4Mem(u16* pMem, u32 size);
 void SPU2interruptDMA4();
 void SPU2interruptDMA7();
+void SPU2finishDMA7();
 void SPU2readDMA7Mem(u16* pMem, u32 size);
 void SPU2writeDMA7Mem(u16* pMem, u32 size);
 

--- a/pcsx2/SPU2/spu2sys.cpp
+++ b/pcsx2/SPU2/spu2sys.cpp
@@ -196,6 +196,7 @@ void V_Core::Init(int index)
 
 	DMAICounter = 0;
 	AdmaInProgress = false;
+	DMATransferComplete = false;
 
 	Regs.STATX = 0x80;
 	Regs.ENDX = 0xffffff; // PS2 confirmed
@@ -1017,7 +1018,6 @@ static void RegWrite_Core(u16 value)
 			bool irqe = thiscore.IRQEnable;
 			int bit0 = thiscore.AttrBit0;
 			bool oldFXenable = thiscore.FxEnable;
-			u8 oldDmaMode = thiscore.DmaMode;
 
 			thiscore.AttrBit0 = (value >> 0) & 0x01;  //1 bit
 			thiscore.DMABits = (value >> 1) & 0x07;   //3 bits
@@ -1037,10 +1037,12 @@ static void RegWrite_Core(u16 value)
 					thiscore.AnalyzeReverbPreset();
 			}
 
-			if (!thiscore.DmaMode && !(thiscore.Regs.STATX & 0x400))
+			// DMA mode switched off: drop stale status and abandon any unfinished transfer
+			if (!thiscore.DmaMode)
+			{
 				thiscore.Regs.STATX &= ~0x80;
-			else if (!oldDmaMode && thiscore.DmaMode)
-				thiscore.Regs.STATX |= 0x80;
+				thiscore.ReadSize = 0;
+			}
 
 			thiscore.ActiveTSA = thiscore.TSA;
 

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1401,6 +1401,11 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 					Error::SetString(error, std::string("cannot open arcade media image"));
 					return false;
 				}
+				if (s_acmedia == "CD" && !ACATA::imgpath.empty()) {
+					CDVDsys_SetFile(CDVD_SourceType::Iso, ACATA::imgpath);
+					CDVDsys_ChangeSource(CDVD_SourceType::Iso);
+					Console.WriteLn(Color_Green, "ACGAME: CD media, also loading into CDVD subsystem");
+				}
 				Console.WriteLnFmt(Color_Green, "ACGAME: elf:'{}'", s_elf_override);
 				Console.WriteLnFmt(Color_Green, "ACGAME: sram:'{}'", ACSRAM::filepath);
 				Console.WriteLnFmt(Color_Green, "ACGAME: media:'{}'", ACATA::imgpath);


### PR DESCRIPTION
- Add and correct all remaining fighting game button layouts
- Promote `Bloody Roar 3` to playable (ACRAM pointer decoding + CDVD init fixes)
- Replace the old DmaMode DMA-completion workaround with a per-transfer `DMATransferComplete` flag, mimicking real hardware (no regression detected)