### PR TITLE
Reset cached ATAPI mode page on shutdown

### DIFF
--- a/pcsx2/DEV9/ACATAPI.cpp
+++ b/pcsx2/DEV9/ACATAPI.cpp
@@ -26,6 +26,8 @@ static u32 atapi_dma_len = 0;
 static u8 mode_page_01[12] = {};
 static bool mode_page_01_set = false;
 
+void ACATAPI::Reset() { mode_page_01_set = false; }
+
 static void atapi_pio_write_setup(u32 len) {
     atapi_pio_write_len = len;
     atapi_pio_write_pos = 0;

--- a/pcsx2/DEV9/ACATAPI.h
+++ b/pcsx2/DEV9/ACATAPI.h
@@ -31,6 +31,7 @@ typedef union {
 namespace ACATAPI
 {
     void handle_cmd(atapi_packet_t P);
+    void Reset();
     void Setup(); // change ACATA stuff to handle CDROM instead of HDD
     u16 pio_read_word();
     bool has_pio_data();

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -83,6 +83,7 @@
 #include "common/ARCADE.h"
 
 #include "DEV9/ACATA.h"
+#include "DEV9/ACATAPI.h"
 #include "DEV9/ACJV.h"
 #include "DEV9/ACSRAM.h"
 
@@ -1864,6 +1865,9 @@ void VMManager::Shutdown(bool save_resume_state)
 	FWclose();
 	FileMcd_EmuClose();
 	ACATA::TH::IO_CloseImage();
+
+	// drop the previous game's cached ATAPI mode page so a game switch gets a fresh MODE_SENSE
+	ACATAPI::Reset();
 
 	// If the fullscreen UI is running, do a hardware reset on the GS
 	// so that the texture cache and targets are all cleared.


### PR DESCRIPTION
A CD game's MODE_SELECT page 01 was cached and replayed to the next game loaded in the same process, hanging its boot. Clear it on shutdown. Allowing switching game without exiting PCSX2X6.

Tested on BR3 -> TK4 and VPN -> TK4.