### PR TITLE
JVS: input layouts for standard and twin-stick games (2/2)

### DIFF
--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -152,6 +152,25 @@ static void UpdateFightingBindings(FightingLayout layout)
 	}
 }
 
+static constexpr GenericInputBinding s_standard_face_buttons[][6] = { // one row per game, BTN1-6 -> pad button
+	{GenericInputBinding::Square, GenericInputBinding::Triangle, GenericInputBinding::L1,      GenericInputBinding::Cross,   GenericInputBinding::Circle,  GenericInputBinding::R1},      // BASEBALL
+	{GenericInputBinding::Cross,  GenericInputBinding::Square,   GenericInputBinding::Unknown, GenericInputBinding::Unknown, GenericInputBinding::Unknown, GenericInputBinding::Unknown}, // SMASHCOURT
+	{GenericInputBinding::Cross,  GenericInputBinding::Square,   GenericInputBinding::Triangle, GenericInputBinding::Unknown, GenericInputBinding::Unknown, GenericInputBinding::Unknown}, // TECHNICBEAT
+};
+
+static void UpdateStandardBindings(StandardLayout layout)
+{
+	s_active_p1_bindings = s_jvs_p1_button_bindings;
+	s_active_p2_bindings = s_jvs_p2_button_bindings;
+	const auto& face = s_standard_face_buttons[static_cast<int>(layout)];
+	constexpr int BTN1_INDEX = 4;
+	for (int i = 0; i < 6; i++)
+	{
+		s_active_p1_bindings[BTN1_INDEX + i].generic_mapping = face[i];
+		s_active_p2_bindings[BTN1_INDEX + i].generic_mapping = face[i];
+	}
+}
+
 // Generic racing layout (BTN1-6): each entry sets its own JVS bit, so a game can wire switches beyond Sw1-6 (e.g. AD3's Push9).
 struct RacingButton { u16 bind_index; GenericInputBinding host; };
 static constexpr RacingButton s_racing_buttons[][6] = {
@@ -311,14 +330,14 @@ static JVS_MODE m_jvsMode = JVS_MODE::DEFAULT;
 
 std::span<const InputBindingInfo> ACJV::GetButtonBindings()
 {
-	if (m_jvsMode == JVS_MODE::FIGHTING || m_jvsMode == JVS_MODE::DRIVE)
+	if (m_jvsMode == JVS_MODE::FIGHTING || m_jvsMode == JVS_MODE::DRIVE || m_jvsMode == JVS_MODE::STANDARD)
 		return s_active_p1_bindings;
 	return s_jvs_p1_button_bindings;
 }
 
 std::span<const InputBindingInfo> ACJV::GetP2ButtonBindings()
 {
-	if (m_jvsMode == JVS_MODE::FIGHTING || m_jvsMode == JVS_MODE::DRIVE)
+	if (m_jvsMode == JVS_MODE::FIGHTING || m_jvsMode == JVS_MODE::DRIVE || m_jvsMode == JVS_MODE::STANDARD)
 		return s_active_p2_bindings;
 	return s_jvs_p2_button_bindings;
 }
@@ -499,6 +518,12 @@ static const std::map<std::string, RacingLayout> s_racing_layouts = {
 	{"NM00001", RacingLayout::RRV},          // Ridge Racer V (discovery sweep)
 };
 
+static const std::map<std::string, StandardLayout> s_standard_layouts = {
+	{"NM00009", StandardLayout::BASEBALL},    // Netchu Pro Baseball 2002
+	{"NM00006", StandardLayout::SMASHCOURT},  // Smash Court Pro Tournament
+	{"NM00003", StandardLayout::TECHNICBEAT}, // Technic Beat (shares gameid with VPN)
+};
+
 // Gamepad input -> JVS button state: set or clear a button bit for a player
 void ACJV::SetButtonState(u32 player, u16 mask, bool pressed)
 {
@@ -604,6 +629,7 @@ void ACJV::SetGameId(const std::string& gameid)
 
 	auto fit = s_fighting_layouts.find(gameid);
 	auto rit = s_racing_layouts.find(gameid);
+	auto sit = s_standard_layouts.find(gameid);
 	if (fit != s_fighting_layouts.end())
 	{
 		constexpr const char* layout_names[] = {"tekken", "gundam", "6-button", "soulcalibur", "bloodyroar"};
@@ -615,6 +641,12 @@ void ACJV::SetGameId(const std::string& gameid)
 		constexpr const char* racing_names[] = {"acedriver3", "bg3", "wangan", "rrv"};
 		Console.WriteLn("ACJV: racing layout for %s: %s", gameid.c_str(), racing_names[static_cast<int>(rit->second)]);
 		UpdateRacingBindings(rit->second);
+	}
+	else if (sit != s_standard_layouts.end())
+	{
+		constexpr const char* standard_names[] = {"baseball", "smashcourt", "technicbeat"};
+		Console.WriteLn("ACJV: standard layout for %s: %s", gameid.c_str(), standard_names[static_cast<int>(sit->second)]);
+		UpdateStandardBindings(sit->second);
 	}
 	else
 	{

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -519,6 +519,7 @@ static const std::map<std::string, FightingLayout> s_fighting_layouts = {
 	{"NM00027", FightingLayout::TEKKEN},     // Super Dragon Ball Z
 	{"NM00029", FightingLayout::SOULCAL},    // Kinnikuman MGP
 	{"NM00035", FightingLayout::GUNDAM},     // YuYu Hakusho
+	{"NM00030", FightingLayout::GUNDAM},     // Mobile Suit Gundam Quiz Warrior (quiz, same 4-button layout)
 	{"NM00040", FightingLayout::SOULCAL},    // Kinnikuman MGP 2
 	{"NM00011", FightingLayout::TEKKEN},     // Pride GP 2003
 	{"NM00018", FightingLayout::SIX_BUTTON}, // Capcom Fighting Jam

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -120,6 +120,25 @@ static constexpr const std::array<InputBindingInfo, 4> s_jvs_wheel_bindings = {{
 	{"Brake",      TRANSLATE_NOOP("JVS", "Brake"),          nullptr, InputBindingInfo::Type::HalfAxis, 3, GenericInputBinding::L2},
 }};
 
+// Zoids twin-stick (NM00016/25): custom JVS switch-word wiring, mapped live via the I/O-TEST SWITCH TEST.
+// Left lever -> left stick, right lever -> right stick; Start/Service on the standard JVS bits.
+static constexpr const std::array<InputBindingInfo, 14> s_twinstick_p1_button_bindings = {{
+	{"P1_LLeverUp",    TRANSLATE_NOOP("JVS", "P1 Left Lever Up"),     nullptr, InputBindingInfo::Type::HalfAxis, 0x0001, GenericInputBinding::LeftStickUp},
+	{"P1_LLeverDown",  TRANSLATE_NOOP("JVS", "P1 Left Lever Down"),   nullptr, InputBindingInfo::Type::HalfAxis, 0x8000, GenericInputBinding::LeftStickDown},
+	{"P1_LLeverLeft",  TRANSLATE_NOOP("JVS", "P1 Left Lever Left"),   nullptr, InputBindingInfo::Type::HalfAxis, 0x4000, GenericInputBinding::LeftStickLeft},
+	{"P1_LLeverRight", TRANSLATE_NOOP("JVS", "P1 Left Lever Right"),  nullptr, InputBindingInfo::Type::HalfAxis, 0x2000, GenericInputBinding::LeftStickRight},
+	{"P1_RLeverUp",    TRANSLATE_NOOP("JVS", "P1 Right Lever Up"),    nullptr, InputBindingInfo::Type::HalfAxis, 0x0010, GenericInputBinding::RightStickUp},
+	{"P1_RLeverDown",  TRANSLATE_NOOP("JVS", "P1 Right Lever Down"),  nullptr, InputBindingInfo::Type::HalfAxis, 0x0008, GenericInputBinding::RightStickDown},
+	{"P1_RLeverLeft",  TRANSLATE_NOOP("JVS", "P1 Right Lever Left"),  nullptr, InputBindingInfo::Type::HalfAxis, 0x0004, GenericInputBinding::RightStickLeft},
+	{"P1_RLeverRight", TRANSLATE_NOOP("JVS", "P1 Right Lever Right"), nullptr, InputBindingInfo::Type::HalfAxis, 0x0002, GenericInputBinding::RightStickRight},
+	{"P1_LTrigger",    TRANSLATE_NOOP("JVS", "P1 Left Trigger"),      nullptr, InputBindingInfo::Type::HalfAxis, 0x0400, GenericInputBinding::L2},
+	{"P1_RTrigger",    TRANSLATE_NOOP("JVS", "P1 Right Trigger"),     nullptr, InputBindingInfo::Type::HalfAxis, 0x1000, GenericInputBinding::R2},
+	{"P1_LButton",     TRANSLATE_NOOP("JVS", "P1 Left Button"),       nullptr, InputBindingInfo::Type::Button,   0x0200, GenericInputBinding::L1},
+	{"P1_RButton",     TRANSLATE_NOOP("JVS", "P1 Right Button"),      nullptr, InputBindingInfo::Type::Button,   0x0800, GenericInputBinding::R1},
+	{"P1_Start",       TRANSLATE_NOOP("JVS", "P1 Start"),            nullptr, InputBindingInfo::Type::Button,   JVS_BTN_START,   GenericInputBinding::Start},
+	{"P1_Service",     TRANSLATE_NOOP("JVS", "P1 Service"),          nullptr, InputBindingInfo::Type::Button,   JVS_BTN_SERVICE, GenericInputBinding::Select},
+}};
+
 // Per-layout face button default inputs (BTN1-6), mirroring each game's
 // official PS2 port pad. Some games share the same layout. Rows follow FightingLayout order.
 static constexpr GenericInputBinding s_fighting_face_buttons[][6] = {
@@ -330,6 +349,8 @@ static JVS_MODE m_jvsMode = JVS_MODE::DEFAULT;
 
 std::span<const InputBindingInfo> ACJV::GetButtonBindings()
 {
+	if (m_jvsMode == JVS_MODE::TWINSTICK)
+		return s_twinstick_p1_button_bindings;
 	if (m_jvsMode == JVS_MODE::FIGHTING || m_jvsMode == JVS_MODE::DRIVE || m_jvsMode == JVS_MODE::STANDARD)
 		return s_active_p1_bindings;
 	return s_jvs_p1_button_bindings;
@@ -337,6 +358,7 @@ std::span<const InputBindingInfo> ACJV::GetButtonBindings()
 
 std::span<const InputBindingInfo> ACJV::GetP2ButtonBindings()
 {
+	// Twin-stick (Zoids) is 1 player per cabinet (versus is networked), so no P2 layout.
 	if (m_jvsMode == JVS_MODE::FIGHTING || m_jvsMode == JVS_MODE::DRIVE || m_jvsMode == JVS_MODE::STANDARD)
 		return s_active_p2_bindings;
 	return s_jvs_p2_button_bindings;

--- a/pcsx2/DEV9/ACJV.h
+++ b/pcsx2/DEV9/ACJV.h
@@ -44,6 +44,7 @@ enum class JVS_MODE {
 	DRUM,
 	TOUCH,
 	STANDARD, // generic full 6-button group for games that fit no specific category
+	TWINSTICK, // dual-lever cabinets (Zoids): custom JVS bit wiring, 2 sticks + 2 triggers + 2 buttons
 };
 
 // Sw -> pad order per layout, mirroring each game's official PS2 port.

--- a/pcsx2/DEV9/ACJV.h
+++ b/pcsx2/DEV9/ACJV.h
@@ -43,6 +43,7 @@ enum class JVS_MODE {
 	DRIVE,
 	DRUM,
 	TOUCH,
+	STANDARD, // generic full 6-button group for games that fit no specific category
 };
 
 // Sw -> pad order per layout, mirroring each game's official PS2 port.
@@ -59,6 +60,12 @@ enum class RacingLayout {
 	BG3,        // NM00010/15: SHIFT UP=R1, SHIFT DOWN=L1, VIEW=Triangle, SIDEBRAKE=Square, HAZARD=Circle
 	WANGAN,     // NM00008/05: SHIFT UP=R1, SHIFT DOWN=L1, SELECT=D-pad, SERVICE=Select
 	RRV,        // NM00001: SHIFT UP=R1, SHIFT DOWN=L1, VIEW=Triangle, ENTER=Square, SELECT=D-pad, SERVICE=Select
+};
+
+enum class StandardLayout {
+	BASEBALL,    // NM00009: Netchu Pro Baseball (Sw1-6 superset)
+	SMASHCOURT,  // NM00006: Smash Court Pro (2 buttons)
+	TECHNICBEAT, // NM00003: Technic Beat (3 buttons)
 };
 
 #define JVS_WHEEL_CHANNEL_MAX 3

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1400,6 +1400,11 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 						ACJV::SetMode(JVS_MODE::DRIVE);
 						Console.WriteLn(Color_Green, "ACGAME: jvsmode=racing");
 					}
+					else if (jvsmode == "standard")
+					{
+						ACJV::SetMode(JVS_MODE::STANDARD);
+						Console.WriteLn(Color_Green, "ACGAME: jvsmode=standard");
+					}
 					else
 						ACJV::SetMode(JVS_MODE::DEFAULT);
 				}

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1405,6 +1405,11 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 						ACJV::SetMode(JVS_MODE::STANDARD);
 						Console.WriteLn(Color_Green, "ACGAME: jvsmode=standard");
 					}
+					else if (jvsmode == "twinstick")
+					{
+						ACJV::SetMode(JVS_MODE::TWINSTICK);
+						Console.WriteLn(Color_Green, "ACGAME: jvsmode=twinstick");
+					}
 					else
 						ACJV::SetMode(JVS_MODE::DEFAULT);
 				}


### PR DESCRIPTION
(Part 2/2)
3 commits adding proper JVS button layouts for several games (each game gets its own map).

1. Standard layouts: add a "standard" input mode  (`jvsmode=standard`) for games that fit none of the existing ones. In this PR, three games:  Netchuu! Pro Yakyuu 2002 (6 buttons but seems to use 3 only), Smash Court Pro (2 buttons), Technic Beat (3 buttons).
2. Twin-stick layout: add a twin-stick mode (`jvsmode=twinstick`) for Zoids cabinets. In short: 2 dpad levers: left lever to the left stick, right lever to the right stick, plus the two triggers (L2/R2) and two buttons (L1/R1).
3. Quiz Gundam: reuse the existing Gundam fighting layout, since it answers with the same four buttons. Not a fighting game tho, but it's the same series.

PROMOTE TO PLAYABLE THE FOLLOWING GAMES:
- NM00003 | Technic Beat
- NM00006 | Smash Court Pro Tournament
- NM00009 | Netchuu! Pro Baseball 2002
- NM00016 | Zoids Infinity
- NM00025 | Zoids Infinity - EX
- NM00030 | Mobile Suit Gundam Quiz Warrior

Tested ALL games, no regression.
