### PR TITLE
JVS: add initial support to Taiko games (JVS tab)

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -161,6 +161,8 @@ NM00023:
   bootprog: TA7LOAD
   media: DVD
   input: drum
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 NM00024:
   name: Mobile Suit Gundam SEED - Federation vs. Z.A.F.T.
   region: System246
@@ -230,6 +232,8 @@ NM00033:
   bootprog: TA8LOAD
   media: DVD
   input: drum
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 NM00034:
   name: Mobile Suit Gundam SEED Destiny - Federation vs. Z.A.F.T. II
   region: System256
@@ -260,6 +264,8 @@ NM00038:
   bootprog: TA9LOAD
   media: DVD
   input: drum
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 NM00039:
   name: MotoGP
   region: System256
@@ -278,6 +284,8 @@ NM00041:
   bootprog: T10LOAD
   media: DVD
   input: drum
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 NM00042:
   name: Sengoku Basara X
   region: System246
@@ -296,6 +304,8 @@ NM00044:
   bootprog: T11LOAD
   media: DVD
   input: drum
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 NM00045:
   name: Taiko Drum Master 11 Asian Edition Taiwan
   region: System256
@@ -326,6 +336,8 @@ NM00051:
   bootprog: T12LOAD
   media: HDD
   input: drum
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 NM00052:
   name: Mobile Suit Gundam - Gundam vs. Gundam NEXT
   region: System256
@@ -350,9 +362,13 @@ NM00056:
   bootprog: T13LOAD
   media: HDD
   input: drum
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.
 NM00057:
   name: Taiko Drum Master 14
   region: System256
   bootprog: T14LOAD
   media: HDD
   input: drum
+  gsHWFixes:
+    alignSprite: 1 # Fixes vertical lines.

--- a/pcsx2-qt/Settings/JVSControlsWidget.cpp
+++ b/pcsx2-qt/Settings/JVSControlsWidget.cpp
@@ -11,6 +11,7 @@
 
 #include <QtCore/QCoreApplication>
 #include <QtWidgets/QGridLayout>
+#include <QtWidgets/QGroupBox>
 #include <QtWidgets/QLabel>
 
 JVSControlsWidget::JVSControlsWidget(QWidget* parent, ControllerSettingsWindow* dialog)
@@ -25,6 +26,7 @@ JVSControlsWidget::JVSControlsWidget(QWidget* parent, ControllerSettingsWindow* 
 
 	bindDIPSwitchWidgets();
 	bindSystemButtonWidgets();
+	bindDrumWidgets();
 
 	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(m_dialog->getProfileSettingsInterface(), m_ui.suppressDaemon,
 		ACJV::CONFIG_SECTION, "SuppressDaemon", true);
@@ -90,6 +92,43 @@ void JVSControlsWidget::bindSystemButtonWidgets()
 		bind->setMaximumWidth(225);
 		layout->addWidget(bind, i, 1);
 	}
+}
+
+void JVSControlsWidget::bindDrumWidgets()
+{
+	SettingsInterface* sif = m_dialog->getProfileSettingsInterface();
+
+	QGroupBox* group = new QGroupBox(tr("Taiko Drum"), this);
+	QGridLayout* layout = new QGridLayout(group);
+
+	struct DrumEntry {
+		const char* label;
+		const char* config_key;
+	};
+	// config_key must match the s_jvs_drum_bindings names in ACJV.cpp (which carry the real analog channels).
+	static constexpr DrumEntry entries[] = {
+		{"P1 Don Left (inner, red)", "P1_DonLeft"},
+		{"P1 Don Right (inner, red)", "P1_DonRight"},
+		{"P1 Ka Left (outer, blue)", "P1_KaLeft"},
+		{"P1 Ka Right (outer, blue)", "P1_KaRight"},
+		{"P2 Don Left (inner, red)", "P2_DonLeft"},
+		{"P2 Don Right (inner, red)", "P2_DonRight"},
+		{"P2 Ka Left (outer, blue)", "P2_KaLeft"},
+		{"P2 Ka Right (outer, blue)", "P2_KaRight"},
+	};
+
+	for (int i = 0; i < static_cast<int>(std::size(entries)); i++)
+	{
+		layout->addWidget(new QLabel(tr(entries[i].label), group), i, 0);
+
+		InputBindingWidget* bind = new InputBindingWidget(
+			group, sif, InputBindingInfo::Type::Button, ACJV::CONFIG_SECTION, entries[i].config_key);
+		bind->setMinimumWidth(225);
+		bind->setMaximumWidth(225);
+		layout->addWidget(bind, i, 1);
+	}
+
+	m_ui.scrollLayout->addWidget(group);
 }
 
 #include "moc_JVSControlsWidget.cpp"

--- a/pcsx2-qt/Settings/JVSControlsWidget.h
+++ b/pcsx2-qt/Settings/JVSControlsWidget.h
@@ -20,6 +20,7 @@ public:
 private:
 	void bindDIPSwitchWidgets();
 	void bindSystemButtonWidgets();
