### PR TITLE
Add native bezel support

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -41,6 +41,8 @@
 #include "pcsx2/SaveState.h"
 #include "pcsx2/SIO/Sio.h"
 #include "pcsx2/GS/GSExtra.h"
+#include "pcsx2/INISettingsInterface.h"
+#include "pcsx2/VMManager.h"
 
 #include "common/Assertions.h"
 #include "common/CocoaTools.h"
@@ -1588,6 +1590,12 @@ void MainWindow::onGameListEntryContextMenuRequested(const QPoint& point)
 		action = menu.addAction(tr("Set Cover Image..."));
 		connect(action, &QAction::triggered, [this, entry]() { setGameListEntryCoverImage(*entry); });
 
+		action = menu.addAction(tr("Set Bezel Image..."));
+		connect(action, &QAction::triggered, [this, entry]() { setGameListEntryBezelImage(*entry); });
+
+		action = menu.addAction(tr("Clear Bezel Image"));
+		connect(action, &QAction::triggered, [this, entry]() { clearGameListEntryBezelImage(*entry); });
+
 #if !defined(__APPLE__)
 		connect(menu.addAction(tr("Create Game Shortcut...")), &QAction::triggered, [this]() { MainWindow::onCreateGameShortcutTriggered(); });
 #endif
@@ -3119,6 +3127,51 @@ void MainWindow::setGameListEntryCoverImage(const GameList::Entry& entry)
 	}
 
 	m_game_list_widget->refreshGridCovers();
+}
+
+void MainWindow::setGameListEntryBezelImage(const GameList::Entry& entry)
+{
+	const QString filename = QDir::toNativeSeparators(QFileDialog::getOpenFileName(
+		this, tr("Select Bezel Image"), QString(), tr("Image Files (*.png *.jpg *.jpeg *.webp *.bmp)")));
+
+	if (filename.isEmpty())
+		return;
+
+	std::string_view game_serial;
+	if (entry.type != GameList::EntryType::ELF)
+		game_serial = entry.serial;
+
+	const std::string settings_path = VMManager::GetGameSettingsPath(game_serial, entry.crc);
+
+	INISettingsInterface sif(settings_path);
+	if (FileSystem::FileExists(sif.GetFileName().c_str()))
+		sif.Load();
+
+	const QByteArray utf8 = filename.toUtf8();
+	sif.SetStringValue("EmuCore/GS", "BezelPath", utf8.constData());
+	sif.SetBoolValue("EmuCore/GS", "BezelEnabled", true);
+	sif.Save();
+
+	g_emu_thread->reloadGameSettings();
+}
+
+void MainWindow::clearGameListEntryBezelImage(const GameList::Entry& entry)
+{
+	std::string_view game_serial;
+	if (entry.type != GameList::EntryType::ELF)
+		game_serial = entry.serial;
+
+	const std::string settings_path = VMManager::GetGameSettingsPath(game_serial, entry.crc);
+
+	INISettingsInterface sif(settings_path);
+	if (FileSystem::FileExists(sif.GetFileName().c_str()))
+		sif.Load();
+
+	sif.DeleteValue("EmuCore/GS", "BezelPath");
+	sif.DeleteValue("EmuCore/GS", "BezelEnabled");
+	sif.Save();
+
+	g_emu_thread->reloadGameSettings();
 }
 
 void MainWindow::clearGameListEntryPlayTime(const GameList::Entry& entry, const time_t entry_played_time)

--- a/pcsx2-qt/MainWindow.h
+++ b/pcsx2-qt/MainWindow.h
@@ -146,6 +146,8 @@ private Q_SLOTS:
 	void onGameListSelectionChanged();
 	void onGameListEntryActivated();
 	void onGameListEntryContextMenuRequested(const QPoint& point);
+	void setGameListEntryBezelImage(const GameList::Entry& entry);
+	void clearGameListEntryBezelImage(const GameList::Entry& entry);
 
 	void onStartFileActionTriggered();
 	void onStartDiscActionTriggered();

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -241,6 +241,15 @@ enum class FMVAspectRatioSwitchType : u8
 	MaxCount
 };
 
+enum class GSBezelFitMode : u8
+{
+	Fit,
+	Fill,
+	Stretch,
+	Center,
+	MaxCount
+};
+
 enum class MemoryCardType
 {
 	Empty,
@@ -701,6 +710,7 @@ struct Pcsx2Config
 	{
 		static const char* AspectRatioNames[];
 		static const char* FMVAspectRatioSwitchNames[];
+		static const char* BezelFitModeNames[];
 		static const char* BlendingLevelNames[];
 		static const char* CaptureContainers[];
 
@@ -852,6 +862,14 @@ struct Pcsx2Config
 
 		float StretchY = 100.0f;
 		int Crop[4] = {};
+
+		bool BezelEnabled = false;
+		std::string BezelPath;
+		float BezelOpacity = 1.0f;
+		float BezelScale = 100.0f;
+		GSBezelFitMode BezelFitMode = GSBezelFitMode::Fit;
+		bool BezelShowInFullscreen = true;
+		bool BezelShowInBigPicture = true;
 
 		float OsdScale = DEFAULT_OSD_SCALE;
 		float OsdMargin = DEFAULT_OSD_MARGIN;

--- a/pcsx2/GS/GS.cpp
+++ b/pcsx2/GS/GS.cpp
@@ -104,6 +104,23 @@ static RenderAPI GetAPIForRenderer(GSRendererType renderer)
 	}
 }
 
