### PR TITLE
Fix Bloody Roar 3 boot

### DIFF
--- a/pcsx2/DEV9/ACATAPI.cpp
+++ b/pcsx2/DEV9/ACATAPI.cpp
@@ -198,7 +198,10 @@ void ACATAPI::handle_cmd(atapi_packet_t P) {
     case ATAPICMD::READ_10: {
         if ((!ACATA::TH::IMAGE && !ACATA::TH::isCHD) || nsec == 0) {
             if (nsec == 0) {
-                Console.Warning("ACATAPI:READ_10: zero sectors requested (LBA:%X)", transf_lba);
+                // Not an error per the ATAPI spec; CD games spam it while streaming, so log only the first few.
+                static int nsec0_count = 0;
+                if (nsec0_count++ < 3)
+                    Console.Warning("ACATAPI:READ_10: zero sectors requested (LBA:%X)", transf_lba);
             } else {
                 Console.Error("ACATAPI:READ_10: no image open");
                 ACATA::R_STATUS |= ATA_STAT_ERR;

--- a/pcsx2/DEV9/ACRAM.cpp
+++ b/pcsx2/DEV9/ACRAM.cpp
@@ -34,13 +34,19 @@ void ACRAM::Write16(u32 addr, u16 val) {
     u32 bank_base = bank * ACRAM_BANK_SIZE;
 
     if (reg >= ACRAM_REG_READ && reg < ACRAM_REG_WRITE) {
-        banks[bank].read_addr = bank_base + ((u32)val << 11); // val is a page number, <<11 = 2KB granularity
+        // One register write carries a full address, split in two:
+        //   address = (value << 11) + (register offset & 0x7FC)
+        // The value picks the 2KB page, the register offset picks the spot
+        // inside that page (that's how the driver works — ps2sdk acram ram.c).
+        banks[bank].read_addr = bank_base + ((u32)val << 11) + (reg & 0x7FC);
         return;
     } else if (reg >= ACRAM_REG_WRITE && reg < 0x80000) {
-        banks[bank].write_addr = bank_base + ((u32)val << 11);
+        banks[bank].write_addr = bank_base + ((u32)val << 11) + (reg & 0x7FC);
         return;
     } else if (reg >= 0x20000 && reg < ACRAM_REG_READ) {
-        return; // size/config registers — control only, don't touch SDRAM
+        // Size/config registers: control only, nothing to store — the actual
+        // transfer size comes from the DMA8 BCR.
+        return;
     }
 
     u32 off = GET_RAM_OFF(addr);

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1402,6 +1402,11 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 					Error::SetString(error, std::string("cannot open arcade media image"));
 					return false;
 				}
+				if (s_acmedia == "CD" && !ACATA::imgpath.empty()) {
+					CDVDsys_SetFile(CDVD_SourceType::Iso, ACATA::imgpath);
+					CDVDsys_ChangeSource(CDVD_SourceType::Iso);
+					Console.WriteLn(Color_Green, "ACGAME: CD media, also loading into CDVD subsystem");
+				}
 				Console.WriteLnFmt(Color_Green, "ACGAME: elf:'{}'", s_elf_override);
 				Console.WriteLnFmt(Color_Green, "ACGAME: sram:'{}'", ACSRAM::filepath);
 				Console.WriteLnFmt(Color_Green, "ACGAME: media:'{}'", ACATA::imgpath);


### PR DESCRIPTION
Promote `Bloody Roar 3` to playable (ACRAM pointer decoding + CDVD init fixes). 

Two blockers fixed:

First: ELF game calls for sceCdDiskReady(0) (this is the CD LOCATION SETUP freeze). We add an answer.
Second: Sound bank was uploading data at the wrong place (the SETUP SOUND MODULE freeze).