+	void bindDrumWidgets();
 
 	Ui::JVSControlsWidget m_ui;
 	ControllerSettingsWindow* m_dialog;

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -120,6 +120,19 @@ static constexpr const std::array<InputBindingInfo, 4> s_jvs_wheel_bindings = {{
 	{"Brake",      TRANSLATE_NOOP("JVS", "Brake"),          nullptr, InputBindingInfo::Type::HalfAxis, 3, GenericInputBinding::L2},
 }};
 
+// Taiko drum: 8 piezo sensors on JVS analog channels. bind_index = MEASURED channel (in-game TAIKO TEST,
+// scrambled vs the on-screen order): 1P DL=0 DR=3 KL=5 KR=4 | 2P DL=2 DR=7 KL=1 KR=6
+static constexpr const std::array<InputBindingInfo, JVS_DRUM_CHANNEL_MAX> s_jvs_drum_bindings = {{
+	{"P1_DonLeft",  TRANSLATE_NOOP("JVS", "P1 Don Left (inner, red)"),   nullptr, InputBindingInfo::Type::Button, 0, GenericInputBinding::Unknown},
+	{"P1_DonRight", TRANSLATE_NOOP("JVS", "P1 Don Right (inner, red)"),  nullptr, InputBindingInfo::Type::Button, 3, GenericInputBinding::Unknown},
+	{"P1_KaLeft",   TRANSLATE_NOOP("JVS", "P1 Ka Left (outer, blue)"),   nullptr, InputBindingInfo::Type::Button, 5, GenericInputBinding::Unknown},
+	{"P1_KaRight",  TRANSLATE_NOOP("JVS", "P1 Ka Right (outer, blue)"),  nullptr, InputBindingInfo::Type::Button, 4, GenericInputBinding::Unknown},
+	{"P2_DonLeft",  TRANSLATE_NOOP("JVS", "P2 Don Left (inner, red)"),   nullptr, InputBindingInfo::Type::Button, 2, GenericInputBinding::Unknown},
+	{"P2_DonRight", TRANSLATE_NOOP("JVS", "P2 Don Right (inner, red)"),  nullptr, InputBindingInfo::Type::Button, 7, GenericInputBinding::Unknown},
+	{"P2_KaLeft",   TRANSLATE_NOOP("JVS", "P2 Ka Left (outer, blue)"),   nullptr, InputBindingInfo::Type::Button, 1, GenericInputBinding::Unknown},
+	{"P2_KaRight",  TRANSLATE_NOOP("JVS", "P2 Ka Right (outer, blue)"),  nullptr, InputBindingInfo::Type::Button, 6, GenericInputBinding::Unknown},
+}};
+
 // Zoids twin-stick (NM00016/25): custom JVS switch-word wiring, mapped live via the I/O-TEST SWITCH TEST.
 // Left lever -> left stick, right lever -> right stick; Start/Service on the standard JVS bits.
 static constexpr const std::array<InputBindingInfo, 14> s_twinstick_p1_button_bindings = {{
@@ -374,6 +387,11 @@ std::span<const InputBindingInfo> ACJV::GetWheelBindings()
 	return s_jvs_wheel_bindings;
 }
 
+std::span<const InputBindingInfo> ACJV::GetDrumBindings()
+{
+	return s_jvs_drum_bindings;
+}
+
 bool ACJV::GetDIPSwitchState(u32 index)
 {
 	return (index < s_dip_switch_masks.size()) && ((s_dip_switch_state & s_dip_switch_masks[index]) != 0);
@@ -582,6 +600,12 @@ void ACJV::SetWheelAxis(u32 axis, float value)
 		case 3: m_wheelBrake  = value; break;
 		default: break;
 	}
+}
+
+void ACJV::SetDrumHit(u32 channel, bool pressed)
+{
+	if (channel < JVS_DRUM_CHANNEL_MAX)
+		m_jvsDrumChannels[channel] = pressed ? 0xFFFF : 0; // max -> above IN/DAI; big notes (大) emerge from hitting both sides
 }
 
 JVS_MODE ACJV::GetMode()
@@ -849,8 +873,7 @@ void do_jvs_packet(const u8* input, u8* output) {
 
 				(*dstSize) += 12;
 			}