+static ImGuiManager::BezelFitMode ConvertBezelFitMode(GSBezelFitMode mode)
+{
+	switch (mode)
+	{
+		case GSBezelFitMode::Fit:
+			return ImGuiManager::BezelFitMode::Contain;
+
+		case GSBezelFitMode::Fill:
+			return ImGuiManager::BezelFitMode::Cover;
+
+		case GSBezelFitMode::Center:
+		case GSBezelFitMode::Stretch:
+		default:
+			return ImGuiManager::BezelFitMode::Stretch;
+	}
+}
+
 static bool OpenGSDevice(GSRendererType renderer, bool clear_state_on_fail, bool recreate_window,
 	GSVSyncMode vsync_mode, bool allow_present_throttle)
 {
@@ -348,6 +365,13 @@ bool GSopen(const Pcsx2Config::GSOptions& config, GSRendererType renderer, u8* b
 	bool res = OpenGSDevice(renderer, true, false, vsync_mode, allow_present_throttle);
 	if (res)
 	{
+		ImGuiManager::SetBezelOverlay(
+			GSConfig.BezelEnabled,
+			GSConfig.BezelPath,
+			GSConfig.BezelOpacity,
+			GSConfig.BezelScale,
+			ConvertBezelFitMode(GSConfig.BezelFitMode));
+
 		res = OpenGSRenderer(renderer, basemem);
 		if (!res)
 			CloseGSDevice(true);
@@ -806,6 +830,21 @@ void GSUpdateConfig(const Pcsx2Config::GSOptions& new_config)
 
 	if (new_config.OsdFontPath != old_config.OsdFontPath)
 		ImGuiManager::ReloadFonts();
+
+		if (
+		new_config.BezelEnabled != old_config.BezelEnabled ||
+		new_config.BezelPath != old_config.BezelPath ||
+		new_config.BezelOpacity != old_config.BezelOpacity ||
+		new_config.BezelScale != old_config.BezelScale ||
+		new_config.BezelFitMode != old_config.BezelFitMode)
+	{
+		ImGuiManager::SetBezelOverlay(
+			new_config.BezelEnabled,
+			new_config.BezelPath,
+			new_config.BezelOpacity,
+			new_config.BezelScale,
+			ConvertBezelFitMode(new_config.BezelFitMode));
+	}
 
 	// Options which need a full teardown/recreate.
 	if (!GSConfig.RestartOptionsAreEqual(old_config))

--- a/pcsx2/Host.h
+++ b/pcsx2/Host.h
@@ -81,6 +81,9 @@ namespace Host
 	/// Requests a specific display window size.
 	void RequestResizeHostDisplay(s32 width, s32 height);
 
+	/// Returns true when the GS display is currently in fullscreen mode.
+	bool IsFullscreen();
+
 	/// Safely executes a function on the VM thread.
 	void RunOnCPUThread(std::function<void()> function, bool block = false);
 

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -2986,7 +2986,7 @@ void FullscreenUI::DrawGraphicsSettingsPage(SettingsInterface* bsi, bool show_ad
 		"EmuCore/GS", "StretchY", 100, 10, 300, FSUI_CSTR("%d%%"));
 	DrawIntRectSetting(bsi, FSUI_ICONSTR(ICON_FA_CROP, "Crop"), FSUI_CSTR("Crops the image, while respecting aspect ratio."), "EmuCore/GS", "CropLeft", 0,
 		"CropTop", 0, "CropRight", 0, "CropBottom", 0, 0, 720, 1, FSUI_CSTR("%dpx"));
-
+	
 	if (!IsEditingGameSettings(bsi))
 	{
 		DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_TV, "Enable Widescreen Patches"), FSUI_CSTR("Enables loading widescreen patches from pnach files."),

--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -30,6 +30,7 @@
 #include "imgui_internal.h"
 #include "common/Image.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <deque>
@@ -53,6 +54,17 @@ namespace ImGuiManager
 		std::pair<float, float> pos;
 	};
 
+	struct BezelOverlay
+	{
+		std::string image_path;
+		std::unique_ptr<GSTexture> texture;
+		GSDevice* texture_device = nullptr;
+		float opacity = 1.0f;
+		float scale = 1.0f;
+		bool enabled = false;
+		BezelFitMode fit_mode = BezelFitMode::Stretch;
+	};
+
 	static void UpdateScale();
 	static void SetStyle();
 	static void SetKeyMap();
@@ -71,9 +83,14 @@ namespace ImGuiManager
 	static void DestroySoftwareCursorTextures();
 	static void DrawSoftwareCursor(const SoftwareCursor& sc, const std::pair<float, float>& pos);
 	static void DrawSoftwareCursors();
+	static void CreateBezelOverlayTexture();
+	static void UpdateBezelOverlayTexture();
+	static void DestroyBezelOverlayTexture();
+	static ImVec2 CalculateBezelOverlaySize(float image_width, float image_height);
 } // namespace ImGuiManager
 
 static float s_global_scale = 1.0f;
+static bool s_bezel_draw_logged = false;
 
 static std::string s_font_path;
 
@@ -111,6 +128,7 @@ static bool s_fullscreen_ui_was_initialized = false;
 static bool s_scale_changed = false;
 
 static std::array<ImGuiManager::SoftwareCursor, InputManager::MAX_SOFTWARE_CURSORS> s_software_cursors = {};
+static ImGuiManager::BezelOverlay s_bezel_overlay = {};
 
 void ImGuiManager::SetFonts(std::vector<FontInfo> info)
 {
@@ -183,6 +201,7 @@ bool ImGuiManager::Initialize()
 		InitializeFullscreenUI();
 
 	CreateSoftwareCursorTextures();
+	CreateBezelOverlayTexture();
 	return true;
 }
 
@@ -194,6 +213,7 @@ bool ImGuiManager::InitializeFullscreenUI()
 
 void ImGuiManager::Shutdown(bool clear_state)
 {
+	DestroyBezelOverlayTexture();
 	DestroySoftwareCursorTextures();
 
 	FullscreenUI::Shutdown(clear_state);
@@ -1027,7 +1047,10 @@ void ImGuiManager::RenderOSD()
 
 	// Don't draw OSD when we're just running big picture.
 	if (VMManager::HasValidVM())
+	{
+		DrawBezelOverlay();
 		RenderOverlays();
+	}
 
 	const Common::Timer::Value current_time = Common::Timer::GetCurrentValue();
 	AcquirePendingOSDMessages(current_time);
@@ -1228,6 +1251,7 @@ void ImGuiManager::DestroySoftwareCursorTextures()
 void ImGuiManager::UpdateSoftwareCursorTexture(u32 index)
 {
 	SoftwareCursor& sc = s_software_cursors[index];
+
 	if (sc.image_path.empty())
 	{
 		sc.texture.reset();
@@ -1240,13 +1264,21 @@ void ImGuiManager::UpdateSoftwareCursorTexture(u32 index)
 		Console.Error("Failed to load software cursor %u image '%s'", index, sc.image_path.c_str());
 		return;
 	}
-	sc.texture = std::unique_ptr<GSTexture>(g_gs_device->CreateTexture(image.GetWidth(), image.GetHeight(), 1, GSTexture::Format::Color));
+
+	sc.texture = std::unique_ptr<GSTexture>(
+		g_gs_device->CreateTexture(image.GetWidth(), image.GetHeight(), 1, GSTexture::Format::Color));
+
 	if (!sc.texture)
 	{
 		Console.Error(
-			"Failed to upload %ux%u software cursor %u image '%s'", image.GetWidth(), image.GetHeight(), index, sc.image_path.c_str());
+			"Failed to upload %ux%u software cursor %u image '%s'",
+			image.GetWidth(),
+			image.GetHeight(),
+			index,
+			sc.image_path.c_str());
 		return;
 	}
+
 	sc.texture->Update(GSVector4i(0, 0, image.GetWidth(), image.GetHeight()), image.GetPixels(), image.GetPitch(), 0);
 
 	sc.extent_x = std::ceil(static_cast<float>(image.GetWidth()) * sc.scale * s_global_scale) / 2.0f;
@@ -1260,17 +1292,22 @@ void ImGuiManager::DrawSoftwareCursor(const SoftwareCursor& sc, const std::pair<
 
 	const ImVec2 min(pos.first - sc.extent_x, pos.second - sc.extent_y);
 	const ImVec2 max(pos.first + sc.extent_x, pos.second + sc.extent_y);
-
 	ImDrawList* dl = ImGui::GetForegroundDrawList();
 
 	dl->AddImage(
-		reinterpret_cast<ImTextureID>(sc.texture.get()->GetNativeHandle()), min, max, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f), sc.color);
+		reinterpret_cast<ImTextureID>(sc.texture.get()->GetNativeHandle()),
+		min,
+		max,
+		ImVec2(0.0f, 0.0f),
+		ImVec2(1.0f, 1.0f),
+		sc.color);
 }
 
 void ImGuiManager::DrawSoftwareCursors()
 {
 	// This one's okay to race, worst that happens is we render the wrong number of cursors for a frame.
 	const u32 pointer_count = InputManager::MAX_POINTER_DEVICES;
+
 	for (u32 i = 0; i < pointer_count; i++)
 		DrawSoftwareCursor(s_software_cursors[i], InputManager::GetPointerAbsolutePosition(i));
 
@@ -1282,14 +1319,18 @@ void ImGuiManager::SetSoftwareCursor(u32 index, std::string image_path, float im
 {
 	MTGS::RunOnGSThread([index, image_path = std::move(image_path), image_scale, multiply_color]() {
 		pxAssert(index < std::size(s_software_cursors));
+
 		SoftwareCursor& sc = s_software_cursors[index];
 		sc.color = multiply_color | 0xFF000000;
+
 		if (sc.image_path == image_path && sc.scale == image_scale)
 			return;
 
 		const bool is_hiding_or_showing = (image_path.empty() != sc.image_path.empty());
+
 		sc.image_path = std::move(image_path);
 		sc.scale = image_scale;
+
 		if (MTGS::IsOpen())
 			UpdateSoftwareCursorTexture(index);
 
@@ -1312,9 +1353,223 @@ void ImGuiManager::ClearSoftwareCursor(u32 index)
 void ImGuiManager::SetSoftwareCursorPosition(u32 index, float pos_x, float pos_y)
 {
 	pxAssert(index < InputManager::MAX_SOFTWARE_CURSORS);
+
 	SoftwareCursor& sc = s_software_cursors[index];
 	sc.pos.first = pos_x;
 	sc.pos.second = pos_y;
+}
+
+void ImGuiManager::CreateBezelOverlayTexture()
+{
+	if (!s_bezel_overlay.enabled || s_bezel_overlay.image_path.empty())
+		return;
+
+	UpdateBezelOverlayTexture();
+}
+
+void ImGuiManager::UpdateBezelOverlayTexture()
+{
+	Console.WriteLn("Bezel: UpdateBezelOverlayTexture g_gs_device=%s enabled=%s path='%s'",
+		g_gs_device ? "yes" : "no",
+		s_bezel_overlay.enabled ? "true" : "false",
+		s_bezel_overlay.image_path.c_str());
+
+	s_bezel_overlay.texture.reset();
+	s_bezel_overlay.texture_device = nullptr;
+
+	if (!g_gs_device)
+		return;
+
+	if (!s_bezel_overlay.enabled || s_bezel_overlay.image_path.empty())
+		return;
+
+	RGBA8Image image;
+	if (!image.LoadFromFile(s_bezel_overlay.image_path.c_str()))
+	{
+		Console.Error("Failed to load bezel overlay image '%s'", s_bezel_overlay.image_path.c_str());
+		return;
+	}
+
+	Console.WriteLn("Bezel: loaded image %ux%u", image.GetWidth(), image.GetHeight());
+
+	s_bezel_overlay.texture = std::unique_ptr<GSTexture>(
+		g_gs_device->CreateTexture(image.GetWidth(), image.GetHeight(), 1, GSTexture::Format::Color));
+
+	if (!s_bezel_overlay.texture)
+	{
+		Console.Error(
+			"Failed to upload %ux%u bezel overlay image '%s'",
+			image.GetWidth(),
+			image.GetHeight(),
+			s_bezel_overlay.image_path.c_str());
+		return;
+	}
+
+	s_bezel_overlay.texture->Update(
+		GSVector4i(0, 0, image.GetWidth(), image.GetHeight()),
+		image.GetPixels(),
+		image.GetPitch(),
+		0);
+
+	s_bezel_overlay.texture_device = g_gs_device.get();
+
+	Console.WriteLn("Bezel: texture uploaded");
+}
+
+void ImGuiManager::DestroyBezelOverlayTexture()
+{
+	s_bezel_overlay.texture.reset();
+	s_bezel_overlay.texture_device = nullptr;
+}
+
+ImVec2 ImGuiManager::CalculateBezelOverlaySize(float image_width, float image_height)
+{
+	const float window_width = ImGuiManager::GetWindowWidth();
+	const float window_height = ImGuiManager::GetWindowHeight();
+
+	if (window_width <= 0.0f || window_height <= 0.0f || image_width <= 0.0f || image_height <= 0.0f)
+		return ImVec2(0.0f, 0.0f);
+
+	switch (s_bezel_overlay.fit_mode)
+	{
+		case BezelFitMode::Contain:
+		{
+			const float fit_scale = std::min(window_width / image_width, window_height / image_height);
+			return ImVec2(image_width * fit_scale * s_bezel_overlay.scale, image_height * fit_scale * s_bezel_overlay.scale);
+		}
+
+		case BezelFitMode::Cover:
+		{
+			const float fit_scale = std::max(window_width / image_width, window_height / image_height);
+			return ImVec2(image_width * fit_scale * s_bezel_overlay.scale, image_height * fit_scale * s_bezel_overlay.scale);
+		}
+
+		case BezelFitMode::Stretch:
+		default:
+			return ImVec2(window_width * s_bezel_overlay.scale, window_height * s_bezel_overlay.scale);
+	}
+}
+
+void ImGuiManager::DrawBezelOverlay()
+{
+	if (!s_bezel_draw_logged)
+	{
+		Console.WriteLn("Bezel: DrawBezelOverlay enabled=%s texture=%s opacity=%f window=%fx%f fullscreen=%s bigpicture=%s",
+			s_bezel_overlay.enabled ? "true" : "false",
+			s_bezel_overlay.texture ? "yes" : "no",
+			s_bezel_overlay.opacity,
+			ImGuiManager::GetWindowWidth(),
+			ImGuiManager::GetWindowHeight(),
+			Host::IsFullscreen() ? "true" : "false",
+			FullscreenUI::HasActiveWindow() ? "true" : "false");
+		s_bezel_draw_logged = true;
+	}
+
+	if (!s_bezel_overlay.enabled || s_bezel_overlay.image_path.empty() || s_bezel_overlay.opacity <= 0.0f)
+		return;
+
+	// If the GS device changed between games, the old native texture handle is no longer safe.
+	// Recreate the bezel texture before submitting it to ImGui.
+	if (!s_bezel_overlay.texture || s_bezel_overlay.texture_device != g_gs_device.get())
+		UpdateBezelOverlayTexture();
+
+	if (!s_bezel_overlay.texture)
+		return;
+
+	if (Host::IsFullscreen() && !EmuConfig.GS.BezelShowInFullscreen)
+		return;
+
+	if (FullscreenUI::HasActiveWindow() && !EmuConfig.GS.BezelShowInBigPicture)
+		return;
+
+	const float texture_width = static_cast<float>(s_bezel_overlay.texture->GetWidth());
+	const float texture_height = static_cast<float>(s_bezel_overlay.texture->GetHeight());
+
+	const ImVec2 size = CalculateBezelOverlaySize(texture_width, texture_height);
+	if (size.x <= 0.0f || size.y <= 0.0f)
+		return;
+
+	const float window_width = ImGuiManager::GetWindowWidth();
+	const float window_height = ImGuiManager::GetWindowHeight();
+
+	const ImVec2 min(
+		std::floor((window_width - size.x) * 0.5f),
+		std::floor((window_height - size.y) * 0.5f));
+
+	const ImVec2 max(
+		std::floor(min.x + size.x),
+		std::floor(min.y + size.y));
+
+	const u32 alpha = static_cast<u32>(std::clamp(s_bezel_overlay.opacity, 0.0f, 1.0f) * 255.0f);
+	const u32 color = IM_COL32(255, 255, 255, alpha);
+
+	ImDrawList* dl = ImGui::GetBackgroundDrawList();
+
+	dl->AddImage(
+		reinterpret_cast<ImTextureID>(s_bezel_overlay.texture.get()->GetNativeHandle()),
+		min,
+		max,
+		ImVec2(0.0f, 0.0f),
+		ImVec2(1.0f, 1.0f),
+		color);
+}
+
+void ImGuiManager::SetBezelOverlay(bool enabled, std::string image_path, float opacity, float scale, BezelFitMode fit_mode)
+{
+	auto update_state = [enabled, image_path = std::move(image_path), opacity, scale, fit_mode]() mutable {
+		const std::string old_path = s_bezel_overlay.image_path;
+		
+		s_bezel_overlay.enabled = enabled;
+		s_bezel_overlay.image_path = std::move(image_path);
+		s_bezel_overlay.opacity = std::clamp(opacity, 0.0f, 1.0f);
+		s_bezel_overlay.scale = std::max(scale, 0.01f);
+		s_bezel_overlay.fit_mode = fit_mode;
+
+		if (!s_bezel_overlay.enabled || s_bezel_overlay.image_path.empty())
+		{
+			s_bezel_overlay.texture.reset();
+			s_bezel_overlay.texture_device = nullptr;
+			return;
+		}
+
+		if (g_gs_device &&
+			(old_path != s_bezel_overlay.image_path ||
+				!s_bezel_overlay.texture ||
+				s_bezel_overlay.texture_device != g_gs_device.get()))
+		{
+			UpdateBezelOverlayTexture();
+		}
+	};
+
+	if (MTGS::IsOpen())
+		MTGS::RunOnGSThread(std::move(update_state));
+	else
+		update_state();
+}
+
+void ImGuiManager::ClearBezelOverlay()
+{
+	auto clear_state = [] {
+		s_bezel_overlay.enabled = false;
+		s_bezel_overlay.image_path.clear();
+		s_bezel_overlay.texture.reset();
+		s_bezel_overlay.texture_device = nullptr;
+	};
+
+	if (MTGS::IsOpen())
+		MTGS::RunOnGSThread(std::move(clear_state));
+	else
+		clear_state();
+}
+
+void ImGuiManager::ReloadBezelOverlay()
+{
+	MTGS::RunOnGSThread([] {
+		if (!s_bezel_overlay.enabled || s_bezel_overlay.image_path.empty())
+			return;
+
+		UpdateBezelOverlayTexture();
+	});
 }
 
 std::string ImGuiManager::StripIconCharacters(std::string_view str)

--- a/pcsx2/ImGui/ImGuiManager.h
+++ b/pcsx2/ImGui/ImGuiManager.h
@@ -113,6 +113,25 @@ namespace ImGuiManager
 	/// Checks if the North/West gamepad buttons are swapped within ImGui
 	bool IsGamepadNorthWestSwapped();
 
+	enum class BezelFitMode : u8
+	{
+		Stretch,
+		Contain,
+		Cover,
+	};
+
+	/// Sets a global 2D bezel image overlay.
+	void SetBezelOverlay(bool enabled, std::string image_path, float opacity, float scale, BezelFitMode fit_mode);
+
+	/// Clears the active bezel overlay.
+	void ClearBezelOverlay();
+
+	/// Reloads the active bezel image from disk.
+	void ReloadBezelOverlay();
+
+	/// Draws the active bezel overlay.
+	void DrawBezelOverlay();
+
 	/// Sets an image and scale for a software cursor. Software cursors can be used for things like crosshairs.
 	void SetSoftwareCursor(u32 index, std::string image_path, float image_scale, u32 multiply_color = 0xFFFFFF);
 	bool HasSoftwareCursor(u32 index);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -652,6 +652,14 @@ const char* Pcsx2Config::GSOptions::FMVAspectRatioSwitchNames[(size_t)FMVAspectR
 	"10:7",
 	nullptr};
 
+const char* Pcsx2Config::GSOptions::BezelFitModeNames[] = {
+	"Fit",
+	"Fill",
+	"Stretch",
+	"Center",
+	nullptr,
+};
+
 const char* Pcsx2Config::GSOptions::BlendingLevelNames[] = {
 	"Minimum",
 	"Basic",
@@ -819,6 +827,14 @@ bool Pcsx2Config::GSOptions::OptionsAreEqual(const GSOptions& right) const
 		OpEqu(Crop[2]) &&
 		OpEqu(Crop[3]) &&
 
+		OpEqu(BezelEnabled) &&
+		OpEqu(BezelPath) &&
+		OpEqu(BezelOpacity) &&
+		OpEqu(BezelScale) &&
+		OpEqu(BezelFitMode) &&
+		OpEqu(BezelShowInFullscreen) &&
+		OpEqu(BezelShowInBigPicture) &&
+
 		OpEqu(OsdScale) &&
 		OpEqu(OsdMargin) &&
 		OpEqu(OsdFontPath) &&
@@ -946,6 +962,14 @@ void Pcsx2Config::GSOptions::LoadSave(SettingsWrapper& wrap)
 	SettingsWrapEntryEx(Crop[1], "CropTop");
 	SettingsWrapEntryEx(Crop[2], "CropRight");
 	SettingsWrapEntryEx(Crop[3], "CropBottom");
+
+	SettingsWrapBitBool(BezelEnabled);
+	SettingsWrapEntry(BezelPath);
+	SettingsWrapEntry(BezelOpacity);
+	SettingsWrapEntry(BezelScale);
+	SettingsWrapEnumEx(BezelFitMode, "BezelFitMode", BezelFitModeNames);
+	SettingsWrapBitBool(BezelShowInFullscreen);
+	SettingsWrapBitBool(BezelShowInBigPicture);
 
 	// Unfortunately, because code in the GS still reads the setting by key instead of
 	// using these variables, we need to use the old names. Maybe post 2.0 we can change this.

--- a/pcsx2/USB/usb-lightgun/guncon2.cpp
+++ b/pcsx2/USB/usb-lightgun/guncon2.cpp
@@ -539,26 +539,37 @@ namespace usb_lightgun
 
 		const s32 new_pointer_index = s->GetSoftwarePointerIndex();
 
-		if (prev_pointer_index != new_pointer_index || s->cursor_path != cursor_path ||
-			s->cursor_scale != cursor_scale || s->cursor_color != cursor_color)
+		const bool cursor_changed =
+			(prev_pointer_index != new_pointer_index ||
+				s->cursor_path != cursor_path ||
+				s->cursor_scale != cursor_scale ||
+				s->cursor_color != cursor_color);
+
+		if (cursor_changed)
 		{
 			if (prev_pointer_index != new_pointer_index)
 				ImGuiManager::ClearSoftwareCursor(prev_pointer_index);
 
-			// Pointer changed, so need to update software cursor.
 			const bool had_software_cursor = !s->cursor_path.empty();
+
 			s->cursor_path = std::move(cursor_path);
 			s->cursor_scale = cursor_scale;
 			s->cursor_color = cursor_color;
-			if (!s->cursor_path.empty())
+
+			if (s->cursor_path.empty())
 			{
-				ImGuiManager::SetSoftwareCursor(new_pointer_index, s->cursor_path, s->cursor_scale, s->cursor_color);
-				s->UpdateSoftwarePointerPosition();
+				if (had_software_cursor)
+					ImGuiManager::ClearSoftwareCursor(new_pointer_index);
 			}
-			else if (had_software_cursor)
-			{
-				ImGuiManager::ClearSoftwareCursor(new_pointer_index);
-			}
+		}
+
+		// Always re-assert the configured cursor.
+		// ImGui cursor state can be cleared during VM/device shutdown even when
+		// GunCon2 settings did not change between games.
+		if (!s->cursor_path.empty())
+		{
+			ImGuiManager::SetSoftwareCursor(new_pointer_index, s->cursor_path, s->cursor_scale, s->cursor_color);
+			s->UpdateSoftwarePointerPosition();
 		}
 	}
 

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -19,6 +19,7 @@
 #include "Host.h"
 #include "INISettingsInterface.h"
 #include "ImGui/FullscreenUI.h"
+#include "ImGui/ImGuiManager.h"
 #include "ImGui/ImGuiOverlays.h"
 #include "Input/InputManager.h"
 #include "IopBios.h"
@@ -102,6 +103,8 @@ namespace VMManager
 	static void CheckForConfigChanges(const Pcsx2Config& old_config);
 	static void CheckForCPUConfigChanges(const Pcsx2Config& old_config);
 	static void CheckForGSConfigChanges(const Pcsx2Config& old_config);
+	static ImGuiManager::BezelFitMode ConvertBezelFitMode(GSBezelFitMode mode);
+	static void UpdateBezelOverlay();
 	static void CheckForEmulationSpeedConfigChanges(const Pcsx2Config& old_config);
 	static void CheckForPatchConfigChanges(const Pcsx2Config& old_config);
 	static void CheckForDEV9ConfigChanges(const Pcsx2Config& old_config);
@@ -187,6 +190,7 @@ static std::pair<u32, u32> s_elf_text_range;
 static bool s_elf_executed = false;
 static std::string s_elf_override;
 static std::string s_acgame;
+static std::string s_acgame_serial;
 static std::string s_input_profile_name;
 static u32 s_frame_advance_count = 0;
 static bool s_fast_boot_requested = false;
@@ -676,6 +680,8 @@ void VMManager::LoadCoreSettings(SettingsInterface& si)
 	EmuConfig.GS.MaskUserHacks();
 	EmuConfig.GS.MaskUpscalingHacks();
 
+	UpdateBezelOverlay();
+
 	// Force MTVU off when playing back GS dumps, it doesn't get used.
 	if (GSDumpReplayer::IsReplayingDump())
 		EmuConfig.Speedhacks.vuThread = false;
@@ -985,9 +991,14 @@ void VMManager::RequestDisplaySize(float scale /*= 0.0f*/)
 
 std::string VMManager::GetSerialForGameSettings()
 {
-	// If we're running an ELF, we don't want to use the serial for any ISO override
-	// for game settings, since the game settings is where we define the override.
+	// If this is an .acgame launch, use the arcade GameID from the .acgame file.
+	// Arcade CHDs often report a blank disc serial, but the .acgame gameid is valid.
 	std::unique_lock lock(s_info_mutex);
+	if (!s_acgame_serial.empty())
+		return s_acgame_serial;
+
+	// If we're running a normal loose ELF, don't use the serial for game settings,
+	// since the game settings layer is where ELF disc overrides are defined.
 	return s_elf_override.empty() ? std::string(s_disc_serial) : std::string();
 }
 
@@ -996,11 +1007,18 @@ bool VMManager::UpdateGameSettingsLayer()
 	std::unique_ptr<INISettingsInterface> new_interface;
 	if (s_disc_crc != 0)
 	{
-		std::string filename(GetGameSettingsPath(GetSerialForGameSettings(), s_disc_crc));
+		const std::string game_serial = GetSerialForGameSettings();
+		std::string filename(GetGameSettingsPath(game_serial, s_disc_crc));
 		if (!FileSystem::FileExists(filename.c_str()))
 		{
-			// try the legacy format (crc.ini)
-			filename = GetGameSettingsPath({}, s_disc_crc);
+			if (!game_serial.empty())
+				filename = GetGameSettingsPath(game_serial, 0);
+
+			if (!FileSystem::FileExists(filename.c_str()))
+			{
+				// try the legacy format (crc.ini)
+				filename = GetGameSettingsPath({}, s_disc_crc);
+			}
 		}
 
 		if (FileSystem::FileExists(filename.c_str()))
@@ -1080,6 +1098,10 @@ void VMManager::UpdateDiscDetails(bool booting)
 		else if (CDVDsys_GetSourceType() != CDVD_SourceType::NoDisc)
 		{
 			cdvdGetDiscInfo(&s_disc_serial, &s_disc_elf, &s_disc_version, &s_disc_crc, nullptr);
+
+			if (!s_acgame_serial.empty() && s_disc_serial.empty())
+				s_disc_serial = s_acgame_serial;
+
 			serial_is_valid = !s_disc_serial.empty();
 		}
 		else if (!s_acgame.empty()) {
@@ -1319,6 +1341,7 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				s_imgname = INI.GetStringValue("data", "mediasrc");
 				s_title = s_serial = INI.GetStringValue("game", "name");
 				s_disc_serial = s_serial = INI.GetStringValue("game", "gameid");
+				s_acgame_serial = s_serial;
 				bool idvalid = (s_serial.length() == 7 && (s_serial[0] == 'N' && s_serial[1] == 'M'));
     			for (int i = 2; idvalid && i < 7; i++)
     			    idvalid = (s_serial[i] >= '0' && s_serial[i] <= '9');
@@ -1857,6 +1880,7 @@ void VMManager::Shutdown(bool save_resume_state)
 	SaveSessionTime(s_disc_serial);
 	s_elf_override = {};
 	s_acgame = {};
+	s_acgame_serial = {};
 	PS2CLK = PS2CLK_DEFAULT;
 	PSXCLK = 36864000;
 	s_sys256_mode = false;
@@ -3146,6 +3170,42 @@ void VMManager::Internal::PollInputOnCPUThread()
 	}
 }
 
+ImGuiManager::BezelFitMode VMManager::ConvertBezelFitMode(GSBezelFitMode mode)
+{
+	switch (mode)
+	{
+		case GSBezelFitMode::Stretch:
+			return ImGuiManager::BezelFitMode::Stretch;
+
+		case GSBezelFitMode::Fill:
+			return ImGuiManager::BezelFitMode::Cover;
+
+		case GSBezelFitMode::Fit:
+		case GSBezelFitMode::Center:
+		default:
+			return ImGuiManager::BezelFitMode::Contain;
+	}
+}
+
+void VMManager::UpdateBezelOverlay()
+{
+	Console.WriteLn("Bezel: UpdateBezelOverlay enabled=%s path='%s' opacity=%f scale=%d fit=%d fullscreen=%s bigpicture=%s",
+		EmuConfig.GS.BezelEnabled ? "true" : "false",
+		EmuConfig.GS.BezelPath.c_str(),
+		EmuConfig.GS.BezelOpacity,
+		EmuConfig.GS.BezelScale,
+		static_cast<int>(EmuConfig.GS.BezelFitMode),
+		EmuConfig.GS.BezelShowInFullscreen ? "true" : "false",
+		EmuConfig.GS.BezelShowInBigPicture ? "true" : "false");
+
+	ImGuiManager::SetBezelOverlay(
+		EmuConfig.GS.BezelEnabled,
+		EmuConfig.GS.BezelPath,
+		EmuConfig.GS.BezelOpacity,
+		static_cast<float>(EmuConfig.GS.BezelScale) / 100.0f,
+		ConvertBezelFitMode(EmuConfig.GS.BezelFitMode));
+}
+
 void VMManager::CheckForCPUConfigChanges(const Pcsx2Config& old_config)
 {
 	if (EmuConfig.Cpu == old_config.Cpu && EmuConfig.Gamefixes == old_config.Gamefixes &&
@@ -3178,6 +3238,17 @@ void VMManager::CheckForGSConfigChanges(const Pcsx2Config& old_config)
 		return;
 
 	Console.WriteLn("Updating GS configuration...");
+
+	if (EmuConfig.GS.BezelEnabled != old_config.GS.BezelEnabled ||
+		EmuConfig.GS.BezelPath != old_config.GS.BezelPath ||
+		EmuConfig.GS.BezelOpacity != old_config.GS.BezelOpacity ||
+		EmuConfig.GS.BezelScale != old_config.GS.BezelScale ||
+		EmuConfig.GS.BezelFitMode != old_config.GS.BezelFitMode ||
+		EmuConfig.GS.BezelShowInFullscreen != old_config.GS.BezelShowInFullscreen ||
+		EmuConfig.GS.BezelShowInBigPicture != old_config.GS.BezelShowInBigPicture)
+	{
+		UpdateBezelOverlay();
+	}
 
 	// We could just check whichever NTSC or PAL is appropriate for our current mode,
 	// but people _really_ shouldn't be screwing with framerate, so whatever.


### PR DESCRIPTION
### Description of Changes

Adds native bezel overlay support to PCSX2x6.

This adds initial rendering support for displaying a bezel image around the game viewport when selected. The bezel is handled as a general overlay feature.  Underlying code for additional settings/configuration is included for future implementation in the UI.

### Rationale behind Changes

This allows games to use built-in bezel artwork without relying on external overlay tools.

### Suggested Testing Steps

1. Select a valid bezel image via right click menu in games list and confirm it appears during gameplay.
2. Test with both lightgun with sinden border & crosshair, and non-lightgun games.
3. Close and reopen PCSX2X6 and confirm the setting persists.
4. Set a missing or invalid bezel image path and confirm the emulator does not crash.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. AI was used to help review existing overlay related code paths, suggest implementation locations, and draft testing steps. Code changes were implemented, reviewed, and tested manually.

### Related GameIDs

N/A — this is a general overlay feature and is not specific to any individual game.
<img width="1916" height="1042" alt="image" src="https://github.com/user-attachments/assets/74b1a4c4-8715-4bd9-8dff-04e3822481ee" />
<img width="1913" height="1078" alt="image" src="https://github.com/user-attachments/assets/05009b9a-10ca-4c73-ba76-bbf5546ff936" />
