### PR TITLE
Add FightingLayout NM00017 and NM00052

### DIFF
--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -358,6 +358,8 @@ static const std::map<std::string, FightingLayout> s_fighting_layouts = {
 	{"NM00011", FightingLayout::STANDARD},   // Pride GP 2003
 	{"NM00018", FightingLayout::SIX_BUTTON}, // Capcom Fighting Jam
 	{"NM00042", FightingLayout::STANDARD},   // Sengoku Basara X
+	{"NM00017", FightingLayout::STANDARD},   // Mobile Suit Gundam Zeta - A.E.U.G. vs. Titans DX
+	{"NM00052", FightingLayout::STANDARD},   // Mobile Suit Gundam - Gundam vs. Gundam NEXT
 };
 
 // Gamepad input -> JVS button state: set or clear a button bit for a player


### PR DESCRIPTION
### Description of Changes
I have added the following two Gundam titles to the fighting game button layout configuration:
* NM00017 Mobile Suit Gundam Zeta - A.E.U.G. vs. Titans DX
* NM00052 Mobile Suit Gundam - Gundam vs. Gundam NEXT

### Rationale behind Changes
Without this configuration, Button 3 is completely unresponsive, making these games unplayable. This PR ensures all necessary buttons are mapped correctly for a proper gameplay experience.

### Suggested Testing Steps
1. Boot either of the added titles (NM00017 or NM00052).
2. Enter the game's internal Test Mode and open the Input Test screen.
3. Verify that Button 3 now registers correctly (it was non-functional prior to this change).

### Notes
Gundam titles on the SYSTEM2x5 system likely run using the standard configuration as well. However, since I do not own those hardware/discs to personally test them, I have only added the specific titles I successfully verified.

### Did you use AI to help find, test, or implement this issue or feature?
No.