-			// TODO: drum games (e.g. Taiko no Tatsujin)
-#if 0
+			// Taiko drum: 8 analog channels (piezo sensors), 10-bit (measured: game polls READ_INP_ANALOG 8)
 			else if(m_jvsMode == JVS_MODE::DRUM)
 			{
 				(*output++) = 0x03;                 //Analog Input
@@ -860,7 +883,6 @@ void do_jvs_packet(const u8* input, u8* output) {
 
 				(*dstSize) += 4;
 			}
-#endif
 			// TODO: touch panel games
 #if 0
 			else if(m_jvsMode == JVS_MODE::TOUCH)

--- a/pcsx2/DEV9/ACJV.h
+++ b/pcsx2/DEV9/ACJV.h
@@ -117,8 +117,10 @@ namespace ACJV {
     std::span<const InputBindingInfo> GetP2ButtonBindings();
     std::span<const InputBindingInfo> GetCoinBindings();
     std::span<const InputBindingInfo> GetWheelBindings();
+    std::span<const InputBindingInfo> GetDrumBindings();
     void SetButtonState(u32 player, u16 mask, bool pressed);
     void SetWheelAxis(u32 axis, float value);
+    void SetDrumHit(u32 channel, bool pressed); // Taiko drum sensor -> JVS analog channel (0=off, else above DAI threshold)
     float GetSteer(); // host steering, -1 (full left)...+1 (full right); used by the BG3 drive-board responder (acuart)
     float GetGas();   // host accelerator, 0...1
     float GetBrake(); // host brake, 0...1

--- a/pcsx2/Input/InputManager.cpp
+++ b/pcsx2/Input/InputManager.cpp
@@ -909,6 +909,8 @@ void InputManager::AddJVSBindings(SettingsInterface& si, bool is_profile)
 			continue;
 
 		const std::string pad_section = Pad::GetConfigSection(player);
+		// Taiko (drum) uses only the drum sensors + coin; don't mirror the gamepad to JVS player buttons.
+		if (ACJV::GetMode() != JVS_MODE::DRUM)
 		for (const InputBindingInfo& jvs_bi : player_bindings[player])
 		{
 			if (jvs_bi.generic_mapping == GenericInputBinding::Unknown ||
@@ -970,6 +972,18 @@ void InputManager::AddJVSBindings(SettingsInterface& si, bool is_profile)
 
 		AddBindings(bindings, InputAxisEventHandler{[axis = static_cast<u32>(bi.bind_index)](InputBindingKey key, float value) {
 			ACJV::SetWheelAxis(axis, value);
+		}}, bi.bind_type, si, ACJV::CONFIG_SECTION, bi.name, is_profile);
+	}
+
+	// Taiko drum sensors (button press -> above-threshold hit on a JVS analog channel)
+	for (const InputBindingInfo& bi : ACJV::GetDrumBindings())
+	{
+		const std::vector<std::string> bindings(si.GetStringList(ACJV::CONFIG_SECTION, bi.name));
+		if (bindings.empty())
+			continue;
+
+		AddBindings(bindings, InputAxisEventHandler{[channel = static_cast<u32>(bi.bind_index)](InputBindingKey key, float value) {
+			ACJV::SetDrumHit(channel, value > 0.5f);
 		}}, bi.bind_type, si, ACJV::CONFIG_SECTION, bi.name, is_profile);
 	}
 

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1395,6 +1395,11 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 						ACJV::SetMode(JVS_MODE::FIGHTING);
 						Console.WriteLn(Color_Green, "ACGAME: jvsmode=fighting");
 					}
+					else if (jvsmode == "drum")
+					{
+						ACJV::SetMode(JVS_MODE::DRUM);
+						Console.WriteLn(Color_Green, "ACGAME: jvsmode=drum");
+					}
 					else if (jvsmode == "racing")
 					{
 						ACJV::SetMode(JVS_MODE::DRIVE);


### PR DESCRIPTION
Initial Taiko drum support via JVS. Add `jvsmode=drum` in `.acgame` for the time being.

Bind the drum in Controllers window -> JVS Controls tab -> Taiko Drum section (no defaults, bind manually).

<img width="1658" height="940" alt="Screenshot_20260627_150412" src="https://github.com/user-attachments/assets/4fb303f2-6448-4d4b-a1ed-b9895ac1b053" />

PROMOTE THE FOLLOWING GAMES TO PLAYABLE:
  - NM00023 | Taiko Drum Master 7
  - NM00033 | Taiko Drum Master 8
  - NM00038 | Taiko Drum Master 9
  - NM00041 | Taiko Drum Master 10
  - NM00044 | Taiko Drum Master 11
  - NM00051 | Taiko Drum Master 12
  - NM00056 | Taiko Drum Master 13
  - NM00057 | Taiko Drum Master 14

Asian 11/12 (NM00046 / NM00054) and Taiwan 11/12 (NM00045 / NM00053) not included, it need extra hardware (UE PCB + USB key). However, .pnach patch was done with reverse engineering. It's playable with the patch (manually added). To be added in PCSX2X6 later:

```
    NM00046  Taiko 11 Asian   (TEBLOAD, DVD)
      patch=1,EE,8012EF20,word,03E00008
      patch=1,EE,8012EF24,word,24020001

    NM00054  Taiko 12 Asian   (TEDLOAD, HDD)
      patch=1,EE,80134270,word,03E00008
      patch=1,EE,80134274,word,24020001

    NM00045  Taiko 11 Taiwan  (TEALOAD, DVD)
      patch=1,EE,8012EE40,word,03E00008
      patch=1,EE,8012EE44,word,24020001

    NM00053  Taiko 12 Taiwan  (TECLOAD, HDD)
      patch=1,EE,801341E0,word,03E00008
      patch=1,EE,801341E4,word,24020001
```