### PR TITLE
Initial support to racing games

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -4,6 +4,15 @@ NM00001:
   bootprog: START
   media: CD
   input: driving
+  clampModes:
+    vuClampMode: 2
+  gsHWFixes:
+    textureInsideRT: 1
+    halfPixelOffset: 2
+    roundSprite: 1
+    gpuPaletteConversion: 2
+    cpuSpriteRenderBW: 1
+    cpuSpriteRenderLevel: 1
 NM00002:
   name: Bloody Roar 3
   region: System246
@@ -66,6 +75,9 @@ NM00010:
   bootprog: BGRLOAD
   media: HDD
   input: driving
+  clampModes:
+    eeClampMode: 3
+    vuClampMode: 3
 NM00011:
   name: Pride GP 2003
   region: System246
@@ -96,6 +108,9 @@ NM00015:
   bootprog: BGTLOAD
   media: HDD
   input: driving
+  clampModes:
+    eeClampMode: 3
+    vuClampMode: 3
 NM00016:
   name: Zoids Infinity
   region: System246

--- a/pcsx2/DEV9/ACATA.cpp
+++ b/pcsx2/DEV9/ACATA.cpp
@@ -388,6 +388,10 @@ void ACATA::handle_cmd(u16 val) {
         ACCORE::intr(ACCORE::INTRN_ATA);
     break;
     case ATA_C_INITIALIZE_DEVICE_PARAMETERS:
+        // Need to rework this hack.
+        // BG3: 0x91 completes immediately, so mark the device idle (-1); else cmd_handled stays 0 and the BUSY
+        // probe-hack wedges it on -> HDD driver hangs (black screen).
+        ACATA::cmd_handled = -1;
         CLRB(R_STATUS, ATA_STAT_ERR);
         CLRB(R_STATUS, ATA_STAT_BUSY);
         R_STATUS |= ATA_STAT_READY;

--- a/pcsx2/DEV9/ACCORE.cpp
+++ b/pcsx2/DEV9/ACCORE.cpp
@@ -26,7 +26,7 @@ u16 ACCORE::Read16(u32 mem) {
 
 void ACCORE::Write16(u32 mem, u16 value) {
 		switch (mem) {
-		case ACJV_CTR_START: Console.Warning("ACJV::START"); ACJV::enabled = true; break;
+		case ACJV_CTR_START: Console.Warning("ACJV::START"); ACJV::enabled = true; ACJV::OnBoardStart(); break;
 		case ACJV_CTR_STOP:  Console.Warning("ACJV::STOP");  ACJV::enabled = false;  break;
 		case 0x1241510C: Console.Warning("ACCORE::INTR  DISABLE_ACATA_INTR"); break;
 		case 0x1241511C: Console.Warning("ACCORE::INTR  DISABLE_ACUART_INTR"); break;
@@ -68,6 +68,10 @@ void ACCORE::intr(int INTRN) {
 		INTR_REG |= CAUS_ATA;
 		break;
 
+	case INTRN_UART: // V257 drive-board UART RX (Ridge Racer V status stream, see ACUART::StreamV257)
+		INTR_REG |= CAUS_UART;
+		break;
+
 	default:
 
 		return;
@@ -82,6 +86,7 @@ void ACCORE::Interrupt(u32 mem, u16 v) {
 		CLRB(INTR_REG, CAUS_ATA);
 		break;
 	case ACCORE_INTR_UART:
+		CLRB(INTR_REG, CAUS_UART); // acknowledge the UART RX interrupt (clear its cause bit)
 		break;
 	default:
 		Console.Warning("ACCORE: unknown INTR write to: %08X", mem);

--- a/pcsx2/DEV9/ACCORE.h
+++ b/pcsx2/DEV9/ACCORE.h
@@ -29,7 +29,8 @@ namespace ACCORE {
 		INTRN_LAST = 0x2,
 	};
 	enum INTC_CAUS {
-		CAUS_ATA = 0x8000
+		CAUS_ATA = 0x8000,
+		CAUS_UART = 0x4000 // UART receive interrupt (drive-board serial link)
 	};
 }
 

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -1,11 +1,13 @@
 #include "common/Console.h"
 #include "ACMACROS.h"
 #include "ACJV.h"
+#include "ACUART.h"
 #include "Config.h"
 #include "Host.h"
 #include "Input/InputManager.h"
 #include "GS/GS.h"
 #include "common/SettingsInterface.h"
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <string>
@@ -44,6 +46,7 @@ std::string BOARDS[] = {
 	"namco ltd.;FCB;Ver1.02;JPN,TouchPanel&Multipurpose",
 	"namco ltd.;TSS-I/O;Ver2.11;GUN-EXTENTION",
 	"namco ltd.;MIU-I/O;Ver2.05;JPN,GUN-EXTENTION",
+	"TAITO CORP.;I/O PCB-24/24/8/2SE;ver1.2forBG3;IN24/OUT24/AD8/DA2/SERIAL/EEPROM", // Battle Gear 3 / Tuned — real Taito board ID from its TMP95C063 firmware dump
 };
 enum BOARDID ACJV::CurrentBoardID = RAYS_PCB;
 
@@ -53,6 +56,7 @@ static constexpr const char* BOARD_DISPLAY_NAMES[] = {
 	"FCB (Touch Panel)",
 	"TSS-I/O (Gun Extension)",
 	"MIU-I/O (Gun Extension)",
+	"Taito I/O PCB-24/24/8/2SE (Battle Gear 3)",
 };
 
 static constexpr u16 DEFAULT_DIP_SWITCH_STATE =
@@ -109,6 +113,13 @@ static constexpr const std::array<InputBindingInfo, 12> s_jvs_p2_button_bindings
 	{"P2_Service", TRANSLATE_NOOP("JVS", "P2 Service"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_SERVICE, GenericInputBinding::Select},
 }};
 
+static constexpr const std::array<InputBindingInfo, 4> s_jvs_wheel_bindings = {{ // driving analog bindings, auto-mirrored from Pad0
+	{"SteerRight", TRANSLATE_NOOP("JVS", "Steering Right"), nullptr, InputBindingInfo::Type::HalfAxis, 0, GenericInputBinding::LeftStickRight},
+	{"SteerLeft",  TRANSLATE_NOOP("JVS", "Steering Left"),  nullptr, InputBindingInfo::Type::HalfAxis, 1, GenericInputBinding::LeftStickLeft},
+	{"Gas",        TRANSLATE_NOOP("JVS", "Accelerator"),    nullptr, InputBindingInfo::Type::HalfAxis, 2, GenericInputBinding::R2},
+	{"Brake",      TRANSLATE_NOOP("JVS", "Brake"),          nullptr, InputBindingInfo::Type::HalfAxis, 3, GenericInputBinding::L2},
+}};
+
 // Per-layout face button default inputs (BTN1-6), mirroring each game's
 // official PS2 port pad. Some games share the same layout. Rows follow FightingLayout order.
 static constexpr GenericInputBinding s_fighting_face_buttons[][6] = {
@@ -138,6 +149,102 @@ static void UpdateFightingBindings(FightingLayout layout)
 	{
 		s_active_p1_bindings[BTN1_INDEX + i].generic_mapping = face[i];
 		s_active_p2_bindings[BTN1_INDEX + i].generic_mapping = face[i];
+	}
+}
+
+// Generic racing layout (BTN1-6): each entry sets its own JVS bit, so a game can wire switches beyond Sw1-6 (e.g. AD3's Push9).
+struct RacingButton { u16 bind_index; GenericInputBinding host; };
+static constexpr RacingButton s_racing_buttons[][6] = {
+	{ // ACEDRIVER3 (BTN1-6)
+		{JVS_BTN_1, GenericInputBinding::Square},   // ENTER
+		{JVS_BTN_2, GenericInputBinding::Unknown},  // unused
+		{JVS_BTN_3, GenericInputBinding::R1},       // GEAR UP
+		{JVS_BTN_4, GenericInputBinding::L1},       // GEAR DOWN (next to L2 = brake)
+		{JVS_BTN_5, GenericInputBinding::Unknown},  // unused
+		{JVS_BTN_9, GenericInputBinding::Triangle}, // VIEW CHANGE (Push9)
+	},
+};
+
+// Apply a racing layout: copy the base tables, then remap the buttons (JVS bit + pad button) per game.
+static void UpdateRacingBindings(RacingLayout layout)
+{
+	s_active_p1_bindings = s_jvs_p1_button_bindings;
+	s_active_p2_bindings = s_jvs_p2_button_bindings;
+	if (layout == RacingLayout::BG3)
+	{
+		// BG3/Tuned: JVS switch -> function map, RE'd from the game's switch chain @0x1e3f90.
+		const auto remap = [](std::array<InputBindingInfo, 12>& b) {
+			for (InputBindingInfo& e : b)
+			{
+				switch (e.bind_index)
+				{
+					case JVS_BTN_RIGHT: e.generic_mapping = GenericInputBinding::R1; break;       // SHIFT UP
+					case JVS_BTN_1:     e.generic_mapping = GenericInputBinding::L1; break;        // SHIFT DOWN
+					case JVS_BTN_DOWN:  e.generic_mapping = GenericInputBinding::Triangle; break;  // VIEW
+					case JVS_BTN_LEFT:  e.generic_mapping = GenericInputBinding::Square; break;    // SIDEBRAKE
+					case JVS_BTN_UP:    e.generic_mapping = GenericInputBinding::Circle; break;    // HAZARD
+					case JVS_BTN_START:
+					case JVS_BTN_SERVICE: break;
+					default:            e.generic_mapping = GenericInputBinding::Unknown; break;   // unused -> no double-trigger
+				}
+			}
+		};
+		remap(s_active_p1_bindings);
+		remap(s_active_p2_bindings);
+		return;
+	}
+	if (layout == RacingLayout::WANGAN)
+	{
+		// Wangan Midnight / R (NM00008/05): map confirmed live via I/O-TEST SWITCH-TEST.
+		const auto remap = [](std::array<InputBindingInfo, 12>& b) {
+			for (InputBindingInfo& e : b)
+			{
+				switch (e.bind_index)
+				{
+					case JVS_BTN_3: e.generic_mapping = GenericInputBinding::R1;       break; // Sw3 = SHIFT UP
+					case JVS_BTN_4: e.generic_mapping = GenericInputBinding::L1;       break; // Sw4 = SHIFT DOWN
+					case JVS_BTN_1: e.generic_mapping = GenericInputBinding::Square;   break; // Sw1
+					case JVS_BTN_2: e.generic_mapping = GenericInputBinding::Triangle; break; // Sw2
+					case JVS_BTN_5: e.generic_mapping = GenericInputBinding::Circle;   break; // Sw5
+					case JVS_BTN_6: e.generic_mapping = GenericInputBinding::Cross;    break; // Sw6
+					default: break;
+				}
+			}
+		};
+		remap(s_active_p1_bindings);
+		remap(s_active_p2_bindings);
+		return;
+	}
+	if (layout == RacingLayout::RRV)
+	{
+		// Ridge Racer V (NM00001): map from the switch builder FUN_0022ab70 (Ghidra).
+		const auto remap = [](std::array<InputBindingInfo, 12>& b) {
+			for (InputBindingInfo& e : b)
+			{
+				switch (e.bind_index)
+				{
+					case JVS_BTN_3: e.generic_mapping = GenericInputBinding::R1;       break; // Sw3 = SHIFT UP
+					case JVS_BTN_4: e.generic_mapping = GenericInputBinding::L1;       break; // Sw4 = SHIFT DOWN
+					case JVS_BTN_2: e.generic_mapping = GenericInputBinding::Triangle; break; // Sw2 = VIEW CHANGE
+					case JVS_BTN_1: e.generic_mapping = GenericInputBinding::Square;   break; // Sw1 = ENTER
+					case JVS_BTN_5: e.generic_mapping = GenericInputBinding::Unknown;  break; // unused -> no double-trigger
+					case JVS_BTN_6: e.generic_mapping = GenericInputBinding::Unknown;  break; // unused
+					default: break;
+				}
+			}
+		};
+		remap(s_active_p1_bindings);
+		remap(s_active_p2_bindings);
+		return;
+	}
+	const auto& btns = s_racing_buttons[static_cast<int>(layout)];
+	constexpr int BTN1_INDEX = 4;
+	for (int i = 0; i < 6; i++)
+	{
+		s_active_p1_bindings[BTN1_INDEX + i].bind_index = btns[i].bind_index;
+		s_active_p1_bindings[BTN1_INDEX + i].generic_mapping = btns[i].host;
+		s_active_p2_bindings[BTN1_INDEX + i].bind_index = btns[i].bind_index;
+		s_active_p2_bindings[BTN1_INDEX + i].generic_mapping = btns[i].host;
 	}
 }
 
@@ -185,7 +292,7 @@ bool ACJV::IsSuppressDaemonEnabled()
 
 const char* ACJV::GetBoardDisplayName(BOARDID id)
 {
-	if (id >= RAYS_PCB && id <= MIU_IO_JPN_GUN_EXTENTI)
+	if (id >= RAYS_PCB && id <= TAITO_BG3_IO_PCB)
 		return BOARD_DISPLAY_NAMES[id];
 	return "Unknown";
 }
@@ -204,14 +311,14 @@ static JVS_MODE m_jvsMode = JVS_MODE::DEFAULT;
 
 std::span<const InputBindingInfo> ACJV::GetButtonBindings()
 {
-	if (m_jvsMode == JVS_MODE::FIGHTING)
+	if (m_jvsMode == JVS_MODE::FIGHTING || m_jvsMode == JVS_MODE::DRIVE)
 		return s_active_p1_bindings;
 	return s_jvs_p1_button_bindings;
 }
 
 std::span<const InputBindingInfo> ACJV::GetP2ButtonBindings()
 {
-	if (m_jvsMode == JVS_MODE::FIGHTING)
+	if (m_jvsMode == JVS_MODE::FIGHTING || m_jvsMode == JVS_MODE::DRIVE)
 		return s_active_p2_bindings;
 	return s_jvs_p2_button_bindings;
 }
@@ -219,6 +326,11 @@ std::span<const InputBindingInfo> ACJV::GetP2ButtonBindings()
 std::span<const InputBindingInfo> ACJV::GetCoinBindings()
 {
 	return s_jvs_coin_bindings;
+}
+
+std::span<const InputBindingInfo> ACJV::GetWheelBindings()
+{
+	return s_jvs_wheel_bindings;
 }
 
 bool ACJV::GetDIPSwitchState(u32 index)
@@ -299,10 +411,12 @@ void ACJV::SetDefaultConfiguration(SettingsInterface& si)
 	si.SetIntValue(CONFIG_SECTION, "SindenBorderThickness", 10);
 }
 
+// The game reading the JVS board: return the requested word from its read buffer (rdbuf).
 u16 ACJV::Read16(u32 addr) {
     if (addr >= ACJV_RDBASE && addr < 0x124045FE) {
         int x = (addr - ACJV_RDBASE)/2;
-		if (x == 2 || x == 3 || x == 4) return rdbuf.at(x)|1;// initial polling expects these addrs to not be zero
+        // El_isra's initial-polling scaffold, disabled (tested OK without it):
+        // if (x == 2 || x == 3 || x == 4) return rdbuf.at(x)|1;// initial polling expects these addrs to not be zero
         return (u16)rdbuf.at(x);
     } else if ((addr == 0x124045FE)) {
 		return (u16)rdbuf.at((addr - ACJV_RDBASE)/2);
@@ -334,6 +448,11 @@ static float m_jvsLightgunDX = -1.0f;  // normalized display X (-1 = off-screen)
 static float m_jvsLightgunDY = -1.0f;  // normalized display Y (-1 = off-screen)
 static u16 m_jvsWheelChannels[JVS_WHEEL_CHANNEL_MAX] = {};
 static u16 m_jvsDrumChannels[JVS_DRUM_CHANNEL_MAX] = {};
+
+static float m_wheelSteerR = 0.0f; // stick right  -> steering positive
+static float m_wheelSteerL = 0.0f; // stick left   -> steering negative
+static float m_wheelGas    = 0.0f; // right trigger (R2)
+static float m_wheelBrake  = 0.0f; // left trigger  (L2)
 
 // Per-game JVS button mapping for lightgun games, keyed by NM game ID (see issue #9).
 // Field order: pedal, sensor, sensor_active_high, p1_start, p2_start, p1_trigger, p2_trigger
@@ -371,6 +490,15 @@ static const std::map<std::string, FightingLayout> s_fighting_layouts = {
 	{"NM00052", FightingLayout::GUNDAM},     // Gundam vs Gundam NEXT
 };
 
+static const std::map<std::string, RacingLayout> s_racing_layouts = {
+	{"NM00047", RacingLayout::ACEDRIVER3},   // Ace Driver 3: Final Turn
+	{"NM00010", RacingLayout::BG3},          // Battle Gear 3
+	{"NM00015", RacingLayout::BG3},          // Battle Gear 3 Tuned
+	{"NM00008", RacingLayout::WANGAN},       // Wangan Midnight
+	{"NM00005", RacingLayout::WANGAN},       // Wangan Midnight R
+	{"NM00001", RacingLayout::RRV},          // Ridge Racer V (discovery sweep)
+};
+
 // Gamepad input -> JVS button state: set or clear a button bit for a player
 void ACJV::SetButtonState(u32 player, u16 mask, bool pressed)
 {
@@ -396,10 +524,31 @@ void ACJV::SetMode(JVS_MODE mode)
 	m_jvsMode = mode;
 }
 
+void ACJV::SetWheelAxis(u32 axis, float value)
+{
+	switch (axis)
+	{
+		case 0: m_wheelSteerR = value; break;
+		case 1: m_wheelSteerL = value; break;
+		case 2: m_wheelGas    = value; break;
+		case 3: m_wheelBrake  = value; break;
+		default: break;
+	}
+}
+
 JVS_MODE ACJV::GetMode()
 {
 	return m_jvsMode;
 }
+
+// Host steering, -1 (full left)...+1 (full right). GetGas/GetBrake: 0...1.
+float ACJV::GetSteer()
+{
+	return std::clamp(m_wheelSteerR - m_wheelSteerL, -1.0f, 1.0f);
+}
+
+float ACJV::GetGas()   { return std::clamp(m_wheelGas,   0.0f, 1.0f); }
+float ACJV::GetBrake() { return std::clamp(m_wheelBrake, 0.0f, 1.0f); }
 
 bool ACJV::IsSindenBorderEnabled()
 {
@@ -429,6 +578,7 @@ void ACJV::SetGameId(const std::string& gameid)
 {
 	s_gameid = gameid;
 	// Clean slate: zero all input state on game switch within the emulator
+	ACUART::ResetBg3State(); // re-arm the BG3 acuart HANDLE handshake so a game RESET boots cleanly (no HANDLE ERROR)
 	m_coin1 = 0;
 	m_coin2 = 0;
 	m_jvsButtonState[0] = 0;
@@ -453,11 +603,23 @@ void ACJV::SetGameId(const std::string& gameid)
 		m_gunMapping = &s_default_gun_mapping;
 
 	auto fit = s_fighting_layouts.find(gameid);
+	auto rit = s_racing_layouts.find(gameid);
 	if (fit != s_fighting_layouts.end())
 	{
 		constexpr const char* layout_names[] = {"tekken", "gundam", "6-button", "soulcalibur", "bloodyroar"};
 		Console.WriteLn("ACJV: fighting layout for %s: %s", gameid.c_str(), layout_names[static_cast<int>(fit->second)]);
 		UpdateFightingBindings(fit->second);
+	}
+	else if (rit != s_racing_layouts.end())
+	{
+		constexpr const char* racing_names[] = {"acedriver3", "bg3", "wangan", "rrv"};
+		Console.WriteLn("ACJV: racing layout for %s: %s", gameid.c_str(), racing_names[static_cast<int>(rit->second)]);
+		UpdateRacingBindings(rit->second);
+	}
+	else
+	{
+		s_active_p1_bindings = s_jvs_p1_button_bindings;
+		s_active_p2_bindings = s_jvs_p2_button_bindings;
 	}
 
 	// TC3 has 3 I/O boards: TSS-I/O (white flash), MIU-I/O (640x224), RAYS PCB (0xFFFF).
@@ -465,6 +627,8 @@ void ACJV::SetGameId(const std::string& gameid)
 	// RAYS PCB calibration uses DMA protocol (cmd 0x70) that bypasses our JVS handler.
 	if (gameid == "NM00012")
 		CurrentBoardID = MIU_IO_JPN_GUN_EXTENTI;
+	else if (gameid == "NM00010" || gameid == "NM00015")
+		CurrentBoardID = TAITO_BG3_IO_PCB; // BG3/BG3T: real Taito K91X0951A board ID (from the F22 EPROM dump)
 	else
 		CurrentBoardID = RAYS_PCB;
 }
@@ -498,6 +662,24 @@ static void UpdateLightgunFromMouse()
 	const auto& gm = ACJV::GetGunMapping();
 	if (gm.sensor)
 		ACJV::SetButtonState(0, gm.sensor, gm.sensor_active_high ? on_screen : !on_screen);
+}
+
+// Combine host axes into the 3 JVS analog channels (steer/gas/brake). Steering encoding is per-game.
+// (Ridge Racer V uses UpdateFcaFrame instead.)
+static void UpdateWheelChannels()
+{
+	const float steer = std::clamp(m_wheelSteerR - m_wheelSteerL, -1.0f, 1.0f); // -1 full left .. +1 full right
+	const bool isBG3 = (s_gameid == "NM00010" || s_gameid == "NM00015");
+	const bool isWangan = (s_gameid == "NM00008" || s_gameid == "NM00005");
+	if (isBG3)
+		m_jvsWheelChannels[0] = static_cast<u16>(512.0f - steer * 496.0f);                    // BG3: 10-bit, center 512, inverted
+	else if (isWangan)
+		m_jvsWheelChannels[0] = static_cast<u16>(0x8000 + static_cast<int>(steer * 0x7E00));  // Wangan: center 0x8000, +-0x7E00
+	else
+		m_jvsWheelChannels[0] = static_cast<u16>((steer * 0.5f + 0.5f) * 0xFFFF);             // standard JVS: unsigned 16-bit, center 0x8000
+	const float pedalMax = isWangan ? 32767.0f : static_cast<float>(0xFFFF); // Wangan pedals use the 0..0x7FFF half (else they wrap)
+	m_jvsWheelChannels[1] = static_cast<u16>(std::clamp(m_wheelGas,   0.0f, 1.0f) * pedalMax); // accelerator
+	m_jvsWheelChannels[2] = static_cast<u16>(std::clamp(m_wheelBrake, 0.0f, 1.0f) * pedalMax); // brake
 }
 
 void do_jvs_packet(const u8* input, u8* output) {
@@ -578,18 +760,19 @@ void do_jvs_packet(const u8* input, u8* output) {
 			(*output++) = JVS_PLAYER_COUNT; //2 players
 			(*output++) = 0x10;             //16 switches
 			(*output++) = 0x00;
-			// TODO: driving games (e.g. Wangan Midnight)
-#if 0
+			// Driving games (Wangan Midnight, MotoGP, ...): 3 analog channels (steer/gas/brake)
 			if(m_jvsMode == JVS_MODE::DRIVE)
 			{
-				(*output++) = 0x03;                  //Analog Input
-				(*output++) = JVS_WHEEL_CHANNEL_MAX; //Channel Count (3 channels)
-				(*output++) = 0x10;                  //Bits (16 bits)
+				// BG3's Taito K91X0951A is an AD8 board (8 analog ch, 10-bit) per its dumped firmware's
+				// JVS feature descriptor @0xfc0fea (03 08 0a 00); other driving boards report 3x 16-bit.
+				const bool isBG3 = (ACJV::CurrentBoardID == TAITO_BG3_IO_PCB);
+				(*output++) = 0x03;                              //Analog Input
+				(*output++) = isBG3 ? 8 : JVS_WHEEL_CHANNEL_MAX; //Channel Count
+				(*output++) = isBG3 ? 0x0A : 0x10;               //Bits
 				(*output++) = 0x00;
 				(*dstSize) += 4;
 			}
 			else
-#endif
 			if(m_jvsMode == JVS_MODE::LIGHTGUN)
 			{
 				(*output++) = 0x06; //Screen Pos Input
@@ -780,10 +963,14 @@ void do_jvs_packet(const u8* input, u8* output) {
 			}
 			else if(m_jvsMode == JVS_MODE::DRIVE)
 			{
-				for(int i = 0; i < JVS_WHEEL_CHANNEL_MAX; i++)
+				UpdateWheelChannels();
+				// Respond with exactly the channel count the game requested (BG3's AD8 board asks for 8,
+				// other driving boards 3). ch0-2 = steer/gas/brake; spare channels report mid-scale.
+				for(int i = 0; i < channel; i++)
 				{
-					(*output++) = static_cast<u8>(m_jvsWheelChannels[i] >> 8);
-					(*output++) = static_cast<u8>(m_jvsWheelChannels[i]);
+					u16 v = (i < JVS_WHEEL_CHANNEL_MAX) ? m_jvsWheelChannels[i] : 0x8000;
+					(*output++) = static_cast<u8>(v >> 8);
+					(*output++) = static_cast<u8>(v);
 				}
 			}
 
@@ -871,13 +1058,19 @@ void do_jvs_packet(const u8* input, u8* output) {
 
 
 // based on https://github.com/search?q=repo%3Ajpd002/Play-%20CSys246%3A%3AProcessJvsPacket&type=code by Jean-Philip Desjardins
+// Prime the JVS board firmware-version register when ACJV starts (BG3 Tuned polls it before any command).
+void ACJV::OnBoardStart() {
+	rdbuf_getu16()[1] = (s_gameid == "NM00015") ? 0x213 : (s_gameid == "NM00010") ? 0x210 : 0x208;
+}
+
 void do_acjv_packet() {
 	const u16* wr16 = wrbuf_getu16();
 	u16* rd16 = rdbuf_getu16();
 	rd16[0] = wr16[0];
 	u16 RootPacketID = wr16[8];
 	if(rd16[0] == 0x3E6F) {
-		rd16[1]      = 0x208;        // unconfirmed: firmware version
+		// JVFIRM version n246Jvio checks against its own (mismatch stalls boot): BG3=0x210, BG3T=0x213, others 0x208.
+		rd16[1]      = (s_gameid == "NM00015") ? 0x213 : (s_gameid == "NM00010") ? 0x210 : 0x208;
 		rd16[0x14]   = RootPacketID; // Xored with value at 0x10 in send packet, needs to be the same
 		rd16[0x21]   = wr16[0x0D];
 		rd16[0x30]  = s_dip_switch_state; // here the game polls the dip switch values?
@@ -890,8 +1083,60 @@ void do_acjv_packet() {
 			}
 			rd16[0x20] = PacketID;
 		}
-		rd16[0x15] = 0x5210;
-		rd16[0x16] = 0x5210;
-		rd16[0x17] = 0x5210;
+		// ac_jvsif root field (0x2A/0x2C/0x2E): a board value the white-screen loader sums to pace a cosmetic bar.
+		// BG3 gets the bar-skip minimum 0x9C40 (instant boot); others keep 0x5210.
+		if (s_gameid == "NM00010" || s_gameid == "NM00015") {
+			rd16[0x15] = 0x9C40;
+			rd16[0x16] = 0x9C40;
+			rd16[0x17] = 0x9C40;
+		} else {
+			rd16[0x15] = 0x5210;
+			rd16[0x16] = 0x5210;
+			rd16[0x17] = 0x5210;
+		}
 	}
+}
+
+// Free-run the FCA-1 input frame for Ridge Racer V in the rdbuf (do_acjv_packet never runs for it).
+// RRV's init waits on the heartbeat @0x0e/0x0f, then reads steering/pedals/buttons. Ticked from DEV9async.
+void ACJV::UpdateFcaFrame()
+{
+	if (s_gameid != "NM00001")
+		return;
+
+	static u16 s_fcaCounter = 0;
+	s_fcaCounter++;                            // FCA-1 heartbeat — unblocks FUN_00229af0 case 1
+	rdbuf[0x0e] = (u8)(s_fcaCounter & 0xff);   // counter: low byte @0x0e, high byte @0x0f
+	rdbuf[0x0f] = (u8)(s_fcaCounter >> 8);
+
+	// FCA-1 raw range (FUN_0022ab70): steer center 0x8000 +-0x6400, pedals 0..0x5800.
+	const float steerf = std::clamp(m_wheelSteerR - m_wheelSteerL, -1.0f, 1.0f);
+	const u16 steerRaw = (u16)(0x8000 + (int)(steerf * 0x6400));
+	rdbuf[0x80] = (u8)(steerRaw & 0xff);
+	rdbuf[0x81] = (u8)(steerRaw >> 8);
+	const u16 gasRaw = (u16)(std::clamp(m_wheelGas, 0.0f, 1.0f) * 0x5800);
+	rdbuf[0x82] = (u8)(gasRaw & 0xff);
+	rdbuf[0x83] = (u8)(gasRaw >> 8);
+	const u16 brakeRaw = (u16)(std::clamp(m_wheelBrake, 0.0f, 1.0f) * 0x5800);
+	rdbuf[0x84] = (u8)(brakeRaw & 0xff);
+	rdbuf[0x85] = (u8)(brakeRaw >> 8);
+
+	// Buttons (FCA-1 digital inputs, active-high; bit assignments RE'd from I/O TEST FUN_0022bba8).
+	const u16 btn = m_jvsButtonState[0];
+	u8 b40 = 0, b41 = 0;
+	if (btn & JVS_BTN_3)       b40 |= 0x80; // R1       -> UP SHIFT (gear up)
+	if (btn & JVS_BTN_4)       b40 |= 0x40; // L1       -> DOWN SHIFT (gear down)
+	if (btn & JVS_BTN_2)       b41 |= 0x01; // Triangle -> VIEW CHANGE
+	if (btn & (JVS_BTN_START|JVS_BTN_1)) b41 |= 0x02; // Start / Square -> ENTER (confirm/start)
+	if (btn & JVS_BTN_UP)      b41 |= 0x20; // DPad Up   -> UP SELECT
+	if (btn & JVS_BTN_DOWN)    b41 |= 0x10; // DPad Down -> DOWN SELECT
+	if (btn & JVS_BTN_SERVICE) b41 |= 0x40; // Select   -> SERVICE (adds a service credit)
+	rdbuf[0x40] = b40;
+	rdbuf[0x41] = b41;
+
+	// TEST switch (rdbuf[0xe2] b7): RRV's FCA path bypasses the standard DIP register, so feed Test Mode here.
+	rdbuf[0xe2] = (s_dip_switch_state & TESTMODE) ? 0x80 : 0;
+
+	// COIN: FCA-1 coin counter @rdbuf[0xc0]; RRV credits on increase (FUN_0022aa88). Mirror our coin count.
+	rdbuf[0xc0] = (u8)m_coin1;
 }

--- a/pcsx2/DEV9/ACJV.h
+++ b/pcsx2/DEV9/ACJV.h
@@ -32,7 +32,8 @@ enum BOARDID {
 	FCA_1_JPN_MULTIPURPOSE,
 	FCB_JPN_TOUCHPANEL,
 	TSS_GUN_EXTENTION,
-	MIU_IO_JPN_GUN_EXTENTI
+	MIU_IO_JPN_GUN_EXTENTI,
+	TAITO_BG3_IO_PCB
 };
 
 enum class JVS_MODE {
@@ -51,6 +52,13 @@ enum class FightingLayout {
 	SIX_BUTTON, // Sw1-6:     Square, Triangle, L1, Cross, Circle, R1 — JAM
 	SOULCAL,    // Sw1,2,3,4: Square, Triangle, Circle, Cross         — SC2, SC3, KN1, KN2, BAX, FUD
 	BLOODYROAR, // Sw1,2,3,4: Square, Cross, Circle, Triangle         — BR3
+};
+
+enum class RacingLayout {
+	ACEDRIVER3, // NM00047: GEAR UP=Sw3(L1), GEAR DOWN=Sw4(R1), VIEW CHANGE=Push9(Triangle), ENTER=Sw1
+	BG3,        // NM00010/15: SHIFT UP=R1, SHIFT DOWN=L1, VIEW=Triangle, SIDEBRAKE=Square, HAZARD=Circle
+	WANGAN,     // NM00008/05: SHIFT UP=R1, SHIFT DOWN=L1, SELECT=D-pad, SERVICE=Select
+	RRV,        // NM00001: SHIFT UP=R1, SHIFT DOWN=L1, VIEW=Triangle, ENTER=Square, SELECT=D-pad, SERVICE=Select
 };
 
 #define JVS_WHEEL_CHANNEL_MAX 3
@@ -87,6 +95,8 @@ namespace ACJV {
 
     u16 Read16(u32 addr);
     void Write16(u32 addr, u16 val);
+    void UpdateFcaFrame(); // Ridge Racer V: refresh the FCA-1 I/O board's input buffer every frame (steering/pedals/buttons)
+    void OnBoardStart();   // set the JVS I/O board firmware version at power-on (Battle Gear 3 Tuned reads it before its first command)
     extern enum BOARDID CurrentBoardID;
 
     std::span<const DIPSwitchInfo> GetDIPSwitches();
@@ -98,7 +108,12 @@ namespace ACJV {
     std::span<const InputBindingInfo> GetButtonBindings();
     std::span<const InputBindingInfo> GetP2ButtonBindings();
     std::span<const InputBindingInfo> GetCoinBindings();
+    std::span<const InputBindingInfo> GetWheelBindings();
     void SetButtonState(u32 player, u16 mask, bool pressed);
+    void SetWheelAxis(u32 axis, float value);
+    float GetSteer(); // host steering, -1 (full left)...+1 (full right); used by the BG3 drive-board responder (acuart)
+    float GetGas();   // host accelerator, 0...1
+    float GetBrake(); // host brake, 0...1
     void InsertCoin(u32 slot);
 
     bool GetDIPSwitchState(u32 index);
@@ -187,6 +202,7 @@ enum JVSButton : u16 {
     JVS_BTN_4       = 0x4000,
     JVS_BTN_5       = 0x2000,
     JVS_BTN_6       = 0x1000,
+    JVS_BTN_9       = 0x0200, // Ace Driver 3 wires VIEW CHANGE to Push9.
 };
 
 

--- a/pcsx2/DEV9/ACRAM.cpp
+++ b/pcsx2/DEV9/ACRAM.cpp
@@ -24,12 +24,11 @@ u16 ACRAM::Read16(u32 addr) {
     return 0;
 }
 
-// Per-bank pointer tracking: real ACRAM has 2 independent banks with separate DMA controllers.
-// Without this, bank 1 writes (streaming) overwrite bank 0 pointers (disc cache), corrupting
-// the source table and hanging the game at load. Ref: ps2sdk acram/src/ram.c
+// Track DMA pointers per bank (ACRAM_NUM_BANKS): without this, one bank's streaming writes clobber
+// another bank's data/pointers and the game hangs at load. Ref: ps2sdk acram/src/ram.c
 void ACRAM::Write16(u32 addr, u16 val) {
     u32 offset = addr - ACRAM_ADDR_BASE;
-    int bank = (offset >> 21) & 1; // bit 21 selects bank: 64MB = 2x32MB (e.g. TK4: bank0=disc cache, bank1=streaming)
+    int bank = (offset >> 21) & (ACRAM_NUM_BANKS - 1); // address bits 21+ pick the bank
     u32 reg = offset & ACRAM_REG_MASK;
     u32 bank_base = bank * ACRAM_BANK_SIZE;
 
@@ -56,8 +55,8 @@ void ACRAM::Write16(u32 addr, u16 val) {
         OOB_REPORT(addr);
 }
 
-int ACRAM::BankFromDmaTarget(u32 dma_target) { // same bit 21 bank select as Write16
-    return ((dma_target - ACRAM_ADDR_BASE) >> 21) & 1;
+int ACRAM::BankFromDmaTarget(u32 dma_target) { // same bank select as Write16
+    return ((dma_target - ACRAM_ADDR_BASE) >> 21) & (ACRAM_NUM_BANKS - 1);
 }
 
 void ACRAM::DmaRead(u32* iop_buf, u32 size_bytes, int bank) {

--- a/pcsx2/DEV9/ACRAM.h
+++ b/pcsx2/DEV9/ACRAM.h
@@ -26,9 +26,9 @@
 
 #define ACRAM_ADDR_BASE   0x14000000
 #define ACRAM_RANGE       0x1400
-#define ACRAM_MAX_SIZE    _64mb
+#define ACRAM_MAX_SIZE    (_64mb * 2)
 #define ACRAM_BANK_SIZE   0x2000000  // 32MB per bank
-#define ACRAM_NUM_BANKS   2
+#define ACRAM_NUM_BANKS   4          // most games use 1 bank; TK4 needs 2, Wangan 4 (its RAM expansion). Use the max.
 #define ACRAM_REG_READ    0x60000
 #define ACRAM_REG_WRITE   0x70000
 #define ACRAM_REG_MASK    0x1FFFFF   // isolate register offset within bank

--- a/pcsx2/DEV9/ACUART.cpp
+++ b/pcsx2/DEV9/ACUART.cpp
@@ -1,5 +1,9 @@
 #include "ACUART.h"
+#include "ACJV.h"
+#include "ACCORE.h"
 #include "common/Console.h"
+#include <deque>
+#include <string>
 
 // 16550 UART register emulation for Namco System 246 arcade I/O
 // Ref: ps2sdk iop/arcade/acuart/src/uart.c
@@ -21,12 +25,28 @@ static u16 uart_dll = 0;
 static u16 uart_dlh = 0;
 static u16 uart_fcr_shadow = 0;
 
+// State for Battle Gear 3's boot handshake with its steering ("HANDLE") board; cleared each boot by ResetBg3State.
+static int s_bg3TxCnt = 0;
+static u8 s_bg3PrevTx = 0;
+static int s_bg3HandleCycles = 0;
+static bool s_bg3HandleDone = false; // false during the boot HANDLE handshake, true once past it
+
+static std::deque<u8> s_v257RxFifo;                   // bytes Ridge Racer V reads back from its drive board
+static u32 s_v257Accum = 0;                           // throttles the periodic refill
+static constexpr u8 V257_STATUS[3] = {'E', '0', '0'}; // "E00" = no error; RRV won't boot until it reads this
+
 u16 ACUART::Read16(u32 addr) {
 	const u32 reg = addr & 0xFFF;
 	switch (reg) {
 	case 0x000: // RBR or DLL
 		if (uart_lcr & 0x80)
 			return uart_dll;
+		if (!s_v257RxFifo.empty()) // RRV reading the serial port: hand it the next status byte we queued ("E00")
+		{
+			const u8 b = s_v257RxFifo.front();
+			s_v257RxFifo.pop_front();
+			return b;
+		}
 		return 0; // no RX data
 	case 0x002: // IER or DLH
 		if (uart_lcr & 0x80)
@@ -42,7 +62,8 @@ u16 ACUART::Read16(u32 addr) {
 		// bit 5 = THRE (TX holding register empty)
 		// bit 6 = TEMT (TX shift register empty)
 		// both set = transmitter idle, ready to accept data
-		return 0x60;
+		// bit 0 = DR (RX data ready) — set while the V257 status FIFO has bytes (RRV)
+		return 0x60 | (s_v257RxFifo.empty() ? 0x00 : 0x01);
 	case 0x00C: // MSR
 		return 0;
 	case 0x00E: // SCR
@@ -52,13 +73,50 @@ u16 ACUART::Read16(u32 addr) {
 	}
 }
 
+// Battle Gear 3 / Tuned: answer the steering board's boot handshake (BGRLOAD FUN_00133e60) so the game
+// doesn't stall on "HANDLE ERROR". With no emulated FFB board we reply ready and keep the drive-board flag
+// (EE 0x2694b0) CLEAR, so steering stays on the JVS analog wheel. FFB GROUNDWORK: set s_bg3FfbEnabled=true
+// when a real drive board is emulated to run the full calibration handshake.
+// (Thanks to Hydreigon223 for the dump.)
+static void Bg3HandleReply(u8 curTx)
+{
+	s_bg3TxCnt++;
+	if ((s_bg3TxCnt & 1) != 0) { s_bg3PrevTx = curTx; return; } // a {reg,val} command is 2 bytes; reply on the 2nd
+
+	if (s_bg3PrevTx == 0x20 && curTx == 0x00) // {0x20,0} starts an init -> re-arm so a re-init replies fresh
+	{
+		s_bg3HandleDone = false;
+		s_bg3HandleCycles = 0;
+	}
+	u8 hi = 0x00;
+	if (!s_bg3HandleDone)
+	{
+		static constexpr bool s_bg3FfbEnabled = false;    // true once a real FFB drive board is emulated
+		if (s_bg3PrevTx == 0x20 || s_bg3PrevTx == 0x1f)
+			hi = s_bg3FfbEnabled ? 0x80 : 0x01;           // 0x01 = ready (skip calibrate while FFB off)
+		else if (s_bg3PrevTx == 0x14 && curTx == 0x1a)
+			hi = (++s_bg3HandleCycles > 4) ? 0x00 : 0x80; // calibrate busy-loop (FFB on only)
+		if (s_bg3PrevTx == 0x11 && curTx == 0x03)
+			s_bg3HandleDone = true;                       // last init command
+	}
+	s_v257RxFifo.push_back(hi); // byte0 = busy/ready status
+	s_v257RxFifo.push_back(0);  // byte1
+	ACCORE::intr(ACCORE::INTRN_UART);
+	s_bg3PrevTx = curTx;
+}
+
 void ACUART::Write16(u32 addr, u16 val) {
 	const u32 reg = addr & 0xFFF;
 	switch (reg) {
 	case 0x000: // THR or DLL
 		if (uart_lcr & 0x80)
 			uart_dll = val;
-		// else: TX data — silently consumed
+		else // TX byte to the drive board
+		{
+			const std::string& gdrv = ACJV::GetGameId();
+			if (gdrv == "NM00010" || gdrv == "NM00015")
+				Bg3HandleReply((u8)val); // BG3/Tuned: answer the HANDLE handshake (other games ignore TX)
+		}
 		break;
 	case 0x002: // IER or DLH — set to 0 on module stop, bits toggled during xmit (acUartModuleStop, uart_xmit)
 		if (uart_lcr & 0x80)
@@ -81,4 +139,43 @@ void ACUART::Write16(u32 addr, u16 val) {
 	default:
 		break;
 	}
+}
+
+void ACUART::ResetBg3State()
+{
+	// Re-arm the BG3 HANDLE handshake on each game boot/reset, else a reset stalls on "HANDLE ERROR".
+	s_bg3TxCnt = 0;
+	s_bg3PrevTx = 0;
+	s_bg3HandleCycles = 0;
+	s_bg3HandleDone = false;
+}
+
+// Ridge Racer V drive-board status streamer (called each DEV9 tick): refill the receive buffer with the
+// board's status ("E00", or "C01" once FFB is on) and raise the RX interrupt. Only RRV needs this.
+void ACUART::StreamV257(u32 cycles)
+{
+	const std::string& gid2 = ACJV::GetGameId();
+	if (gid2 == "NM00010" || gid2 == "NM00015")
+		return; // BG3: the HANDLE responder is driven synchronously from Write16; leave the RX FIFO intact
+	if (gid2 != "NM00001") // only Ridge Racer V needs the streaming responder
+	{
+		s_v257RxFifo.clear();
+		return;
+	}
+	if (!(uart_ier & 0x01))        // host hasn't enabled the RX-data interrupt yet
+		return;
+	s_v257Accum += cycles;
+	if (s_v257Accum < 240)         // throttle (DEV9async ticks ~tens of kHz with cycles=1) -> a few hundred Hz
+		return;
+	s_v257Accum = 0;
+	// Keep raising the RX IRQ every tick; reload the status only once the ISR has drained the previous copy.
+	if (s_v257RxFifo.empty())
+	{
+		// "E00" = no error; switch to "C01" once the FFB motor is on (EE 0x1f0d008), else MOTOR ERROR 20 after ~30s.
+		static constexpr u8 V257_C01[3] = {'C', '0', '1'};
+		const u8* mm = eeMem ? eeMem->Main : nullptr;
+		const u8* st = (mm && mm[0x01f0d008] >= 1) ? V257_C01 : V257_STATUS;
+		s_v257RxFifo.assign(st, st + 3);
+	}
+	ACCORE::intr(ACCORE::INTRN_UART); // raise the UART RX interrupt
 }

--- a/pcsx2/DEV9/ACUART.h
+++ b/pcsx2/DEV9/ACUART.h
@@ -7,4 +7,6 @@
 namespace ACUART {
     u16 Read16(u32 addr);
     void Write16(u32 addr, u16 val);
+    void StreamV257(u32 cycles); // V257 drive-board status responder, ticked from DEV9async (RRV)
+    void ResetBg3State();        // clear BG3 acuart HANDLE-handshake state on game boot (fixes HANDLE-ERROR-on-reset)
 }

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -8,6 +8,8 @@
 #include "IopDma.h"
 #include "ACATA.h"
 #include "ACCORE.h"
+#include "ACUART.h"
+#include "ACJV.h"
 #include "ACRAM.h"
 #include "IopHw.h"
 
@@ -1172,6 +1174,8 @@ void DEV9async(u32 cycles)
 {
 	smap_async(cycles);
 	dev9.ata->Async(cycles);
+	ACUART::StreamV257(cycles); // Ridge Racer V self-test: stream the V257 drive-board status...
+	ACJV::UpdateFcaFrame();     // ...and free-run the FCA-1 input frame
 }
 
 void DEV9CheckChanges(const Pcsx2Config& old_config)

--- a/pcsx2/DEV9/smap.cpp
+++ b/pcsx2/DEV9/smap.cpp
@@ -15,8 +15,18 @@
 #include "smap.h"
 #include "net.h"
 #include "pcap_io.h"
+#include "ACJV.h" // ACJV::GetGameId (phyLinkUp)
+#include <string>
 
 bool has_link = true;
+
+static bool phyLinkUp()
+{
+	const std::string& gameId = ACJV::GetGameId();
+	if (gameId == "NM00010" || gameId == "NM00015")
+		return false; // BG3/Tuned: no Ethernet link -> NESYS sees "no network" and boots standalone
+	return has_link;
+}
 volatile bool fireIntR = false;
 std::mutex frame_counter_mutex;
 std::mutex reset_mutex;
@@ -286,11 +296,11 @@ void emac3_write(u32 addr)
 					switch (reg)
 					{
 						case SMAP_DsPHYTER_BMSR:
-							if (has_link)
+							if (phyLinkUp())
 								val |= SMAP_PHY_BMSR_LINK | SMAP_PHY_BMSR_ANCP;
 							break;
 						case SMAP_DsPHYTER_PHYSTS:
-							if (has_link)
+							if (phyLinkUp())
 								val |= SMAP_PHY_STS_LINK | SMAP_PHY_STS_100M | SMAP_PHY_STS_FDX | SMAP_PHY_STS_ANCP;
 							break;
 					}

--- a/pcsx2/Input/InputManager.cpp
+++ b/pcsx2/Input/InputManager.cpp
@@ -960,6 +960,45 @@ void InputManager::AddJVSBindings(SettingsInterface& si, bool is_profile)
 				ACJV::InsertCoin(slot);
 		}}, InputBindingInfo::Type::Button, si, ACJV::CONFIG_SECTION, bi.name, is_profile);
 	}
+
+	// driving analog axes (steer/gas/brake) -> JVS wheel channels, mirroring the button bindings above
+	for (const InputBindingInfo& bi : ACJV::GetWheelBindings())
+	{
+		const std::vector<std::string> bindings(si.GetStringList(ACJV::CONFIG_SECTION, bi.name));
+		if (bindings.empty())
+			continue;
+
+		AddBindings(bindings, InputAxisEventHandler{[axis = static_cast<u32>(bi.bind_index)](InputBindingKey key, float value) {
+			ACJV::SetWheelAxis(axis, value);
+		}}, bi.bind_type, si, ACJV::CONFIG_SECTION, bi.name, is_profile);
+	}
+
+	if (const Pad::ControllerInfo* pad_ci = Pad::GetControllerInfo(EmuConfig.Pad.Ports[0].Type))
+	{
+		const std::string pad_section = Pad::GetConfigSection(0);
+		// apply Port 1's deadzone to the auto-mirrored wheel (the JVS path skips the pad's own, so a worn stick drifts)
+		const float stick_deadzone = si.GetFloatValue(pad_section.c_str(), "Deadzone", Pad::DEFAULT_STICK_DEADZONE);
+		const float trig_deadzone = si.GetFloatValue(pad_section.c_str(), "ButtonDeadzone", Pad::DEFAULT_BUTTON_DEADZONE);
+		for (const InputBindingInfo& jvs_bi : ACJV::GetWheelBindings())
+		{
+			for (const InputBindingInfo& pad_bi : pad_ci->bindings)
+			{
+				if (pad_bi.generic_mapping != jvs_bi.generic_mapping)
+					continue;
+
+				// steering (axes 0/1) uses the analog deadzone; gas/brake (2/3) the trigger deadzone
+				const float deadzone = (jvs_bi.bind_index <= 1) ? stick_deadzone : trig_deadzone;
+				const std::vector<std::string> pad_bindings(si.GetStringList(pad_section.c_str(), pad_bi.name));
+				for (const std::string& pb : pad_bindings)
+				{
+					AddBinding(pb, InputAxisEventHandler{[axis = static_cast<u32>(jvs_bi.bind_index), deadzone](InputBindingKey key, float value) {
+						ACJV::SetWheelAxis(axis, ApplySingleBindingScale(1.0f, deadzone, value));
+					}});
+				}
+				break;
+			}
+		}
+	}
 }
 
 void InputManager::AddPadBindings(SettingsInterface& si, u32 pad_index, bool is_profile)

--- a/pcsx2/MemoryTypes.h
+++ b/pcsx2/MemoryTypes.h
@@ -30,7 +30,7 @@ namespace Ps2MemSize
 // sizes for SYSTEM2x6 namco board components
 namespace NamcoMemSize
 {
-	static constexpr u32 ACRAM = _64mb; // can be 0, 32 or 64mb depending on wich system2x6. use largest for simplicity
+	static constexpr u32 ACRAM = _64mb * 2; // largest System2x6 ACRAM (128MB): Wangan's RAM expansion; allocate the max
 	static constexpr u32 ACSRAM = _32kb; // Settings Static memory. always 32kb. used for game settings
 }
 

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -742,7 +742,10 @@ void VMManager::ApplyGameFixes()
 	if (!s_acgame.empty())
 	{
 		if (const auto* game = GameDatabase::findGame(ACJV::GetGameId()))
+		{
+			game->applyGameFixes(EmuConfig, EmuConfig.EnableGameFixes);
 			game->applyGSHardwareFixes(EmuConfig.GS);
+		}
 	}
 
 	if (!HasBootedELF() && !GSDumpReplayer::IsReplayingDump())
@@ -1391,6 +1394,11 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 					{
 						ACJV::SetMode(JVS_MODE::FIGHTING);
 						Console.WriteLn(Color_Green, "ACGAME: jvsmode=fighting");
+					}
+					else if (jvsmode == "racing")
+					{
+						ACJV::SetMode(JVS_MODE::DRIVE);
+						Console.WriteLn(Color_Green, "ACGAME: jvsmode=racing");
 					}
 					else
 						ACJV::SetMode(JVS_MODE::DEFAULT);


### PR DESCRIPTION
Adds JVS analog driving input and the per-board emulation for WN1; WNR; BG3; BG3T; RRV. They need it to boot.

Promote to playable:

- NM00001 | Ridge Racer V - Arcade Battle (fixes #41 )
- NM00005 | Wangan Midnight R (fixes #42 )
- NM00008 | Wangan Midnight
- NM00010 | Battle Gear 3
- NM00015 | Battle Gear 3 Tuned
- NM00039 | MotoGP
- NM00047 | Ace Driver 3 - Final Turn

Some specifics beyond JVS input:

**Ridge Racer V:**
- Emulate the FCA-1 input board and the V257 drive board over the ACJV/ACUART link so the steering self-test passes
- Add GameDB GS fixes for many HW rendering issues (took from PCSX2 default patches)


**Wangan Midnight / R:**
- Expand ACRAM to 128MB (these run with the cabinet's 64MB RAM expansion (thanks to Franco23444 for the hint)


**Battle Gear 3/Tuned:**
- Boot from HDD (ATA init fix)
- Answer the Taito P-DRIVE HANDLE handshake in UART complexity (that thing was killing me)
- Report the JVS board firmware version (black screen otherwise, per MAME documentation and RE analysis)
- Add full-clamp hack to VU or the game renders corrupt gameplay data (flying car upside down, fall under the ground, etc)

I've commented out the initial-polling scaffold hack too (I've tested all games without it, it works fine. Hack if obsolete):

```
if (x == 2 || x == 3 || x == 4) return rdbuf.at(x)|1;// initial polling expects these addrs to not be zero
```

Wired the GUI analog/trigger deadzone onto the mirrored wheel to avoid drifting on cheap or used controllers (very useful because arcade racing games are insanely precise).

TO DO:
- Steering wheel support
- FFB support
- Fix coin bug (that one is funny actually)