### PR TITLE
JVS: complete JVS UI overhaul and some fixes

### DIFF
--- a/pcsx2-qt/Settings/ControllerBindingWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerBindingWidget.cpp
@@ -1051,10 +1051,20 @@ QIcon USBDeviceWidget::getIcon() const
 	return QIcon::fromTheme("usb-fill");
 }
 
+// Hide arcade USB devices (light gun/wheel/drums) from the USB tab
+static bool isHiddenUsbDeviceType(const std::string_view type)
+{
+	return type == "guncon2" || type == "Pad" || type == "RBDrumKit";
+}
+
 void USBDeviceWidget::populateDeviceTypes()
 {
 	for (const auto& [name, display_name] : USB::GetDeviceTypes())
+	{
+		if (isHiddenUsbDeviceType(name))
+			continue;
 		m_ui.deviceType->addItem(qApp->translate("USB", display_name), QString::fromUtf8(name));
+	}
 }
 
 void USBDeviceWidget::populatePages()
@@ -1082,6 +1092,15 @@ void USBDeviceWidget::populatePages()
 		m_ui.stackedWidget->removeWidget(m_settings_widget);
 		delete m_settings_widget;
 		m_settings_widget = nullptr;
+	}
+
+	if (isHiddenUsbDeviceType(m_device_type))
+	{
+		m_ui.deviceSubtype->setVisible(false);
+		m_ui.bindings->setEnabled(false);
+		m_ui.settings->setEnabled(false);
+		updateHeaderToolButtons();
+		return;
 	}
 
 	const std::span<const InputBindingInfo> bindings(USB::GetDeviceBindings(m_device_type, m_device_subtype));

--- a/pcsx2-qt/Settings/ControllerSettingsWindow.cpp
+++ b/pcsx2-qt/Settings/ControllerSettingsWindow.cpp
@@ -476,6 +476,8 @@ void ControllerSettingsWindow::createWidgets()
 		item->setIcon(m_port_bindings[global_slot]->getIcon());
 		item->setData(Qt::UserRole, QVariant(global_slot));
 		m_ui.settingsCategory->addItem(item);
+		// Arcade input is in the JVS Controls tab; hide the controller-port entries (the widget stays built to keep the row index mapping).
+		item->setHidden(true);
 	}
 
 	// USB ports

--- a/pcsx2-qt/Settings/JVSControlsWidget.cpp
+++ b/pcsx2-qt/Settings/JVSControlsWidget.cpp
@@ -8,11 +8,68 @@
 #include "Settings/InputBindingWidget.h"
 
 #include "pcsx2/DEV9/ACJV.h"
+#include "pcsx2/Host.h"
+#include "pcsx2/Input/InputManager.h"
+#include "pcsx2/USB/USB.h"
+
+#include "QtHost.h"
 
 #include <QtCore/QCoreApplication>
+#include <QtCore/QDir>
+#include <QtCore/QEvent>
+#include <QtGui/QAction>
+#include <QtGui/QCursor>
+#include <QtGui/QShowEvent>
+#include <QtWidgets/QBoxLayout>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QDoubleSpinBox>
+#include <QtWidgets/QFileDialog>
 #include <QtWidgets/QGridLayout>
 #include <QtWidgets/QGroupBox>
 #include <QtWidgets/QLabel>
+#include <QtWidgets/QLineEdit>
+#include <QtWidgets/QMenu>
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QSpinBox>
+#include <QtWidgets/QStackedWidget>
+
+#include <utility>
+#include <vector>
+
+// Highlight bind button text
+static constexpr const char* JVS_LABEL_HOVER_STYLE = "color: #4FC3F7; font-weight: bold;";
+namespace {
+class HoverHighlight final : public QObject
+{
+public:
+	HoverHighlight(QWidget* button, QLabel* label) : QObject(button), m_label(label) { button->installEventFilter(this); }
+
+protected:
+	bool eventFilter(QObject* watched, QEvent* event) override
+	{
+		if (event->type() == QEvent::Enter)
+			m_label->setStyleSheet(JVS_LABEL_HOVER_STYLE);
+		else if (event->type() == QEvent::Leave)
+			m_label->setStyleSheet(QString());
+		return QObject::eventFilter(watched, event);
+	}
+
+private:
+	QLabel* m_label;
+};
+} // namespace
+
+// One "[label] [P1] [P2]" bind row; empty p2key = single column, HalfAxis for analog.
+static void addBindRow(QWidget* parent, SettingsInterface* sif, QGridLayout* layout, int row,
+	const QString& label, const std::string& p1key, const std::string& p2key,
+	InputBindingInfo::Type bind_type = InputBindingInfo::Type::Button);
+
+using JvsAutomapBinds = std::vector<std::pair<std::string, GenericInputBinding>>;
+static void addJvsAutomapButton(JVSControlsWidget* w, ControllerSettingsWindow* dialog, QBoxLayout* layout,
+	JvsAutomapBinds p1binds, JvsAutomapBinds p2binds);
+static void addLightgunAutomapButton(JVSControlsWidget* w, ControllerSettingsWindow* dialog, QBoxLayout* layout);
 
 JVSControlsWidget::JVSControlsWidget(QWidget* parent, ControllerSettingsWindow* dialog)
 	: QWidget(parent)
@@ -20,49 +77,277 @@ JVSControlsWidget::JVSControlsWidget(QWidget* parent, ControllerSettingsWindow* 
 {
 	m_ui.setupUi(this);
 
-	for (int i = RAYS_PCB; i <= MIU_IO_JPN_GUN_EXTENTI; i++)
+	// Show current JVS board in use
+	for (int i = RAYS_PCB; i <= TAITO_BG3_IO_PCB; i++)
 		m_ui.boardType->addItem(QString::fromUtf8(ACJV::GetBoardDisplayName(static_cast<BOARDID>(i))));
-	m_ui.boardType->setCurrentIndex(static_cast<int>(ACJV::GetCurrentBoardID()));
+	refreshBoardType();
 
 	bindDIPSwitchWidgets();
 	bindSystemButtonWidgets();
-	bindDrumWidgets();
+	buildDrumPage();
+	buildFightingPage();
+	buildRacingPage();
+	buildTwinstickPage();
+	buildLightgunPage();
+	buildStandardPage();
+
+	// Settings view: analog tuning (deadzone/sensitivity) for the JVS steering and pedals.
+	{
+		SettingsInterface* sif = m_dialog->getProfileSettingsInterface();
+		QGroupBox* group = new QGroupBox(tr("Analog (Steering / Pedals)"), this);
+		QGridLayout* g = new QGridLayout(group);
+		g->setColumnStretch(0, 1);
+		int row = 0;
+		const auto addDescription = [&](const QString& text) {
+			QLabel* desc = new QLabel(text, group);
+			desc->setWordWrap(true);
+			g->addWidget(desc, row++, 0, 1, 2);
+			g->addItem(new QSpacerItem(1, 10, QSizePolicy::Minimum, QSizePolicy::Fixed), row++, 0, 1, 2);
+		};
+		const auto addSpinRow = [&](const QString& label, const char* key, float def, double min, double max, const QString& description) {
+			g->addWidget(new QLabel(label, group), row, 0);
+			QDoubleSpinBox* spin = new QDoubleSpinBox(group);
+			spin->setDecimals(0);
+			spin->setSuffix(QStringLiteral("%"));
+			spin->setMinimum(min);
+			spin->setMaximum(max);
+			spin->setMaximumWidth(110);
+			ControllerSettingWidgetBinder::BindWidgetToInputProfileFloat(sif, spin, ACJV::CONFIG_SECTION, key, def, 100.0f);
+			g->addWidget(spin, row++, 1, Qt::AlignRight);
+			addDescription(description);
+		};
+		addSpinRow(tr("Steering Deadzone"), "AnalogDeadzone", 0.0f, 0, 100,
+			tr("Sets the steering deadzone, i.e. the fraction of wheel travel around the center that is ignored."));
+		addSpinRow(tr("Steering Sensitivity"), "AnalogSensitivity", 1.33f, 1, 200,
+			tr("Sets the steering axis scaling factor. A value between 130% and 140% suits most modern controllers."));
+		addSpinRow(tr("Pedal Deadzone"), "TriggerDeadzone", 0.0f, 0, 100,
+			tr("Sets the pedal deadzone, i.e. the fraction of accelerator/brake travel that is ignored."));
+		QCheckBox* invert = new QCheckBox(tr("Invert Steering"), group);
+		ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(sif, invert, ACJV::CONFIG_SECTION, "InvertSteering", false);
+		g->addWidget(invert, row++, 0, 1, 2);
+		addDescription(tr("Reverses the steering direction. Enable if the wheel turns the opposite way in-game."));
+		m_ui.settingsViewLayout->addWidget(group);
+		m_ui.settingsViewLayout->addStretch(1);
+	}
+
+	m_ui.systemPageLayout->addStretch(1); // top-pack so the page doesn't inherit the tallest page's height
 
 	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(m_dialog->getProfileSettingsInterface(), m_ui.suppressDaemon,
 		ACJV::CONFIG_SECTION, "SuppressDaemon", true);
+
+	// Item order MUST match the QStackedWidget page order in the .ui.
+	m_ui.pageSelector->addItem(tr("System"));
+	m_ui.pageSelector->addItem(tr("Fighting"));
+	m_ui.pageSelector->addItem(tr("Racing"));
+	m_ui.pageSelector->addItem(tr("Taiko Drum"));
+	m_ui.pageSelector->addItem(tr("Twinstick"));
+	m_ui.pageSelector->addItem(tr("Lightgun"));
+	m_ui.pageSelector->addItem(tr("Standard"));
+	connect(m_ui.pageSelector, QOverload<int>::of(&QComboBox::currentIndexChanged),
+		m_ui.pageStack, &QStackedWidget::setCurrentIndex);
+
+	connect(m_ui.viewBindings, &QToolButton::clicked, this, [this]() { m_ui.viewStack->setCurrentIndex(0); });
+	connect(m_ui.viewSettings, &QToolButton::clicked, this, [this]() { m_ui.viewStack->setCurrentIndex(1); });
+	connect(m_ui.viewMacros, &QToolButton::clicked, this, [this]() { m_ui.viewStack->setCurrentIndex(2); });
+
+	connect(g_emu_thread, &EmuThread::onInputDevicesEnumerated, this,
+		[this](const QList<QPair<QString, QString>>&) { refreshAimDevices(); });
+
+	autoPickInputPage();
 }
 
 JVSControlsWidget::~JVSControlsWidget() = default;
 
+void JVSControlsWidget::showEvent(QShowEvent* event)
+{
+	QWidget::showEvent(event);
+	refreshBoardType();
+	refreshAimDevices();
+	refreshMacrosPage();
+	autoPickInputPage();
+}
+
+// Delete a layout's widgets and items immediately so a rebuilt page shows no stale widgets.
+static void clearLayoutImmediate(QLayout* layout)
+{
+	QLayoutItem* item;
+	while ((item = layout->takeAt(0)) != nullptr)
+	{
+		if (QWidget* w = item->widget())
+			delete w;
+		delete item;
+	}
+}
+
+// Macros
+void JVSControlsWidget::refreshMacrosPage()
+{
+	clearLayoutImmediate(m_ui.macrosViewLayout);
+
+	struct MacroLayout { QString name; std::string key; std::span<const InputBindingInfo> buttons; };
+	std::vector<MacroLayout> layouts;
+	for (const ACJV::LayoutInfo& fl : ACJV::GetFightingLayouts())
+		layouts.push_back({QString::fromUtf8(fl.name), ACJV::LayoutKey(fl.buttons), fl.buttons});
+	for (const ACJV::RacingLayoutInfo& rl : ACJV::GetRacingLayouts())
+		layouts.push_back({QString::fromUtf8(rl.name), ACJV::LayoutKey(rl.buttons), rl.buttons});
+	for (const ACJV::LayoutInfo& sl : ACJV::GetStandardLayouts())
+		layouts.push_back({QString::fromUtf8(sl.name), ACJV::LayoutKey(sl.buttons), sl.buttons});
+
+	// Dropdown to pick a layout's macros; build into one content widget so a refresh deletes it whole.
+	QWidget* content = new QWidget(this);
+	QVBoxLayout* contentLayout = new QVBoxLayout(content);
+	contentLayout->setContentsMargins(0, 0, 0, 0);
+	m_ui.macrosViewLayout->addWidget(content);
+
+	const std::string current = ACJV::GetCurrentLayoutKey();
+	QComboBox* combo = new QComboBox(content);
+	int currentIdx = 0;
+	for (int k = 0; k < static_cast<int>(layouts.size()); k++)
+	{
+		QString label = layouts[k].name;
+		if (!current.empty() && layouts[k].key == current)
+		{
+			label += tr(" (current)");
+			currentIdx = k;
+		}
+		combo->addItem(label);
+	}
+	QHBoxLayout* header = new QHBoxLayout();
+	header->addWidget(new QLabel(tr("Game:"), content));
+	header->addWidget(combo, 1);
+	contentLayout->addLayout(header);
+
+	QWidget* rows = new QWidget(content);
+	QVBoxLayout* rowsLayout = new QVBoxLayout(rows);
+	rowsLayout->setContentsMargins(0, 0, 0, 0);
+	contentLayout->addWidget(rows);
+	contentLayout->addStretch(1);
+
+	if (!layouts.empty())
+		buildMacroRows(rowsLayout, layouts[currentIdx].key, layouts[currentIdx].buttons);
+	combo->setCurrentIndex(currentIdx);
+	connect(combo, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+		[this, layouts, rowsLayout](int idx) {
+			if (idx >= 0 && idx < static_cast<int>(layouts.size()))
+				buildMacroRows(rowsLayout, layouts[idx].key, layouts[idx].buttons);
+		});
+}
+
+void JVSControlsWidget::buildMacroRows(QVBoxLayout* rowsLayout, const std::string& layoutKey, std::span<const InputBindingInfo> lbuttons)
+{
+	clearLayoutImmediate(rowsLayout);
+	if (layoutKey.empty())
+		return;
+	QWidget* rows = rowsLayout->parentWidget();
+	SettingsInterface* sif = m_dialog->getProfileSettingsInterface();
+	SettingsInterface& readsi = sif ? *sif : *Host::Internal::GetBaseSettingsLayer();
+	for (int p = 0; p < 2; p++)
+	{
+		QGroupBox* group = new QGroupBox(tr("Player %1 Macros").arg(p + 1), rows);
+		QGridLayout* g = new QGridLayout(group);
+		for (u32 i = 0; i < ACJV::NUM_JVS_MACROS; i++)
+		{
+			const std::string trigKey = ACJV::MacroConfigKey(layoutKey, p, i, "");
+			const std::string bindsKey = ACJV::MacroConfigKey(layoutKey, p, i, "Binds");
+			g->addWidget(new QLabel(tr("Macro %1").arg(i + 1), group), static_cast<int>(i), 0);
+			InputBindingWidget* trig = new InputBindingWidget(group, sif,
+				InputBindingInfo::Type::Macro, ACJV::CONFIG_SECTION, trigKey);
+			trig->setMinimumWidth(120);
+			trig->setMaximumWidth(120);
+			g->addWidget(trig, static_cast<int>(i), 1);
+
+			const std::vector<std::string> selected = readsi.GetStringList(ACJV::CONFIG_SECTION, bindsKey.c_str());
+			QWidget* box = new QWidget(group);
+			QHBoxLayout* bl = new QHBoxLayout(box);
+			bl->setContentsMargins(0, 0, 0, 0);
+			for (const ACJV::JvsMacroSwitch& sw : ACJV::GetMacroSwitches())
+			{
+				const char* fn = nullptr; // this layout's function for the switch, if it uses it
+				for (const InputBindingInfo& bi : lbuttons)
+					if (static_cast<u16>(bi.bind_index) == sw.bit) { fn = bi.display_name; break; }
+				if (!fn)
+					continue; // only show the switches the layout actually uses (cleaner than all 6)
+				QCheckBox* cb = new QCheckBox(QString::fromUtf8(sw.label) + QStringLiteral(" (") + QString::fromUtf8(fn) + QStringLiteral(")"), box);
+				cb->setProperty("jvsbtn", QString::fromUtf8(sw.name));
+				bool on = false;
+				for (const std::string& s : selected)
+					if (s == sw.name) { on = true; break; }
+				cb->setChecked(on);
+				bl->addWidget(cb);
+				connect(cb, &QCheckBox::toggled, this, [this, bindsKey, box]() {
+					std::vector<std::string> names;
+					for (QCheckBox* c : box->findChildren<QCheckBox*>())
+						if (c->isChecked())
+							names.push_back(c->property("jvsbtn").toString().toStdString());
+					const auto write = [&](SettingsInterface& si) {
+						if (names.empty())
+							si.DeleteValue(ACJV::CONFIG_SECTION, bindsKey.c_str());
+						else
+							si.SetStringList(ACJV::CONFIG_SECTION, bindsKey.c_str(), names);
+					};
+					if (m_dialog->isEditingGlobalSettings())
+					{
+						auto lock = Host::GetSettingsLock();
+						write(*Host::Internal::GetBaseSettingsLayer());
+					}
+					else
+					{
+						SettingsInterface* si = m_dialog->getProfileSettingsInterface();
+						write(*si);
+						si->Save();
+					}
+					g_emu_thread->applySettings();
+				});
+			}
+			bl->addStretch(1);
+			g->addWidget(box, static_cast<int>(i), 2);
+		}
+		rowsLayout->addWidget(group);
+	}
+}
+
+// The settings window is cached, so re-pick the running game's board each time the page shows.
+void JVSControlsWidget::refreshBoardType()
+{
+	m_ui.boardType->setCurrentIndex(static_cast<int>(ACJV::GetCurrentBoardID()));
+}
+
+// Auto-select the page for the running game's mode, but only when the game changed.
+void JVSControlsWidget::autoPickInputPage()
+{
+	const std::string& gameid = ACJV::GetGameId();
+	if (gameid == m_autoPickedGameId)
+		return;
+	m_autoPickedGameId = gameid;
+	// Page index in the combo/stack (must match the addItem order above).
+	int page = 0;
+	switch (ACJV::GetMode())
+	{
+		case JVS_MODE::FIGHTING:  page = 1; break;
+		case JVS_MODE::DRIVE:     page = 2; break;
+		case JVS_MODE::DRUM:      page = 3; break;
+		case JVS_MODE::TWINSTICK: page = 4; break;
+		case JVS_MODE::LIGHTGUN:  page = 5; break;
+		case JVS_MODE::STANDARD:  page = 6; break;
+		default:                  page = 0; break;
+	}
+	m_ui.pageSelector->setCurrentIndex(page);
+}
+
 void JVSControlsWidget::bindDIPSwitchWidgets()
 {
-	const ACJV::DIPSwitchInfo& test_mode = ACJV::GetTestModeDIPSwitch();
-	m_ui.testMode->setText(QCoreApplication::translate(ACJV::TRANSLATION_CONTEXT, test_mode.display_name));
-	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(m_dialog->getProfileSettingsInterface(), m_ui.testMode,
-		ACJV::CONFIG_SECTION, test_mode.name, test_mode.default_value);
-	m_ui.toggleTestMode->initialize(m_dialog->getProfileSettingsInterface(),
-		InputBindingInfo::Type::Button, ACJV::CONFIG_SECTION, test_mode.toggle_bind_name);
-
-	const ACJV::DIPSwitchInfo& video_voltage = ACJV::GetVideoVoltageDIPSwitch();
-	m_ui.videoVoltage->setText(QCoreApplication::translate(ACJV::TRANSLATION_CONTEXT, video_voltage.display_name));
-	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(m_dialog->getProfileSettingsInterface(), m_ui.videoVoltage,
-		ACJV::CONFIG_SECTION, video_voltage.name, video_voltage.default_value);
-	m_ui.toggleVideoVoltage->initialize(m_dialog->getProfileSettingsInterface(),
-		InputBindingInfo::Type::Button, ACJV::CONFIG_SECTION, video_voltage.toggle_bind_name);
-
-	const ACJV::DIPSwitchInfo& monitor_sync_frequency = ACJV::GetMonitorSyncFrequencyDIPSwitch();
-	m_ui.monitorSyncFrequency->setText(QCoreApplication::translate(ACJV::TRANSLATION_CONTEXT, monitor_sync_frequency.display_name));
-	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(m_dialog->getProfileSettingsInterface(), m_ui.monitorSyncFrequency,
-		ACJV::CONFIG_SECTION, monitor_sync_frequency.name, monitor_sync_frequency.default_value);
-	m_ui.toggleMonitorSyncFrequency->initialize(m_dialog->getProfileSettingsInterface(),
-		InputBindingInfo::Type::Button, ACJV::CONFIG_SECTION, monitor_sync_frequency.toggle_bind_name);
-
-	const ACJV::DIPSwitchInfo& video_sync_split = ACJV::GetVideoSyncSplitDIPSwitch();
-	m_ui.videoSyncSplit->setText(QCoreApplication::translate(ACJV::TRANSLATION_CONTEXT, video_sync_split.display_name));
-	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(m_dialog->getProfileSettingsInterface(), m_ui.videoSyncSplit,
-		ACJV::CONFIG_SECTION, video_sync_split.name, video_sync_split.default_value);
-	m_ui.toggleVideoSyncSplit->initialize(m_dialog->getProfileSettingsInterface(),
-		InputBindingInfo::Type::Button, ACJV::CONFIG_SECTION, video_sync_split.toggle_bind_name);
+	QCheckBox* checks[] = {m_ui.testMode, m_ui.videoVoltage, m_ui.monitorSyncFrequency, m_ui.videoSyncSplit};
+	InputBindingWidget* toggles[] = {m_ui.toggleTestMode, m_ui.toggleVideoVoltage, m_ui.toggleMonitorSyncFrequency, m_ui.toggleVideoSyncSplit};
+	SettingsInterface* sif = m_dialog->getProfileSettingsInterface();
+	const auto dips = ACJV::GetDIPSwitches();
+	for (size_t i = 0; i < std::size(checks); i++)
+	{
+		checks[i]->setText(QCoreApplication::translate(ACJV::TRANSLATION_CONTEXT, dips[i].display_name));
+		ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(sif, checks[i],
+			ACJV::CONFIG_SECTION, dips[i].name, dips[i].default_value);
+		toggles[i]->initialize(sif, InputBindingInfo::Type::Button, ACJV::CONFIG_SECTION, dips[i].toggle_bind_name);
+	}
+	m_ui.dipSwitchLayout->setRowStretch(4, 1);
 }
 
 void JVSControlsWidget::bindSystemButtonWidgets()
@@ -70,65 +355,633 @@ void JVSControlsWidget::bindSystemButtonWidgets()
 	QGridLayout* layout = m_ui.systemButtonsLayout;
 	SettingsInterface* sif = m_dialog->getProfileSettingsInterface();
 
-	struct ButtonEntry {
-		const char* label;
-		const char* config_key;
-	};
-	static constexpr ButtonEntry entries[] = {
-		{"P1 Service", "P1_Service"},
-		{"P2 Service", "P2_Service"},
-		{"Insert Coin P1", "Coin1"},
-		{"Insert Coin P2", "Coin2"},
-	};
-
-	for (int i = 0; i < static_cast<int>(std::size(entries)); i++)
-	{
-		QLabel* label = new QLabel(tr(entries[i].label), this);
-		layout->addWidget(label, i, 0);
-
-		InputBindingWidget* bind = new InputBindingWidget(
-			this, sif, InputBindingInfo::Type::Button, ACJV::CONFIG_SECTION, entries[i].config_key);
-		bind->setMinimumWidth(225);
-		bind->setMaximumWidth(225);
-		layout->addWidget(bind, i, 1);
-	}
+	// Universal inputs (same JVS bit in every game)
+	layout->addWidget(new QLabel(tr("P1"), this), 0, 1, Qt::AlignHCenter);
+	layout->addWidget(new QLabel(tr("P2"), this), 0, 2, Qt::AlignHCenter);
+	addBindRow(this, sif, layout, 1, tr("Service"), "P1_Service", "P2_Service");
+	addBindRow(this, sif, layout, 2, tr("Enter"),   "P1_Button1", "P2_Button1");
+	addBindRow(this, sif, layout, 3, tr("Coin"),    "Coin1",      "Coin2");
+	addBindRow(this, sif, layout, 4, tr("Start"),   "P1_Start",   "P2_Start");
+	addBindRow(this, sif, layout, 5, tr("Up"),      "P1_Up",      "P2_Up");
+	addBindRow(this, sif, layout, 6, tr("Down"),    "P1_Down",    "P2_Down");
+	addBindRow(this, sif, layout, 7, tr("Left"),    "P1_Left",    "P2_Left");
+	addBindRow(this, sif, layout, 8, tr("Right"),   "P1_Right",   "P2_Right");
+	layout->setRowStretch(9, 1);
 }
 
-void JVSControlsWidget::bindDrumWidgets()
+void JVSControlsWidget::buildDrumPage()
 {
 	SettingsInterface* sif = m_dialog->getProfileSettingsInterface();
 
 	QGroupBox* group = new QGroupBox(tr("Taiko Drum"), this);
-	QGridLayout* layout = new QGridLayout(group);
+	QGridLayout* g = new QGridLayout(group);
+	g->addWidget(new QLabel(tr("P1"), group), 0, 1, Qt::AlignHCenter);
+	g->addWidget(new QLabel(tr("P2"), group), 0, 2, Qt::AlignHCenter);
+	// config keys must match the s_jvs_drum_bindings names in ACJV.cpp (which carry the real analog channels).
+	addBindRow(group, sif, g, 1, tr("Don Left (inner, red)"),  "P1_DonLeft",  "P2_DonLeft");
+	addBindRow(group, sif, g, 2, tr("Don Right (inner, red)"), "P1_DonRight", "P2_DonRight");
+	addBindRow(group, sif, g, 3, tr("Ka Left (outer, blue)"),  "P1_KaLeft",   "P2_KaLeft");
+	addBindRow(group, sif, g, 4, tr("Ka Right (outer, blue)"), "P1_KaRight",  "P2_KaRight");
+	g->setColumnStretch(0, 1); // stretch the label column so the binds sit to the right
 
-	struct DrumEntry {
-		const char* label;
-		const char* config_key;
-	};
-	// config_key must match the s_jvs_drum_bindings names in ACJV.cpp (which carry the real analog channels).
-	static constexpr DrumEntry entries[] = {
-		{"P1 Don Left (inner, red)", "P1_DonLeft"},
-		{"P1 Don Right (inner, red)", "P1_DonRight"},
-		{"P1 Ka Left (outer, blue)", "P1_KaLeft"},
-		{"P1 Ka Right (outer, blue)", "P1_KaRight"},
-		{"P2 Don Left (inner, red)", "P2_DonLeft"},
-		{"P2 Don Right (inner, red)", "P2_DonRight"},
-		{"P2 Ka Left (outer, blue)", "P2_KaLeft"},
-		{"P2 Ka Right (outer, blue)", "P2_KaRight"},
-	};
+	QHBoxLayout* row = new QHBoxLayout();
+	row->addWidget(group, 1);
+	row->addStretch(1);
+	m_ui.drumPageLayout->addLayout(row);
+	m_ui.drumPageLayout->addStretch(1);
 
-	for (int i = 0; i < static_cast<int>(std::size(entries)); i++)
+	// Opt-in automap default: Don (red) = Square/Triangle, Ka (blue) = Cross/Circle.
+	addJvsAutomapButton(this, m_dialog, m_ui.drumPageLayout,
+		{{"P1_DonLeft", GenericInputBinding::Square}, {"P1_DonRight", GenericInputBinding::Triangle},
+			{"P1_KaLeft", GenericInputBinding::Cross}, {"P1_KaRight", GenericInputBinding::Circle}},
+		{{"P2_DonLeft", GenericInputBinding::Square}, {"P2_DonRight", GenericInputBinding::Triangle},
+			{"P2_KaLeft", GenericInputBinding::Cross}, {"P2_KaRight", GenericInputBinding::Circle}});
+}
+
+static void addBindRow(QWidget* parent, SettingsInterface* sif, QGridLayout* layout, int row,
+	const QString& label, const std::string& p1key, const std::string& p2key,
+	InputBindingInfo::Type bind_type)
+{
+	QLabel* desc = new QLabel(label, parent);
+	layout->addWidget(desc, row, 0);
+	InputBindingWidget* p1 = new InputBindingWidget(parent, sif, bind_type, ACJV::CONFIG_SECTION, p1key);
+	p1->setMinimumWidth(140);
+	p1->setMaximumWidth(140);
+	layout->addWidget(p1, row, 1);
+	new HoverHighlight(p1, desc);
+	if (p2key.empty())
+		return;
+	InputBindingWidget* p2 = new InputBindingWidget(parent, sif, bind_type, ACJV::CONFIG_SECTION, p2key);
+	p2->setMinimumWidth(140);
+	p2->setMaximumWidth(140);
+	layout->addWidget(p2, row, 2);
+	new HoverHighlight(p2, desc);
+}
+
+// A 4-way movement cross on the given JVS keys; shared by the Fighting d-pad and Twinstick levers.
+static void addMovementCompass(QWidget* parent, SettingsInterface* sif, QGridLayout* g, int colBase,
+	const QString& header, const std::string& upKey, const std::string& downKey,
+	const std::string& leftKey, const std::string& rightKey)
+{
+	QLabel* h = new QLabel(header, parent);
+	h->setAlignment(Qt::AlignHCenter);
+	g->addWidget(h, 0, colBase, 1, 3);
+	const auto bind = [&](const std::string& key) {
+		InputBindingWidget* w = new InputBindingWidget(parent, sif, InputBindingInfo::Type::Button,
+			ACJV::CONFIG_SECTION, key);
+		w->setMinimumWidth(130);
+		w->setMaximumWidth(130);
+		return w;
+	};
+	g->addWidget(bind(upKey),    1, colBase + 1);
+	g->addWidget(bind(leftKey),  2, colBase + 0);
+	g->addWidget(bind(rightKey), 2, colBase + 2);
+	g->addWidget(bind(downKey),  3, colBase + 1);
+}
+
+// Shared page builder for Fighting and Standard: movement, per-layout buttons, automap.
+template<typename LayoutT>
+static void buildJvsLayoutPage(JVSControlsWidget* self, SettingsInterface* sif, ControllerSettingsWindow* dialog,
+	QBoxLayout* pageLayout, std::span<const LayoutT> layouts)
+{
 	{
-		layout->addWidget(new QLabel(tr(entries[i].label), group), i, 0);
-
-		InputBindingWidget* bind = new InputBindingWidget(
-			group, sif, InputBindingInfo::Type::Button, ACJV::CONFIG_SECTION, entries[i].config_key);
-		bind->setMinimumWidth(225);
-		bind->setMaximumWidth(225);
-		layout->addWidget(bind, i, 1);
+		QGroupBox* group = new QGroupBox(JVSControlsWidget::tr("Movement"), self);
+		QGridLayout* g = new QGridLayout(group);
+		g->setColumnStretch(0, 1);
+		addMovementCompass(group, sif, g, 1, JVSControlsWidget::tr("P1"), "P1_Up", "P1_Down", "P1_Left", "P1_Right");
+		g->setColumnStretch(4, 1);
+		addMovementCompass(group, sif, g, 5, JVSControlsWidget::tr("P2"), "P2_Up", "P2_Down", "P2_Left", "P2_Right");
+		g->setColumnStretch(8, 1);
+		pageLayout->addWidget(group);
 	}
 
-	m_ui.scrollLayout->addWidget(group);
+	QGridLayout* grid = new QGridLayout();
+	int idx = 0;
+	for (const LayoutT& fl : layouts)
+	{
+		QGroupBox* group = new QGroupBox(QString::fromUtf8(fl.name), self);
+		QGridLayout* g = new QGridLayout(group);
+		g->addWidget(new QLabel(JVSControlsWidget::tr("P1"), group), 0, 1, Qt::AlignHCenter);
+		if (!fl.one_player)
+			g->addWidget(new QLabel(JVSControlsWidget::tr("P2"), group), 0, 2, Qt::AlignHCenter);
+		int row = 1;
+		for (const InputBindingInfo& b : fl.buttons)
+		{
+			const std::string base(b.name);
+			addBindRow(group, sif, g, row++,
+				QCoreApplication::translate(ACJV::TRANSLATION_CONTEXT, b.display_name),
+				base + "_P1", fl.one_player ? std::string() : (base + "_P2"));
+		}
+		if (fl.note)
+		{
+			QLabel* note = new QLabel(QCoreApplication::translate(ACJV::TRANSLATION_CONTEXT, fl.note), group);
+			note->setWordWrap(true);
+			note->setStyleSheet("font-style: italic;");
+			g->addWidget(note, row++, 0, 1, 3);
+		}
+		grid->addWidget(group, idx / 2, idx % 2);
+		idx++;
+	}
+	pageLayout->addLayout(grid);
+	pageLayout->addStretch(1);
+
+	JvsAutomapBinds p1 = {{"P1_Up", GenericInputBinding::DPadUp}, {"P1_Down", GenericInputBinding::DPadDown},
+		{"P1_Left", GenericInputBinding::DPadLeft}, {"P1_Right", GenericInputBinding::DPadRight}};
+	JvsAutomapBinds p2 = {{"P2_Up", GenericInputBinding::DPadUp}, {"P2_Down", GenericInputBinding::DPadDown},
+		{"P2_Left", GenericInputBinding::DPadLeft}, {"P2_Right", GenericInputBinding::DPadRight}};
+	for (const LayoutT& fl : layouts)
+		for (const InputBindingInfo& b : fl.buttons)
+		{
+			p1.emplace_back(std::string(b.name) + "_P1", b.generic_mapping);
+			if (!fl.one_player)
+				p2.emplace_back(std::string(b.name) + "_P2", b.generic_mapping);
+		}
+	addJvsAutomapButton(self, dialog, pageLayout, std::move(p1), std::move(p2));
+}
+
+void JVSControlsWidget::buildFightingPage()
+{
+	buildJvsLayoutPage(this, m_dialog->getProfileSettingsInterface(), m_dialog,
+		m_ui.fightingPageLayout, ACJV::GetFightingLayouts());
+}
+
+void JVSControlsWidget::buildRacingPage()
+{
+	SettingsInterface* sif = m_dialog->getProfileSettingsInterface();
+
+	QGroupBox* wheel = new QGroupBox(tr("Steering && Pedals"), this);
+	QGridLayout* g = new QGridLayout(wheel);
+	{
+		const auto cell = [&](int row, int col, const QString& label, const std::string& key, InputBindingInfo::Type type) {
+			QLabel* l = new QLabel(label, wheel);
+			l->setAlignment(Qt::AlignHCenter);
+			g->addWidget(l, row, col);
+			InputBindingWidget* bind = new InputBindingWidget(wheel, sif, type, ACJV::CONFIG_SECTION, key);
+			bind->setMinimumWidth(140);
+			bind->setMaximumWidth(140);
+			g->addWidget(bind, row + 1, col, Qt::AlignHCenter);
+			new HoverHighlight(bind, l);
+		};
+		cell(0, 0, tr("Shift Down"),     "Racing_ShiftDown_P1", InputBindingInfo::Type::Button);
+		cell(0, 1, tr("Accelerator"),    "Gas",                 InputBindingInfo::Type::HalfAxis);
+		cell(0, 2, tr("Shift Up"),       "Racing_ShiftUp_P1",   InputBindingInfo::Type::Button);
+		cell(2, 0, tr("Steering Left"),  "SteerLeft",           InputBindingInfo::Type::HalfAxis);
+		cell(2, 2, tr("Steering Right"), "SteerRight",          InputBindingInfo::Type::HalfAxis);
+		cell(4, 1, tr("Brake"),          "Brake",               InputBindingInfo::Type::HalfAxis);
+		cell(6, 2, tr("View Change"),    "Racing_View_P1",      InputBindingInfo::Type::Button);
+	}
+
+	std::vector<QGroupBox*> sections;
+	for (const ACJV::RacingLayoutInfo& rl : ACJV::GetRacingLayouts())
+	{
+		if (ACJV::LayoutKey(rl.buttons) == "Racing")
+			continue;
+		QGroupBox* group = new QGroupBox(QString::fromUtf8(rl.name), this);
+		QGridLayout* gg = new QGridLayout(group);
+		int row = 0;
+		for (const InputBindingInfo& b : rl.buttons)
+			addBindRow(group, sif, gg, row++,
+				QCoreApplication::translate(ACJV::TRANSLATION_CONTEXT, b.display_name),
+				std::string(b.name) + "_P1", "");
+		gg->setColumnStretch(0, 1);
+		sections.push_back(group);
+	}
+
+	QGridLayout* grid = new QGridLayout();
+	grid->addWidget(wheel, 0, 0, Qt::AlignTop);
+	for (int i = 0; i < static_cast<int>(sections.size()); i++)
+		grid->addWidget(sections[i], 0, i + 1, Qt::AlignTop);
+	for (int c = 0; c <= static_cast<int>(sections.size()); c++)
+		grid->setColumnStretch(c, 1);
+	m_ui.racingPageLayout->addLayout(grid);
+	m_ui.racingPageLayout->addStretch(1);
+
+	JvsAutomapBinds binds = {{"SteerLeft", GenericInputBinding::LeftStickLeft},
+		{"SteerRight", GenericInputBinding::LeftStickRight},
+		{"Gas", GenericInputBinding::R2}, {"Brake", GenericInputBinding::L2}};
+	for (const ACJV::RacingLayoutInfo& rl : ACJV::GetRacingLayouts())
+		for (const InputBindingInfo& b : rl.buttons)
+			binds.emplace_back(std::string(b.name) + "_P1", b.generic_mapping);
+	addJvsAutomapButton(this, m_dialog, m_ui.racingPageLayout, std::move(binds), {});
+}
+
+// Twinstick (Zoids) page: two lever compasses plus triggers and buttons (1 player).
+void JVSControlsWidget::buildTwinstickPage()
+{
+	SettingsInterface* sif = m_dialog->getProfileSettingsInterface();
+
+	QGroupBox* levers = new QGroupBox(tr("Levers"), this);
+	QGridLayout* g = new QGridLayout(levers);
+	g->setColumnStretch(0, 1);
+	addMovementCompass(levers, sif, g, 1, tr("Left Lever"),
+		"P1_LLeverUp", "P1_LLeverDown", "P1_LLeverLeft", "P1_LLeverRight");
+	g->setColumnStretch(4, 1);
+	addMovementCompass(levers, sif, g, 5, tr("Right Lever"),
+		"P1_RLeverUp", "P1_RLeverDown", "P1_RLeverLeft", "P1_RLeverRight");
+	g->setColumnStretch(8, 1);
+	m_ui.twinstickPageLayout->addWidget(levers);
+
+	QGroupBox* btns = new QGroupBox(tr("Triggers && Buttons"), this); // && -> literal & (Qt treats & as a mnemonic)
+	QGridLayout* bg = new QGridLayout(btns);
+	addBindRow(btns, sif, bg, 0, tr("Left Trigger"),  "P1_LTrigger", std::string(), InputBindingInfo::Type::HalfAxis);
+	addBindRow(btns, sif, bg, 1, tr("Right Trigger"), "P1_RTrigger", std::string(), InputBindingInfo::Type::HalfAxis);
+	addBindRow(btns, sif, bg, 2, tr("Left Button"),   "P1_LButton",  std::string());
+	addBindRow(btns, sif, bg, 3, tr("Right Button"),  "P1_RButton",  std::string());
+	bg->setColumnStretch(0, 1);
+	QHBoxLayout* brow = new QHBoxLayout();
+	brow->addWidget(btns, 1);
+	brow->addStretch(1);
+	m_ui.twinstickPageLayout->addLayout(brow);
+	m_ui.twinstickPageLayout->addStretch(1);
+
+	// Automap from the twin-stick defaults; Start/Service live on the System page, so skip them.
+	JvsAutomapBinds binds;
+	for (const InputBindingInfo& b : ACJV::GetTwinstickBindings())
+	{
+		const std::string name(b.name);
+		if (name == "P1_Start" || name == "P1_Service" || b.generic_mapping == GenericInputBinding::Unknown)
+			continue;
+		binds.emplace_back(b.name, b.generic_mapping);
+	}
+	addJvsAutomapButton(this, m_dialog, m_ui.twinstickPageLayout, std::move(binds), {});
+}
+
+// Lightgun (GunCon2) page: bind the gun's USB1/USB2 guncon2_* button keys directly here.
+void JVSControlsWidget::buildLightgunPage()
+{
+	SettingsInterface* sif = m_dialog->getProfileSettingsInterface();
+
+	// One row: label + P1/P2 binds to guncon2_<name>.
+	const auto gunRow = [&](QWidget* box, QGridLayout* gl, int r, const QString& label, const char* name,
+		InputBindingInfo::Type type) {
+		QLabel* desc = new QLabel(label, box);
+		gl->addWidget(desc, r, 0);
+		const std::string key = USB::GetConfigSubKey("guncon2", name);
+		const auto cell = [&](int col, const char* section) {
+			InputBindingWidget* wdg = new InputBindingWidget(box, sif, type, section, key);
+			wdg->setMinimumWidth(140);
+			wdg->setMaximumWidth(140);
+			gl->addWidget(wdg, r, col);
+			new HoverHighlight(wdg, desc);
+		};
+		cell(1, "USB1");
+		cell(2, "USB2");
+	};
+	const auto header = [&](QGridLayout* gl, QWidget* box) {
+		gl->addWidget(new QLabel(tr("P1"), box), 0, 1, Qt::AlignHCenter);
+		gl->addWidget(new QLabel(tr("P2"), box), 0, 2, Qt::AlignHCenter);
+	};
+
+	QLabel* aim = new QLabel(tr("Pick each player's aim device below: the mouse, or a controller's stick. Point off-screen to reload."), this);
+	aim->setStyleSheet("font-style: italic;"); // info, not a control
+	m_ui.lightgunPageLayout->addWidget(aim);
+
+	QGroupBox* aimGroup = new QGroupBox(tr("Aim Device"), this);
+	QGridLayout* ag = new QGridLayout(aimGroup);
+	header(ag, aimGroup);
+	ag->addWidget(new QLabel(tr("Device"), aimGroup), 1, 0);
+	// Chosen device stored in guncon2_Pointer; a controller auto-binds its left stick to Relative Aim.
+	const auto makeAimCombo = [&](int col, const char* section) {
+		QComboBox* combo = new QComboBox(aimGroup);
+		combo->setMinimumWidth(160);
+		m_aimCombos[col - 1] = combo;
+		connect(combo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this, section, combo](int) {
+			const QString dev = combo->currentData().toString();
+			if (dev.isEmpty())
+				return;
+			m_dialog->setStringValue(section, "guncon2_Pointer", dev.toUtf8().constData());
+			// A controller -> auto-fill this player's Relative Aim from its left stick. Mouse needs nothing.
+			if (!dev.startsWith(QStringLiteral("Pointer-")))
+			{
+				const auto mapping = InputManager::GetGenericBindingMapping(dev.toStdString());
+				const auto host = [&](GenericInputBinding g) -> std::string {
+					for (const auto& [gg, h] : mapping)
+						if (gg == g)
+							return h;
+					return std::string();
+				};
+				m_dialog->setStringValue(section, USB::GetConfigSubKey("guncon2", "RelativeLeft").c_str(),  host(GenericInputBinding::LeftStickLeft).c_str());
+				m_dialog->setStringValue(section, USB::GetConfigSubKey("guncon2", "RelativeRight").c_str(), host(GenericInputBinding::LeftStickRight).c_str());
+				m_dialog->setStringValue(section, USB::GetConfigSubKey("guncon2", "RelativeUp").c_str(),    host(GenericInputBinding::LeftStickUp).c_str());
+				m_dialog->setStringValue(section, USB::GetConfigSubKey("guncon2", "RelativeDown").c_str(),  host(GenericInputBinding::LeftStickDown).c_str());
+				for (InputBindingWidget* w : findChildren<InputBindingWidget*>())
+					w->reloadBinding();
+			}
+			g_emu_thread->applySettings(); // re-read so the GunCon2 picks up the new aim source
+		});
+		ag->addWidget(combo, 1, col, Qt::AlignLeft);
+	};
+	makeAimCombo(1, "USB1");
+	makeAimCombo(2, "USB2");
+	refreshAimDevices();
+	ag->setColumnStretch(0, 1);
+	QHBoxLayout* top = new QHBoxLayout();
+	top->addWidget(aimGroup, 1);
+	top->addStretch(1);
+	m_ui.lightgunPageLayout->addLayout(top);
+
+	QGroupBox* group = new QGroupBox(tr("Light gun buttons"), this);
+	QGridLayout* g = new QGridLayout(group);
+	QLabel* calibNote = new QLabel(tr("Reminder: calibrate in-game before playing. Most light gun games won't "
+		"work correctly if you don't. For Vampire Night, you need to calibrate both players."), group);
+	calibNote->setWordWrap(true);
+	calibNote->setStyleSheet("font-style: italic;");
+	g->addWidget(calibNote, 0, 0, 1, 3);
+	// P1/P2 header on its own row (row 0 is taken by the reminder).
+	g->addWidget(new QLabel(tr("P1"), group), 1, 1, Qt::AlignHCenter);
+	g->addWidget(new QLabel(tr("P2"), group), 1, 2, Qt::AlignHCenter);
+	gunRow(group, g, 2, tr("Trigger"),    "Trigger", InputBindingInfo::Type::Button);
+	gunRow(group, g, 3, tr("Foot Pedal"), "A",       InputBindingInfo::Type::Button);
+	g->setColumnStretch(0, 1);
+	g->setRowStretch(4, 1); // absorb the extra height beside the taller Relative Aim box
+
+	QGroupBox* rel = new QGroupBox(tr("Relative Aim (stick)"), this);
+	QGridLayout* rg = new QGridLayout(rel);
+	header(rg, rel);
+	gunRow(rel, rg, 1, tr("Up"),    "RelativeUp",    InputBindingInfo::Type::HalfAxis);
+	gunRow(rel, rg, 2, tr("Down"),  "RelativeDown",  InputBindingInfo::Type::HalfAxis);
+	gunRow(rel, rg, 3, tr("Left"),  "RelativeLeft",  InputBindingInfo::Type::HalfAxis);
+	gunRow(rel, rg, 4, tr("Right"), "RelativeRight", InputBindingInfo::Type::HalfAxis);
+	rg->setColumnStretch(0, 1);
+
+	QHBoxLayout* bottom = new QHBoxLayout();
+	bottom->addWidget(group, 1);
+	bottom->addWidget(rel, 1);
+	m_ui.lightgunPageLayout->addLayout(bottom);
+
+	// Per-player crosshair image (guncon2_cursor_* keys); clearing the path = system cursor.
+	const auto makeCrosshair = [&](const char* section, const QString& title) -> QGroupBox* {
+		QGroupBox* box = new QGroupBox(title, this);
+		QGridLayout* cg = new QGridLayout(box);
+		cg->setColumnStretch(1, 1);
+
+		QLineEdit* path = new QLineEdit(box);
+		QPushButton* browse = new QPushButton(tr("Browse..."), box);
+		ControllerSettingWidgetBinder::BindWidgetToInputProfileString(
+			sif, path, section, USB::GetConfigSubKey("guncon2", "cursor_path"), "");
+		connect(browse, &QPushButton::clicked, this, [this, path]() {
+			const QString p(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Select Crosshair Image"))));
+			if (!p.isEmpty())
+				path->setText(p);
+		});
+		QHBoxLayout* ph = new QHBoxLayout();
+		ph->addWidget(path, 1);
+		ph->addWidget(browse);
+		cg->addWidget(new QLabel(tr("Image"), box), 0, 0);
+		cg->addLayout(ph, 0, 1);
+
+		QDoubleSpinBox* scale = new QDoubleSpinBox(box);
+		scale->setMinimum(1);
+		scale->setMaximum(1000);
+		scale->setSingleStep(1);
+		scale->setDecimals(0);
+		scale->setSuffix(QStringLiteral("%"));
+		ControllerSettingWidgetBinder::BindWidgetToInputProfileFloat(
+			sif, scale, section, USB::GetConfigSubKey("guncon2", "cursor_scale"), 1.0f, 100.0f);
+		cg->addWidget(new QLabel(tr("Scale"), box), 1, 0);
+		cg->addWidget(scale, 1, 1);
+
+		QLineEdit* color = new QLineEdit(box);
+		ControllerSettingWidgetBinder::BindWidgetToInputProfileString(
+			sif, color, section, USB::GetConfigSubKey("guncon2", "cursor_color"), "#ffffff");
+		cg->addWidget(new QLabel(tr("Color"), box), 2, 0);
+		cg->addWidget(color, 2, 1);
+		return box;
+	};
+	QHBoxLayout* crosshairRow = new QHBoxLayout();
+	crosshairRow->addWidget(makeCrosshair("USB1", tr("Crosshair (P1)")), 1);
+	crosshairRow->addWidget(makeCrosshair("USB2", tr("Crosshair (P2)")), 1);
+	m_ui.lightgunPageLayout->addLayout(crosshairRow);
+
+	// Sinden lightgun border-friendly
+	QGroupBox* sinden = new QGroupBox(tr("Sinden Border"), this);
+	QGridLayout* sg = new QGridLayout(sinden);
+	sg->setColumnStretch(1, 1);
+	QCheckBox* sEnabled = new QCheckBox(tr("Show white border"), sinden);
+	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(sif, sEnabled, ACJV::CONFIG_SECTION, "SindenBorderEnabled", false);
+	sg->addWidget(sEnabled, 0, 0, 1, 2);
+	QComboBox* sMode = new QComboBox(sinden);
+	sMode->addItem(tr("4:3"));        // mode 0 = GS draw rect (the aspect-correct game image)
+	sMode->addItem(tr("Fullscreen")); // mode 1 = whole window
+	ControllerSettingWidgetBinder::BindWidgetToInputProfileInt(sif, sMode, ACJV::CONFIG_SECTION, "SindenBorderMode", 0);
+	sg->addWidget(new QLabel(tr("Aspect ratio"), sinden), 1, 0);
+	sg->addWidget(sMode, 1, 1);
+	QSpinBox* sThickness = new QSpinBox(sinden);
+	sThickness->setMinimum(1);
+	sThickness->setMaximum(100);
+	sThickness->setSuffix(tr(" px"));
+	ControllerSettingWidgetBinder::BindWidgetToInputProfileInt(sif, sThickness, ACJV::CONFIG_SECTION, "SindenBorderThickness", 10);
+	sg->addWidget(new QLabel(tr("Thickness"), sinden), 2, 0);
+	sg->addWidget(sThickness, 2, 1);
+	QHBoxLayout* sindenRow = new QHBoxLayout();
+	sindenRow->addWidget(sinden, 1); // left half of the row, like the Crosshair box above
+	sindenRow->addStretch(1);
+	m_ui.lightgunPageLayout->addLayout(sindenRow);
+
+	m_ui.lightgunPageLayout->addStretch(1);
+
+	addLightgunAutomapButton(this, m_dialog, m_ui.lightgunPageLayout);
+}
+
+void JVSControlsWidget::buildStandardPage()
+{
+	buildJvsLayoutPage(this, m_dialog->getProfileSettingsInterface(), m_dialog,
+		m_ui.standardPageLayout, ACJV::GetStandardLayouts());
+}
+
+// (Re)fill the lightgun Aim Device combos; devices enumerate asynchronously, so this reruns on show.
+void JVSControlsWidget::refreshAimDevices()
+{
+	const char* sections[2] = {"USB1", "USB2"};
+	for (int i = 0; i < 2; i++)
+	{
+		QComboBox* combo = m_aimCombos[i];
+		if (!combo)
+			continue;
+		combo->blockSignals(true);
+		combo->clear();
+		for (u32 j = 0; j < InputManager::MAX_POINTER_DEVICES; j++)
+		{
+			const QString name = (InputManager::MAX_POINTER_DEVICES == 1)
+				? tr("Mouse (system)") : QString::fromStdString(InputManager::GetPointerDeviceName(j));
+			combo->addItem(name, QString::fromStdString(InputManager::GetPointerDeviceName(j)));
+		}
+		for (const QPair<QString, QString>& dev : m_dialog->getDeviceList())
+		{
+			// Skip the "Mouse"/"Keyboard" pseudo-devices: no aim stick, and the mouse is already the pointer above.
+			if (dev.first == QLatin1String("Mouse") || dev.first == QLatin1String("Keyboard"))
+				continue;
+			combo->addItem(dev.second, dev.first);
+		}
+		const QString want = QString::fromStdString(m_dialog->getStringValue(sections[i], "guncon2_Pointer",
+			InputManager::GetPointerDeviceName(0).c_str()));
+		const int idx = combo->findData(want);
+		combo->setCurrentIndex((idx >= 0) ? idx : 0);
+		combo->blockSignals(false);
+	}
+}
+
+static void applyJvsAutomap(JVSControlsWidget* w, ControllerSettingsWindow* dialog, const QString& device,
+	const JvsAutomapBinds& binds, const char* section = ACJV::CONFIG_SECTION)
+{
+	const auto mapping = InputManager::GetGenericBindingMapping(device.toStdString());
+	if (mapping.empty())
+	{
+		QMessageBox::critical(w, JVSControlsWidget::tr("Automatic Mapping"),
+			JVSControlsWidget::tr("No default mapping is available for device '%1'.").arg(device));
+		return;
+	}
+
+	const auto apply = [&](SettingsInterface& si) {
+		for (const auto& [key, generic] : binds)
+		{
+			if (generic == GenericInputBinding::Unknown)
+				continue;
+			for (const auto& [g, host] : mapping)
+			{
+				if (g == generic)
+				{
+					si.SetStringValue(section, key.c_str(), host.c_str());
+					break;
+				}
+			}
+		}
+	};
+
+	if (dialog->isEditingGlobalSettings())
+	{
+		{
+			auto lock = Host::GetSettingsLock();
+			apply(*Host::Internal::GetBaseSettingsLayer());
+		}
+		Host::CommitBaseSettingChanges();
+	}
+	else
+	{
+		apply(*dialog->getProfileSettingsInterface());
+		dialog->getProfileSettingsInterface()->Save();
+		g_emu_thread->reloadInputBindings();
+	}
+
+	for (InputBindingWidget* widget : w->findChildren<InputBindingWidget*>())
+		widget->reloadBinding();
+	g_emu_thread->applySettings();
+}
+
+static QString jvsDeviceLabel(const QPair<QString, QString>& dev)
+{
+	return (dev.first.compare(dev.second, Qt::CaseInsensitive) == 0)
+		? dev.first : QStringLiteral("%1: %2").arg(dev.first).arg(dev.second);
+}
+
+static void showJvsAutomapMenu(JVSControlsWidget* w, ControllerSettingsWindow* dialog,
+	const JvsAutomapBinds& p1binds, const JvsAutomapBinds& p2binds)
+{
+	QMenu menu(w);
+	bool added = false;
+	if (p2binds.empty())
+	{
+		for (const QPair<QString, QString>& dev : dialog->getDeviceList())
+		{
+			const QString device = dev.first;
+			const QString label = jvsDeviceLabel(dev);
+			QObject::connect(menu.addAction(label), &QAction::triggered, w,
+				[w, dialog, device, p1binds]() { applyJvsAutomap(w, dialog, device, p1binds); });
+			added = true;
+		}
+	}
+	else
+	{
+		QMenu* sub[2] = {menu.addMenu(JVSControlsWidget::tr("Map Player 1 from...")),
+			menu.addMenu(JVSControlsWidget::tr("Map Player 2 from..."))};
+		const JvsAutomapBinds* binds[2] = {&p1binds, &p2binds};
+		for (const QPair<QString, QString>& dev : dialog->getDeviceList())
+		{
+			const QString device = dev.first;
+			const QString label = jvsDeviceLabel(dev);
+			for (int p = 0; p < 2; p++)
+			{
+				const JvsAutomapBinds* b = binds[p];
+				QObject::connect(sub[p]->addAction(label), &QAction::triggered, w,
+					[w, dialog, device, b]() { applyJvsAutomap(w, dialog, device, *b); });
+			}
+			added = true;
+		}
+	}
+	if (!added)
+		menu.addAction(JVSControlsWidget::tr("No devices available"))->setEnabled(false);
+	menu.exec(QCursor::pos());
+}
+
+static void clearJvsPageBindings(JVSControlsWidget* w, QBoxLayout* layout)
+{
+	if (QMessageBox::question(w, JVSControlsWidget::tr("Clear Mapping"),
+			JVSControlsWidget::tr("Clear all input bindings on this page?")) != QMessageBox::Yes)
+		return;
+	if (QWidget* page = layout->parentWidget())
+		for (InputBindingWidget* widget : page->findChildren<InputBindingWidget*>())
+			widget->clearBinding();
+}
+
+static void addMappingButtonRow(JVSControlsWidget* w, QBoxLayout* layout, QPushButton* automap)
+{
+	QPushButton* clear = new QPushButton(JVSControlsWidget::tr("Clear Mapping"), w);
+	QObject::connect(clear, &QPushButton::clicked, w, [w, layout]() { clearJvsPageBindings(w, layout); });
+	QHBoxLayout* row = new QHBoxLayout();
+	row->addWidget(automap, 1);
+	row->addWidget(clear);
+	layout->insertLayout(0, row);
+}
+
+static void addJvsAutomapButton(JVSControlsWidget* w, ControllerSettingsWindow* dialog, QBoxLayout* layout,
+	JvsAutomapBinds p1binds, JvsAutomapBinds p2binds)
+{
+	QPushButton* btn = new QPushButton(JVSControlsWidget::tr("Automatic Mapping (PS2 default layout)"), w);
+	QObject::connect(btn, &QPushButton::clicked, w,
+		[w, dialog, p1binds, p2binds]() { showJvsAutomapMenu(w, dialog, p1binds, p2binds); });
+	addMappingButtonRow(w, layout, btn);
+}
+
+static void showLightgunAutomapMenu(JVSControlsWidget* w, ControllerSettingsWindow* dialog, const JvsAutomapBinds& binds)
+{
+	QMenu menu(w);
+	QMenu* sub[2] = {menu.addMenu(JVSControlsWidget::tr("Map Player 1 from...")),
+		menu.addMenu(JVSControlsWidget::tr("Map Player 2 from..."))};
+	const char* sections[2] = {"USB1", "USB2"};
+	bool added = false;
+	for (const QPair<QString, QString>& dev : dialog->getDeviceList())
+	{
+		const QString device = dev.first;
+		const QString label = jvsDeviceLabel(dev);
+		for (int p = 0; p < 2; p++)
+		{
+			const char* section = sections[p];
+			QObject::connect(sub[p]->addAction(label), &QAction::triggered, w,
+				[w, dialog, device, binds, section]() { applyJvsAutomap(w, dialog, device, binds, section); });
+		}
+		added = true;
+	}
+	if (!added)
+		menu.addAction(JVSControlsWidget::tr("No devices available"))->setEnabled(false);
+	menu.exec(QCursor::pos());
+}
+
+static void addLightgunAutomapButton(JVSControlsWidget* w, ControllerSettingsWindow* dialog, QBoxLayout* layout)
+{
+	// GunCon2 defaults (guncon2_* keys); Start and Coins are on the System page, so skip them.
+	JvsAutomapBinds binds;
+	for (const InputBindingInfo& bi : USB::GetDeviceBindings("guncon2", 0))
+	{
+		const std::string_view name(bi.name);
+		if (name == "Start" || name == "Select")
+			continue;
+		if (bi.generic_mapping != GenericInputBinding::Unknown)
+			binds.emplace_back(USB::GetConfigSubKey("guncon2", bi.name), bi.generic_mapping);
+	}
+	QPushButton* btn = new QPushButton(JVSControlsWidget::tr("Automatic Mapping (PS2 default layout)"), w);
+	QObject::connect(btn, &QPushButton::clicked, w,
+		[w, dialog, binds]() { showLightgunAutomapMenu(w, dialog, binds); });
+	addMappingButtonRow(w, layout, btn);
 }
 
 #include "moc_JVSControlsWidget.cpp"

--- a/pcsx2-qt/Settings/JVSControlsWidget.h
+++ b/pcsx2-qt/Settings/JVSControlsWidget.h
@@ -7,7 +7,14 @@
 
 #include <QtWidgets/QWidget>
 
+#include <span>
+#include <string>
+
 class ControllerSettingsWindow;
+class QShowEvent;
+class QComboBox;
+class QVBoxLayout;
+struct InputBindingInfo;
 
 class JVSControlsWidget final : public QWidget
 {
@@ -17,11 +24,26 @@ public:
 	JVSControlsWidget(QWidget* parent, ControllerSettingsWindow* dialog);
 	~JVSControlsWidget() override;
 
+protected:
+	void showEvent(QShowEvent* event) override;
+
 private:
+	void refreshBoardType();
+	void autoPickInputPage();
 	void bindDIPSwitchWidgets();
 	void bindSystemButtonWidgets();
-	void bindDrumWidgets();
+	void buildDrumPage();
+	void buildFightingPage();
+	void buildRacingPage();
+	void buildTwinstickPage();
+	void buildLightgunPage();
+	void buildStandardPage();
+	void refreshAimDevices();
+	void refreshMacrosPage(); // rebuild the Macros view (layout dropdown + per-layout rows)
+	void buildMacroRows(QVBoxLayout* rowsLayout, const std::string& layoutKey, std::span<const InputBindingInfo> lbuttons);
 
 	Ui::JVSControlsWidget m_ui;
 	ControllerSettingsWindow* m_dialog;
+	std::string m_autoPickedGameId;
+	QComboBox* m_aimCombos[2] = {}; // [0] = USB1/P1, [1] = USB2/P2
 };

--- a/pcsx2-qt/Settings/JVSControlsWidget.ui
+++ b/pcsx2-qt/Settings/JVSControlsWidget.ui
@@ -21,111 +21,273 @@
       </property>
       <layout class="QVBoxLayout" name="scrollLayout">
 
-       <!-- Hardware (full width) -->
+       <!-- View selector: Bindings / Settings (mirrors the Controller tab's header) -->
        <item>
-        <widget class="QGroupBox" name="hardwareGroup">
-         <property name="title"><string>Hardware</string></property>
-         <layout class="QGridLayout" name="hardwareLayout" columnstretch="0,1">
-          <item row="0" column="0">
-           <widget class="QLabel" name="boardTypeLabel">
-            <property name="text"><string>JVS Board Type:</string></property>
-            <property name="buddy"><cstring>boardType</cstring></property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="boardType">
-            <property name="enabled"><bool>false</bool></property>
-            <property name="toolTip"><string>Auto-detected from the game. Manual selection is not yet supported.</string></property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-
-       <!-- DIP Switches (left) + System Buttons (right) -->
-       <item>
-        <layout class="QHBoxLayout" name="middleRow">
+        <layout class="QHBoxLayout" name="viewSelectorRow">
          <item>
-          <widget class="QGroupBox" name="dipSwitchGroup">
-           <property name="title"><string>DIP Switches</string></property>
-           <layout class="QGridLayout" name="dipSwitchLayout" columnstretch="1,0">
-            <item row="0" column="0">
-             <widget class="QCheckBox" name="testMode">
-              <property name="text"><string>Test Mode</string></property>
-              <property name="toolTip"><string>Enter the machine's diagnostic test menu</string></property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="InputBindingWidget" name="toggleTestMode">
-              <property name="minimumSize"><size><width>225</width><height>0</height></size></property>
-              <property name="maximumSize"><size><width>225</width><height>16777215</height></size></property>
-              <property name="text"><string/></property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QCheckBox" name="videoVoltage">
-              <property name="text"><string>Video Voltage</string></property>
-              <property name="toolTip"><string>Video output voltage level (3.3V when ON, 5V when OFF)</string></property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="InputBindingWidget" name="toggleVideoVoltage">
-              <property name="minimumSize"><size><width>225</width><height>0</height></size></property>
-              <property name="maximumSize"><size><width>225</width><height>16777215</height></size></property>
-              <property name="text"><string/></property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QCheckBox" name="monitorSyncFrequency">
-              <property name="text"><string>Monitor Sync Frequency</string></property>
-              <property name="toolTip"><string>Monitor sync frequency (31kHz when ON, 15kHz when OFF)</string></property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="InputBindingWidget" name="toggleMonitorSyncFrequency">
-              <property name="minimumSize"><size><width>225</width><height>0</height></size></property>
-              <property name="maximumSize"><size><width>225</width><height>16777215</height></size></property>
-              <property name="text"><string/></property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QCheckBox" name="videoSyncSplit">
-              <property name="text"><string>Video Sync Split</string></property>
-              <property name="toolTip"><string>Video sync signal mode (separate H/V sync when ON, composite sync when OFF)</string></property>
-             </widget>
-            </item>
-            <item row="3" column="1">
-             <widget class="InputBindingWidget" name="toggleVideoSyncSplit">
-              <property name="minimumSize"><size><width>225</width><height>0</height></size></property>
-              <property name="maximumSize"><size><width>225</width><height>16777215</height></size></property>
-              <property name="text"><string/></property>
-             </widget>
-            </item>
-           </layout>
+          <widget class="QToolButton" name="viewBindings">
+           <property name="text"><string>Bindings</string></property>
+           <property name="icon">
+            <iconset theme="controller-line"><normaloff>.</normaloff>.</iconset>
+           </property>
+           <property name="checkable"><bool>true</bool></property>
+           <property name="checked"><bool>true</bool></property>
+           <property name="autoExclusive"><bool>true</bool></property>
+           <property name="toolButtonStyle"><enum>Qt::ToolButtonTextBesideIcon</enum></property>
+           <property name="autoRaise"><bool>true</bool></property>
           </widget>
          </item>
          <item>
-          <widget class="QGroupBox" name="systemButtonsGroup">
-           <property name="title"><string>System Buttons</string></property>
-           <layout class="QGridLayout" name="systemButtonsLayout" columnstretch="1,0">
-           </layout>
+          <widget class="QToolButton" name="viewSettings">
+           <property name="text"><string>Settings</string></property>
+           <property name="icon">
+            <iconset theme="checkbox-multiple-blank-line"><normaloff>.</normaloff>.</iconset>
+           </property>
+           <property name="checkable"><bool>true</bool></property>
+           <property name="autoExclusive"><bool>true</bool></property>
+           <property name="toolButtonStyle"><enum>Qt::ToolButtonTextBesideIcon</enum></property>
+           <property name="autoRaise"><bool>true</bool></property>
           </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="viewMacros">
+           <property name="text"><string>Macros</string></property>
+           <property name="icon">
+            <iconset theme="flashlight-line"><normaloff>.</normaloff>.</iconset>
+           </property>
+           <property name="checkable"><bool>true</bool></property>
+           <property name="autoExclusive"><bool>true</bool></property>
+           <property name="toolButtonStyle"><enum>Qt::ToolButtonTextBesideIcon</enum></property>
+           <property name="autoRaise"><bool>true</bool></property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="viewSelectorSpacer">
+           <property name="orientation"><enum>Qt::Horizontal</enum></property>
+           <property name="sizeHint" stdset="0"><size><width>40</width><height>20</height></size></property>
+          </spacer>
          </item>
         </layout>
        </item>
 
-       <!-- System Settings (full width) -->
+       <!-- Outer view stack: [0] Bindings (hardware + per-mode pages), [1] Settings -->
        <item>
-        <widget class="QGroupBox" name="systemSettingsGroup">
-         <property name="title"><string>System Settings</string></property>
-         <layout class="QGridLayout" name="systemSettingsLayout" columnstretch="1,0">
-          <item row="0" column="0" colspan="2">
-           <widget class="QCheckBox" name="suppressDaemon">
-            <property name="text"><string>Suppress DAEMON security thread</string></property>
-            <property name="toolTip"><string>Avoids dongle I/O errors by suppressing the DAEMON driver security dongle check routine</string></property>
-           </widget>
-          </item>
-         </layout>
+        <widget class="QStackedWidget" name="viewStack">
+         <widget class="QWidget" name="bindingsView">
+          <layout class="QVBoxLayout" name="bindingsViewLayout">
+           <property name="leftMargin"><number>0</number></property>
+           <property name="topMargin"><number>0</number></property>
+           <property name="rightMargin"><number>0</number></property>
+           <property name="bottomMargin"><number>0</number></property>
+
+           <!-- Hardware + input-page selector (always visible in Bindings view) -->
+           <item>
+            <layout class="QHBoxLayout" name="hardwareRow">
+             <item>
+              <spacer name="hwLeftSpacer">
+               <property name="orientation"><enum>Qt::Horizontal</enum></property>
+               <property name="sizeHint" stdset="0"><size><width>0</width><height>0</height></size></property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="hardwareGroup">
+             <property name="title"><string>Hardware</string></property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <layout class="QGridLayout" name="hardwareLayout">
+              <item row="0" column="0">
+               <widget class="QLabel" name="boardTypeLabel">
+                <property name="text"><string>JVS Board Type:</string></property>
+                <property name="alignment"><set>Qt::AlignRight|Qt::AlignVCenter</set></property>
+                <property name="buddy"><cstring>boardType</cstring></property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QComboBox" name="boardType">
+                <property name="enabled"><bool>false</bool></property>
+                <property name="minimumWidth"><number>200</number></property>
+                <property name="maximumWidth"><number>200</number></property>
+                <property name="toolTip"><string>Auto-detected from the game. Manual selection is not yet supported.</string></property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="pageLabel">
+                <property name="text"><string>JVS Mode:</string></property>
+                <property name="alignment"><set>Qt::AlignRight|Qt::AlignVCenter</set></property>
+                <property name="buddy"><cstring>pageSelector</cstring></property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QComboBox" name="pageSelector">
+                <property name="minimumWidth"><number>200</number></property>
+                <property name="maximumWidth"><number>200</number></property>
+                <property name="toolTip"><string>Choose which JVS input group to configure (auto-selected from the game's mode).</string></property>
+               </widget>
+              </item>
+             </layout>
+              </widget>
+             </item>
+             <item>
+              <spacer name="hwRightSpacer">
+               <property name="orientation"><enum>Qt::Horizontal</enum></property>
+               <property name="sizeHint" stdset="0"><size><width>0</width><height>0</height></size></property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
+
+           <!-- Per-mode input pages -->
+           <item>
+            <widget class="QStackedWidget" name="pageStack">
+             <widget class="QWidget" name="systemPage">
+              <layout class="QVBoxLayout" name="systemPageLayout">
+               <property name="leftMargin"><number>0</number></property>
+               <property name="rightMargin"><number>0</number></property>
+               <item>
+                <layout class="QHBoxLayout" name="middleRow">
+                 <item>
+                  <widget class="QGroupBox" name="dipSwitchGroup">
+                   <property name="title"><string>DIP Switches</string></property>
+                   <layout class="QGridLayout" name="dipSwitchLayout" columnstretch="1,0">
+                    <item row="0" column="0">
+                     <widget class="QCheckBox" name="testMode">
+                      <property name="text"><string>Test Mode</string></property>
+                      <property name="toolTip"><string>Enter the machine's diagnostic test menu</string></property>
+                     </widget>
+                    </item>
+                    <item row="0" column="1">
+                     <widget class="InputBindingWidget" name="toggleTestMode">
+                      <property name="minimumSize"><size><width>225</width><height>0</height></size></property>
+                      <property name="maximumSize"><size><width>225</width><height>16777215</height></size></property>
+                      <property name="text"><string/></property>
+                     </widget>
+                    </item>
+                    <item row="1" column="0">
+                     <widget class="QCheckBox" name="videoVoltage">
+                      <property name="text"><string>Video Voltage</string></property>
+                      <property name="toolTip"><string>Video output voltage level (3.3V when ON, 5V when OFF)</string></property>
+                     </widget>
+                    </item>
+                    <item row="1" column="1">
+                     <widget class="InputBindingWidget" name="toggleVideoVoltage">
+                      <property name="minimumSize"><size><width>225</width><height>0</height></size></property>
+                      <property name="maximumSize"><size><width>225</width><height>16777215</height></size></property>
+                      <property name="text"><string/></property>
+                     </widget>
+                    </item>
+                    <item row="2" column="0">
+                     <widget class="QCheckBox" name="monitorSyncFrequency">
+                      <property name="text"><string>Monitor Sync Frequency</string></property>
+                      <property name="toolTip"><string>Monitor sync frequency (31kHz when ON, 15kHz when OFF)</string></property>
+                     </widget>
+                    </item>
+                    <item row="2" column="1">
+                     <widget class="InputBindingWidget" name="toggleMonitorSyncFrequency">
+                      <property name="minimumSize"><size><width>225</width><height>0</height></size></property>
+                      <property name="maximumSize"><size><width>225</width><height>16777215</height></size></property>
+                      <property name="text"><string/></property>
+                     </widget>
+                    </item>
+                    <item row="3" column="0">
+                     <widget class="QCheckBox" name="videoSyncSplit">
+                      <property name="text"><string>Video Sync Split</string></property>
+                      <property name="toolTip"><string>Video sync signal mode (separate H/V sync when ON, composite sync when OFF)</string></property>
+                     </widget>
+                    </item>
+                    <item row="3" column="1">
+                     <widget class="InputBindingWidget" name="toggleVideoSyncSplit">
+                      <property name="minimumSize"><size><width>225</width><height>0</height></size></property>
+                      <property name="maximumSize"><size><width>225</width><height>16777215</height></size></property>
+                      <property name="text"><string/></property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QGroupBox" name="systemButtonsGroup">
+                   <property name="title"><string>System Buttons</string></property>
+                   <layout class="QGridLayout" name="systemButtonsLayout" columnstretch="1,0">
+                   </layout>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="systemSettingsGroup">
+                 <property name="title"><string>System Settings</string></property>
+                 <layout class="QGridLayout" name="systemSettingsLayout" columnstretch="1,0">
+                  <item row="0" column="0" colspan="2">
+                   <widget class="QCheckBox" name="suppressDaemon">
+                    <property name="text"><string>Suppress DAEMON security thread</string></property>
+                    <property name="toolTip"><string>Avoids dongle I/O errors by suppressing the DAEMON driver security dongle check routine</string></property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+             <widget class="QWidget" name="fightingPage">
+              <layout class="QVBoxLayout" name="fightingPageLayout">
+               <property name="leftMargin"><number>0</number></property>
+               <property name="rightMargin"><number>0</number></property>
+              </layout>
+             </widget>
+             <widget class="QWidget" name="racingPage">
+              <layout class="QVBoxLayout" name="racingPageLayout">
+               <property name="leftMargin"><number>0</number></property>
+               <property name="rightMargin"><number>0</number></property>
+              </layout>
+             </widget>
+             <widget class="QWidget" name="drumPage">
+              <layout class="QVBoxLayout" name="drumPageLayout">
+               <property name="leftMargin"><number>0</number></property>
+               <property name="rightMargin"><number>0</number></property>
+              </layout>
+             </widget>
+             <widget class="QWidget" name="twinstickPage">
+              <layout class="QVBoxLayout" name="twinstickPageLayout">
+               <property name="leftMargin"><number>0</number></property>
+               <property name="rightMargin"><number>0</number></property>
+              </layout>
+             </widget>
+             <widget class="QWidget" name="lightgunPage">
+              <layout class="QVBoxLayout" name="lightgunPageLayout">
+               <property name="leftMargin"><number>0</number></property>
+               <property name="rightMargin"><number>0</number></property>
+              </layout>
+             </widget>
+             <widget class="QWidget" name="standardPage">
+              <layout class="QVBoxLayout" name="standardPageLayout">
+               <property name="leftMargin"><number>0</number></property>
+               <property name="rightMargin"><number>0</number></property>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="settingsView">
+          <layout class="QVBoxLayout" name="settingsViewLayout">
+           <property name="leftMargin"><number>0</number></property>
+           <property name="topMargin"><number>0</number></property>
+           <property name="rightMargin"><number>0</number></property>
+           <property name="bottomMargin"><number>0</number></property>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="macrosView">
+          <layout class="QVBoxLayout" name="macrosViewLayout">
+           <property name="leftMargin"><number>0</number></property>
+           <property name="topMargin"><number>0</number></property>
+           <property name="rightMargin"><number>0</number></property>
+           <property name="bottomMargin"><number>0</number></property>
+          </layout>
+         </widget>
         </widget>
        </item>
 
@@ -151,7 +313,11 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>viewBindings</tabstop>
+  <tabstop>viewSettings</tabstop>
+  <tabstop>viewMacros</tabstop>
   <tabstop>boardType</tabstop>
+  <tabstop>pageSelector</tabstop>
   <tabstop>testMode</tabstop>
   <tabstop>toggleTestMode</tabstop>
   <tabstop>videoVoltage</tabstop>

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -21,14 +21,7 @@ enum ACJVCMD {
 };
 
 bool ACJV::enabled = false;
-#define JVS_PKTINDX_TO_ADDR(index) ((2 * (index & 0x3FFF)) + 0x12400000)
-
-#define ANS(addr, what) case addr: return what
-#define JVS_CHECK_ADDR_JVSPACKET(addr) ((addr & 0x00000F00) == 0x00000600) // when ACJV writes to 0x12406???.
 void do_acjv_packet();
-
-u16 RootAddr = 0x3E6F;
-u16 Sent0D = 0, Sent0C = 0;
 
 // R/W arrays are u8 because ACJV is processing (u8) arrays, but the MMIO is performed over (volatile u16*). leaving the higher byte empty
 std::array<u8, ACJV_PACKETSIZE> rdbuf; // NAMCO_PCB ---> IOP
@@ -136,14 +129,14 @@ static constexpr const std::array<InputBindingInfo, JVS_DRUM_CHANNEL_MAX> s_jvs_
 // Zoids twin-stick (NM00016/25): custom JVS switch-word wiring, mapped live via the I/O-TEST SWITCH TEST.
 // Left lever -> left stick, right lever -> right stick; Start/Service on the standard JVS bits.
 static constexpr const std::array<InputBindingInfo, 14> s_twinstick_p1_button_bindings = {{
-	{"P1_LLeverUp",    TRANSLATE_NOOP("JVS", "P1 Left Lever Up"),     nullptr, InputBindingInfo::Type::HalfAxis, 0x0001, GenericInputBinding::LeftStickUp},
-	{"P1_LLeverDown",  TRANSLATE_NOOP("JVS", "P1 Left Lever Down"),   nullptr, InputBindingInfo::Type::HalfAxis, 0x8000, GenericInputBinding::LeftStickDown},
-	{"P1_LLeverLeft",  TRANSLATE_NOOP("JVS", "P1 Left Lever Left"),   nullptr, InputBindingInfo::Type::HalfAxis, 0x4000, GenericInputBinding::LeftStickLeft},
-	{"P1_LLeverRight", TRANSLATE_NOOP("JVS", "P1 Left Lever Right"),  nullptr, InputBindingInfo::Type::HalfAxis, 0x2000, GenericInputBinding::LeftStickRight},
-	{"P1_RLeverUp",    TRANSLATE_NOOP("JVS", "P1 Right Lever Up"),    nullptr, InputBindingInfo::Type::HalfAxis, 0x0010, GenericInputBinding::RightStickUp},
-	{"P1_RLeverDown",  TRANSLATE_NOOP("JVS", "P1 Right Lever Down"),  nullptr, InputBindingInfo::Type::HalfAxis, 0x0008, GenericInputBinding::RightStickDown},
-	{"P1_RLeverLeft",  TRANSLATE_NOOP("JVS", "P1 Right Lever Left"),  nullptr, InputBindingInfo::Type::HalfAxis, 0x0004, GenericInputBinding::RightStickLeft},
-	{"P1_RLeverRight", TRANSLATE_NOOP("JVS", "P1 Right Lever Right"), nullptr, InputBindingInfo::Type::HalfAxis, 0x0002, GenericInputBinding::RightStickRight},
+	{"P1_LLeverUp",    TRANSLATE_NOOP("JVS", "P1 Left Lever Up"),     nullptr, InputBindingInfo::Type::Button,   0x0001, GenericInputBinding::LeftStickUp},
+	{"P1_LLeverDown",  TRANSLATE_NOOP("JVS", "P1 Left Lever Down"),   nullptr, InputBindingInfo::Type::Button,   0x8000, GenericInputBinding::LeftStickDown},
+	{"P1_LLeverLeft",  TRANSLATE_NOOP("JVS", "P1 Left Lever Left"),   nullptr, InputBindingInfo::Type::Button,   0x4000, GenericInputBinding::LeftStickLeft},
+	{"P1_LLeverRight", TRANSLATE_NOOP("JVS", "P1 Left Lever Right"),  nullptr, InputBindingInfo::Type::Button,   0x2000, GenericInputBinding::LeftStickRight},
+	{"P1_RLeverUp",    TRANSLATE_NOOP("JVS", "P1 Right Lever Up"),    nullptr, InputBindingInfo::Type::Button,   0x0010, GenericInputBinding::RightStickUp},
+	{"P1_RLeverDown",  TRANSLATE_NOOP("JVS", "P1 Right Lever Down"),  nullptr, InputBindingInfo::Type::Button,   0x0008, GenericInputBinding::RightStickDown},
+	{"P1_RLeverLeft",  TRANSLATE_NOOP("JVS", "P1 Right Lever Left"),  nullptr, InputBindingInfo::Type::Button,   0x0004, GenericInputBinding::RightStickLeft},
+	{"P1_RLeverRight", TRANSLATE_NOOP("JVS", "P1 Right Lever Right"), nullptr, InputBindingInfo::Type::Button,   0x0002, GenericInputBinding::RightStickRight},
 	{"P1_LTrigger",    TRANSLATE_NOOP("JVS", "P1 Left Trigger"),      nullptr, InputBindingInfo::Type::HalfAxis, 0x0400, GenericInputBinding::L2},
 	{"P1_RTrigger",    TRANSLATE_NOOP("JVS", "P1 Right Trigger"),     nullptr, InputBindingInfo::Type::HalfAxis, 0x1000, GenericInputBinding::R2},
 	{"P1_LButton",     TRANSLATE_NOOP("JVS", "P1 Left Button"),       nullptr, InputBindingInfo::Type::Button,   0x0200, GenericInputBinding::L1},
@@ -152,152 +145,145 @@ static constexpr const std::array<InputBindingInfo, 14> s_twinstick_p1_button_bi
 	{"P1_Service",     TRANSLATE_NOOP("JVS", "P1 Service"),          nullptr, InputBindingInfo::Type::Button,   JVS_BTN_SERVICE, GenericInputBinding::Select},
 }};
 
-// Per-layout face button default inputs (BTN1-6), mirroring each game's
-// official PS2 port pad. Some games share the same layout. Rows follow FightingLayout order.
-static constexpr GenericInputBinding s_fighting_face_buttons[][6] = {
-	// BTN1,                       BTN2,                          BTN3,                         BTN4,                          BTN5,                         BTN6
-	{GenericInputBinding::Square, GenericInputBinding::Triangle, GenericInputBinding::Unknown, GenericInputBinding::Cross,    GenericInputBinding::Circle,  GenericInputBinding::Unknown}, // TEKKEN
-	{GenericInputBinding::Square, GenericInputBinding::Triangle, GenericInputBinding::Cross,   GenericInputBinding::Circle,   GenericInputBinding::Unknown, GenericInputBinding::Unknown}, // GUNDAM (YuYu + Gundam VS)
-	{GenericInputBinding::Square, GenericInputBinding::Triangle, GenericInputBinding::L1,      GenericInputBinding::Cross,    GenericInputBinding::Circle,  GenericInputBinding::R1},      // SIX_BUTTON
-	{GenericInputBinding::Square, GenericInputBinding::Triangle, GenericInputBinding::Circle,  GenericInputBinding::Cross,    GenericInputBinding::Unknown, GenericInputBinding::Unknown}, // SOULCAL
-	{GenericInputBinding::Square, GenericInputBinding::Cross,    GenericInputBinding::Circle,  GenericInputBinding::Triangle, GenericInputBinding::Unknown, GenericInputBinding::Unknown}, // BLOODYROAR
+// Per-layout fighting action buttons (real labels + per-layout config keys), selected by gameid via
+// GetFightingButtons. D-pad/Start stay in the global P1/P2 tables; generic_mapping = the PS2-port default.
+static constexpr InputBindingInfo s_fight_tekken[] = {
+	{"Tekken_LeftPunch",  TRANSLATE_NOOP("JVS", "Left Punch"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_1, GenericInputBinding::Square},
+	{"Tekken_RightPunch", TRANSLATE_NOOP("JVS", "Right Punch"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Triangle},
+	{"Tekken_LeftKick",   TRANSLATE_NOOP("JVS", "Left Kick"),   nullptr, InputBindingInfo::Type::Button, JVS_BTN_4, GenericInputBinding::Cross},
+	{"Tekken_RightKick",  TRANSLATE_NOOP("JVS", "Right Kick"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_5, GenericInputBinding::Circle},
+};
+static constexpr InputBindingInfo s_fight_soulcal[] = {
+	{"SoulCal_Horizontal", TRANSLATE_NOOP("JVS", "Horizontal Attack"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_1, GenericInputBinding::Square},
+	{"SoulCal_Vertical",   TRANSLATE_NOOP("JVS", "Vertical Attack"),   nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Triangle},
+	{"SoulCal_Kick",       TRANSLATE_NOOP("JVS", "Kick"),              nullptr, InputBindingInfo::Type::Button, JVS_BTN_3, GenericInputBinding::Circle},
+	{"SoulCal_Guard",      TRANSLATE_NOOP("JVS", "Guard"),             nullptr, InputBindingInfo::Type::Button, JVS_BTN_4, GenericInputBinding::Cross},
+};
+static constexpr InputBindingInfo s_fight_sixbutton[] = {
+	{"SixButton_LightPunch",  TRANSLATE_NOOP("JVS", "Light Punch"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_1, GenericInputBinding::Square},
+	{"SixButton_MediumPunch", TRANSLATE_NOOP("JVS", "Medium Punch"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Triangle},
+	{"SixButton_HeavyPunch",  TRANSLATE_NOOP("JVS", "Heavy Punch"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_3, GenericInputBinding::L1},
+	{"SixButton_LightKick",   TRANSLATE_NOOP("JVS", "Light Kick"),   nullptr, InputBindingInfo::Type::Button, JVS_BTN_4, GenericInputBinding::Cross},
+	{"SixButton_MediumKick",  TRANSLATE_NOOP("JVS", "Medium Kick"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_5, GenericInputBinding::Circle},
+	{"SixButton_HeavyKick",   TRANSLATE_NOOP("JVS", "Heavy Kick"),   nullptr, InputBindingInfo::Type::Button, JVS_BTN_6, GenericInputBinding::R1},
+};
+static constexpr InputBindingInfo s_fight_gundam[] = {
+	{"Gundam_Shoot",  TRANSLATE_NOOP("JVS", "Shoot"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_1, GenericInputBinding::Square},
+	{"Gundam_Melee",  TRANSLATE_NOOP("JVS", "Melee"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Triangle},
+	{"Gundam_Jump",   TRANSLATE_NOOP("JVS", "Jump"),   nullptr, InputBindingInfo::Type::Button, JVS_BTN_3, GenericInputBinding::Cross},
+	{"Gundam_Target", TRANSLATE_NOOP("JVS", "Target"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_4, GenericInputBinding::Circle},
+};
+static constexpr InputBindingInfo s_fight_bloodyroar[] = {
+	{"BloodyRoar_Punch", TRANSLATE_NOOP("JVS", "Punch"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_1, GenericInputBinding::Square},
+	{"BloodyRoar_Kick",  TRANSLATE_NOOP("JVS", "Kick"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Cross},
+	{"BloodyRoar_Beast", TRANSLATE_NOOP("JVS", "Beast"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_3, GenericInputBinding::Circle},
+	{"BloodyRoar_Block", TRANSLATE_NOOP("JVS", "Block"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_4, GenericInputBinding::Triangle},
 };
 
-static std::array<InputBindingInfo, 12> s_active_p1_bindings;
-static std::array<InputBindingInfo, 12> s_active_p2_bindings;
-
-// Copy the base P1/P2 tables, then set the default pad button of BTN1-6 from
-// the game's layout row. Binding table indices:
-//   [0]=Up    [1]=Down  [2]=Left   [3]=Right
-//   [4]=BTN1  [5]=BTN2  [6]=BTN3   [7]=BTN4
-//   [8]=BTN5  [9]=BTN6  [10]=Start [11]=Service
-static void UpdateFightingBindings(FightingLayout layout)
-{
-	s_active_p1_bindings = s_jvs_p1_button_bindings;
-	s_active_p2_bindings = s_jvs_p2_button_bindings;
-	const auto& face = s_fighting_face_buttons[static_cast<int>(layout)];
-	constexpr int BTN1_INDEX = 4;
-	for (int i = 0; i < 6; i++)
-	{
-		s_active_p1_bindings[BTN1_INDEX + i].generic_mapping = face[i];
-		s_active_p2_bindings[BTN1_INDEX + i].generic_mapping = face[i];
-	}
-}
-
-static constexpr GenericInputBinding s_standard_face_buttons[][6] = { // one row per game, BTN1-6 -> pad button
-	{GenericInputBinding::Square, GenericInputBinding::Triangle, GenericInputBinding::L1,      GenericInputBinding::Cross,   GenericInputBinding::Circle,  GenericInputBinding::R1},      // BASEBALL
-	{GenericInputBinding::Cross,  GenericInputBinding::Square,   GenericInputBinding::Unknown, GenericInputBinding::Unknown, GenericInputBinding::Unknown, GenericInputBinding::Unknown}, // SMASHCOURT
-	{GenericInputBinding::Cross,  GenericInputBinding::Square,   GenericInputBinding::Triangle, GenericInputBinding::Unknown, GenericInputBinding::Unknown, GenericInputBinding::Unknown}, // TECHNICBEAT
+// Per-game fighting layouts: identical button scheme to the parent franchise (same JVS bits + host
+// defaults), but their own config keys so each game can be remapped independently of the others.
+static constexpr InputBindingInfo s_fight_fate[] = { // Fate: Unlimited Codes (PS2 manual: Weak/Medium/Strong + Reflect Guard)
+	{"Fate_Weak",   TRANSLATE_NOOP("JVS", "Weak Attack"),   nullptr, InputBindingInfo::Type::Button, JVS_BTN_1, GenericInputBinding::Square},
+	{"Fate_Medium", TRANSLATE_NOOP("JVS", "Medium Attack"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Triangle},
+	{"Fate_Strong", TRANSLATE_NOOP("JVS", "Strong Attack"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_3, GenericInputBinding::Circle},
+	{"Fate_Guard",  TRANSLATE_NOOP("JVS", "Reflect Guard"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_4, GenericInputBinding::Cross},
+};
+static constexpr InputBindingInfo s_fight_kinnikuman[] = { // Kinnikuman MGP 1 & 2: Attack, Throw/Grab, Special, Guard
+	{"Kinnikuman_Attack",    TRANSLATE_NOOP("JVS", "Attack"),     nullptr, InputBindingInfo::Type::Button, JVS_BTN_1, GenericInputBinding::Square},
+	{"Kinnikuman_ThrowGrab", TRANSLATE_NOOP("JVS", "Throw/Grab"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Triangle},
+	{"Kinnikuman_Special",   TRANSLATE_NOOP("JVS", "Special"),    nullptr, InputBindingInfo::Type::Button, JVS_BTN_3, GenericInputBinding::Circle},
+	{"Kinnikuman_Guard",     TRANSLATE_NOOP("JVS", "Guard"),      nullptr, InputBindingInfo::Type::Button, JVS_BTN_4, GenericInputBinding::Cross},
+};
+static constexpr InputBindingInfo s_fight_pridegp[] = { // Pride GP 2003 (limb-based: Left/Right Punch + Kick)
+	{"PrideGP_LeftPunch",  TRANSLATE_NOOP("JVS", "Left Punch"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_1, GenericInputBinding::Square},
+	{"PrideGP_RightPunch", TRANSLATE_NOOP("JVS", "Right Punch"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Triangle},
+	{"PrideGP_LeftKick",   TRANSLATE_NOOP("JVS", "Left Kick"),   nullptr, InputBindingInfo::Type::Button, JVS_BTN_4, GenericInputBinding::Cross},
+	{"PrideGP_RightKick",  TRANSLATE_NOOP("JVS", "Right Kick"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_5, GenericInputBinding::Circle},
+};
+static constexpr InputBindingInfo s_fight_basara[] = { // Sengoku Basara X (US manual: Weak/Medium/Strong + Striker)
+	{"Basara_Weak",    TRANSLATE_NOOP("JVS", "Weak Attack"),   nullptr, InputBindingInfo::Type::Button, JVS_BTN_1, GenericInputBinding::Square},
+	{"Basara_Medium",  TRANSLATE_NOOP("JVS", "Medium Attack"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Triangle},
+	{"Basara_Strong",  TRANSLATE_NOOP("JVS", "Strong Attack"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_3, GenericInputBinding::Circle},
+	{"Basara_Striker", TRANSLATE_NOOP("JVS", "Striker"),       nullptr, InputBindingInfo::Type::Button, JVS_BTN_4, GenericInputBinding::Cross},
+};
+static constexpr InputBindingInfo s_fight_sdbz[] = { // Super Dragon Ball Z (PS2 manual: Light/Heavy Attack, Jump, Guard)
+	{"DragonBallZ_Light", TRANSLATE_NOOP("JVS", "Light Attack"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_1, GenericInputBinding::Square},
+	{"DragonBallZ_Heavy", TRANSLATE_NOOP("JVS", "Heavy Attack"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Triangle},
+	{"DragonBallZ_Guard", TRANSLATE_NOOP("JVS", "Guard"),        nullptr, InputBindingInfo::Type::Button, JVS_BTN_4, GenericInputBinding::Cross},
+	{"DragonBallZ_Jump",  TRANSLATE_NOOP("JVS", "Jump"),         nullptr, InputBindingInfo::Type::Button, JVS_BTN_5, GenericInputBinding::Circle},
+};
+// YuYu Hakusho: Deathmatch (versus, 3 buttons: Punch/Kick/Guard).
+static constexpr InputBindingInfo s_fight_yuyu[] = {
+	{"YuYu_Punch", TRANSLATE_NOOP("JVS", "Punch"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_1, GenericInputBinding::Square},
+	{"YuYu_Kick",  TRANSLATE_NOOP("JVS", "Kick"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Triangle},
+	{"YuYu_Guard", TRANSLATE_NOOP("JVS", "Guard"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_3, GenericInputBinding::Cross},
 };
 
-static void UpdateStandardBindings(StandardLayout layout)
-{
-	s_active_p1_bindings = s_jvs_p1_button_bindings;
-	s_active_p2_bindings = s_jvs_p2_button_bindings;
-	const auto& face = s_standard_face_buttons[static_cast<int>(layout)];
-	constexpr int BTN1_INDEX = 4;
-	for (int i = 0; i < 6; i++)
-	{
-		s_active_p1_bindings[BTN1_INDEX + i].generic_mapping = face[i];
-		s_active_p2_bindings[BTN1_INDEX + i].generic_mapping = face[i];
-	}
-}
-
-// Generic racing layout (BTN1-6): each entry sets its own JVS bit, so a game can wire switches beyond Sw1-6 (e.g. AD3's Push9).
-struct RacingButton { u16 bind_index; GenericInputBinding host; };
-static constexpr RacingButton s_racing_buttons[][6] = {
-	{ // ACEDRIVER3 (BTN1-6)
-		{JVS_BTN_1, GenericInputBinding::Square},   // ENTER
-		{JVS_BTN_2, GenericInputBinding::Unknown},  // unused
-		{JVS_BTN_3, GenericInputBinding::R1},       // GEAR UP
-		{JVS_BTN_4, GenericInputBinding::L1},       // GEAR DOWN (next to L2 = brake)
-		{JVS_BTN_5, GenericInputBinding::Unknown},  // unused
-		{JVS_BTN_9, GenericInputBinding::Triangle}, // VIEW CHANGE (Push9)
-	},
+// Fighting page: section title + action buttons per layout.
+static constexpr ACJV::LayoutInfo s_fighting_layout_ui[] = {
+	{"Tekken (TK4 / TK5 / TK5DR)", s_fight_tekken,     false},
+	{"Soul Calibur (SC2 / SC3)",   s_fight_soulcal,    false},
+	{"Gundam VS",                  s_fight_gundam,     true},  // 1 player per cabinet (versus is networked)
+	{"Bloody Roar 3",              s_fight_bloodyroar, false},
+	{"Fate: Unlimited Codes",      s_fight_fate,       false},
+	{"Kinnikuman MGP 1 / 2",       s_fight_kinnikuman, false},
+	{"Pride GP 2003",              s_fight_pridegp,    false},
+	{"Sengoku Basara X",           s_fight_basara,     false},
+	{"Super Dragon Ball Z",        s_fight_sdbz,       false},
+	{"YuYu Hakusho: Deathmatch",   s_fight_yuyu,       false},
+	{"Capcom Fighting Jam",        s_fight_sixbutton,  false}, // 6 buttons -> last so the 4-button sections pair evenly
 };
 
-// Apply a racing layout: copy the base tables, then remap the buttons (JVS bit + pad button) per game.
-static void UpdateRacingBindings(RacingLayout layout)
-{
-	s_active_p1_bindings = s_jvs_p1_button_bindings;
-	s_active_p2_bindings = s_jvs_p2_button_bindings;
-	if (layout == RacingLayout::BG3)
-	{
-		// BG3/Tuned: JVS switch -> function map, RE'd from the game's switch chain @0x1e3f90.
-		const auto remap = [](std::array<InputBindingInfo, 12>& b) {
-			for (InputBindingInfo& e : b)
-			{
-				switch (e.bind_index)
-				{
-					case JVS_BTN_RIGHT: e.generic_mapping = GenericInputBinding::R1; break;       // SHIFT UP
-					case JVS_BTN_1:     e.generic_mapping = GenericInputBinding::L1; break;        // SHIFT DOWN
-					case JVS_BTN_DOWN:  e.generic_mapping = GenericInputBinding::Triangle; break;  // VIEW
-					case JVS_BTN_LEFT:  e.generic_mapping = GenericInputBinding::Square; break;    // SIDEBRAKE
-					case JVS_BTN_UP:    e.generic_mapping = GenericInputBinding::Circle; break;    // HAZARD
-					case JVS_BTN_START:
-					case JVS_BTN_SERVICE: break;
-					default:            e.generic_mapping = GenericInputBinding::Unknown; break;   // unused -> no double-trigger
-				}
-			}
-		};
-		remap(s_active_p1_bindings);
-		remap(s_active_p2_bindings);
-		return;
-	}
-	if (layout == RacingLayout::WANGAN)
-	{
-		// Wangan Midnight / R (NM00008/05): map confirmed live via I/O-TEST SWITCH-TEST.
-		const auto remap = [](std::array<InputBindingInfo, 12>& b) {
-			for (InputBindingInfo& e : b)
-			{
-				switch (e.bind_index)
-				{
-					case JVS_BTN_3: e.generic_mapping = GenericInputBinding::R1;       break; // Sw3 = SHIFT UP
-					case JVS_BTN_4: e.generic_mapping = GenericInputBinding::L1;       break; // Sw4 = SHIFT DOWN
-					case JVS_BTN_1: e.generic_mapping = GenericInputBinding::Square;   break; // Sw1
-					case JVS_BTN_2: e.generic_mapping = GenericInputBinding::Triangle; break; // Sw2
-					case JVS_BTN_5: e.generic_mapping = GenericInputBinding::Circle;   break; // Sw5
-					case JVS_BTN_6: e.generic_mapping = GenericInputBinding::Cross;    break; // Sw6
-					default: break;
-				}
-			}
-		};
-		remap(s_active_p1_bindings);
-		remap(s_active_p2_bindings);
-		return;
-	}
-	if (layout == RacingLayout::RRV)
-	{
-		// Ridge Racer V (NM00001): map from the switch builder FUN_0022ab70 (Ghidra).
-		const auto remap = [](std::array<InputBindingInfo, 12>& b) {
-			for (InputBindingInfo& e : b)
-			{
-				switch (e.bind_index)
-				{
-					case JVS_BTN_3: e.generic_mapping = GenericInputBinding::R1;       break; // Sw3 = SHIFT UP
-					case JVS_BTN_4: e.generic_mapping = GenericInputBinding::L1;       break; // Sw4 = SHIFT DOWN
-					case JVS_BTN_2: e.generic_mapping = GenericInputBinding::Triangle; break; // Sw2 = VIEW CHANGE
-					case JVS_BTN_1: e.generic_mapping = GenericInputBinding::Square;   break; // Sw1 = ENTER
-					case JVS_BTN_5: e.generic_mapping = GenericInputBinding::Unknown;  break; // unused -> no double-trigger
-					case JVS_BTN_6: e.generic_mapping = GenericInputBinding::Unknown;  break; // unused
-					default: break;
-				}
-			}
-		};
-		remap(s_active_p1_bindings);
-		remap(s_active_p2_bindings);
-		return;
-	}
-	const auto& btns = s_racing_buttons[static_cast<int>(layout)];
-	constexpr int BTN1_INDEX = 4;
-	for (int i = 0; i < 6; i++)
-	{
-		s_active_p1_bindings[BTN1_INDEX + i].bind_index = btns[i].bind_index;
-		s_active_p1_bindings[BTN1_INDEX + i].generic_mapping = btns[i].host;
-		s_active_p2_bindings[BTN1_INDEX + i].bind_index = btns[i].bind_index;
-		s_active_p2_bindings[BTN1_INDEX + i].generic_mapping = btns[i].host;
-	}
-}
+// Per-layout racing buttons (real labels + per-game keys); 1 player per cabinet. Analog steering/pedals
+// live in s_jvs_wheel_bindings (shared); menu nav = D-pad Up/Down (System).
+static constexpr InputBindingInfo s_race_universal[] = { // Wangan/RRV/MotoGP/Ace Driver 3 (View = Sw2|Push9)
+	{"Racing_ShiftUp",   TRANSLATE_NOOP("JVS", "Shift Up"),    nullptr, InputBindingInfo::Type::Button, JVS_BTN_3, GenericInputBinding::R1},
+	{"Racing_ShiftDown", TRANSLATE_NOOP("JVS", "Shift Down"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_4, GenericInputBinding::L1},
+	{"Racing_View",      TRANSLATE_NOOP("JVS", "View Change"), nullptr, InputBindingInfo::Type::Button, static_cast<u16>(JVS_BTN_2 | JVS_BTN_9), GenericInputBinding::Triangle},
+};
+static constexpr InputBindingInfo s_race_bg3[] = { // Battle Gear 3 (switch chain @0x1e3f90)
+	{"BG3_ShiftUp",   TRANSLATE_NOOP("JVS", "Shift Up"),    nullptr, InputBindingInfo::Type::Button, JVS_BTN_RIGHT, GenericInputBinding::R1},
+	{"BG3_ShiftDown", TRANSLATE_NOOP("JVS", "Shift Down"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_1,     GenericInputBinding::L1},
+	{"BG3_View",      TRANSLATE_NOOP("JVS", "View Change"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_DOWN,  GenericInputBinding::Triangle},
+	{"BG3_Sidebrake", TRANSLATE_NOOP("JVS", "Sidebrake"),   nullptr, InputBindingInfo::Type::Button, JVS_BTN_LEFT,  GenericInputBinding::Square},
+	{"BG3_Hazard",    TRANSLATE_NOOP("JVS", "Hazard"),      nullptr, InputBindingInfo::Type::Button, JVS_BTN_UP,    GenericInputBinding::Circle},
+};
+
+static constexpr ACJV::RacingLayoutInfo s_racing_layout_ui[] = {
+	{"Racing (Shift / View)", s_race_universal},
+	{"Battle Gear 3 / Tuned", s_race_bg3},
+};
+
+// Per-layout standard action buttons
+static constexpr InputBindingInfo s_standard_smashcourt[] = {
+	{"Smash_TopSpin", TRANSLATE_NOOP("JVS", "Top Spin"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_1, GenericInputBinding::Cross},
+	{"Smash_Slice",   TRANSLATE_NOOP("JVS", "Slice"),    nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Square},
+};
+static constexpr InputBindingInfo s_standard_technicbeat[] = {
+	{"Technic_Activate", TRANSLATE_NOOP("JVS", "Activate"),     nullptr, InputBindingInfo::Type::Button, JVS_BTN_1, GenericInputBinding::Square},
+	{"Technic_Action",   TRANSLATE_NOOP("JVS", "Action"),       nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Cross},
+	{"Technic_Super",    TRANSLATE_NOOP("JVS", "Super Action"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_3, GenericInputBinding::Circle},
+};
+static constexpr InputBindingInfo s_standard_baseball[] = {
+	{"Baseball_A", TRANSLATE_NOOP("JVS", "Swing / Throw"),    nullptr, InputBindingInfo::Type::Button, JVS_BTN_1, GenericInputBinding::Cross},
+	{"Baseball_B", TRANSLATE_NOOP("JVS", "Full Swing / Run"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Square},
+	{"Baseball_C", TRANSLATE_NOOP("JVS", "Relay Throw"),      nullptr, InputBindingInfo::Type::Button, JVS_BTN_3, GenericInputBinding::Triangle},
+};
+// Gundam Quiz Warrior (NM00030): a quiz, but on the same 4-button wiring as the Gundam VS games (own keys).
+static constexpr InputBindingInfo s_standard_gundamquiz[] = {
+	{"GundamQuiz_Shoot",  TRANSLATE_NOOP("JVS", "Shoot"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_1, GenericInputBinding::Square},
+	{"GundamQuiz_Melee",  TRANSLATE_NOOP("JVS", "Melee"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Triangle},
+	{"GundamQuiz_Jump",   TRANSLATE_NOOP("JVS", "Jump"),   nullptr, InputBindingInfo::Type::Button, JVS_BTN_3, GenericInputBinding::Cross},
+	{"GundamQuiz_Target", TRANSLATE_NOOP("JVS", "Target"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_4, GenericInputBinding::Circle},
+};
+
+// Standard page: section title + action buttons per layout.
+static constexpr ACJV::LayoutInfo s_standard_layout_ui[] = {
+	{"Smash Court Pro Tournament", s_standard_smashcourt,  false, TRANSLATE_NOOP("JVS", "Top Spin + Slice together = Lob / Drop")},
+	{"Technic Beat",               s_standard_technicbeat, false},
+	{"Necchuu! Pro Yakyuu 2002",   s_standard_baseball,    false},
+	{"Gundam Quiz Warrior",        s_standard_gundamquiz,  false},
+};
 
 static constexpr const std::array<InputBindingInfo, 2> s_jvs_coin_bindings = {{
 	{"Coin1", TRANSLATE_NOOP("JVS", "Insert Coin P1"), nullptr, InputBindingInfo::Type::Button, 0, GenericInputBinding::Unknown},
@@ -364,16 +350,14 @@ std::span<const InputBindingInfo> ACJV::GetButtonBindings()
 {
 	if (m_jvsMode == JVS_MODE::TWINSTICK)
 		return s_twinstick_p1_button_bindings;
-	if (m_jvsMode == JVS_MODE::FIGHTING || m_jvsMode == JVS_MODE::DRIVE || m_jvsMode == JVS_MODE::STANDARD)
-		return s_active_p1_bindings;
 	return s_jvs_p1_button_bindings;
 }
 
 std::span<const InputBindingInfo> ACJV::GetP2ButtonBindings()
 {
 	// Twin-stick (Zoids) is 1 player per cabinet (versus is networked), so no P2 layout.
-	if (m_jvsMode == JVS_MODE::FIGHTING || m_jvsMode == JVS_MODE::DRIVE || m_jvsMode == JVS_MODE::STANDARD)
-		return s_active_p2_bindings;
+	if (m_jvsMode == JVS_MODE::TWINSTICK)
+		return {};
 	return s_jvs_p2_button_bindings;
 }
 
@@ -390,6 +374,11 @@ std::span<const InputBindingInfo> ACJV::GetWheelBindings()
 std::span<const InputBindingInfo> ACJV::GetDrumBindings()
 {
 	return s_jvs_drum_bindings;
+}
+
+std::span<const InputBindingInfo> ACJV::GetTwinstickBindings()
+{
+	return s_twinstick_p1_button_bindings;
 }
 
 bool ACJV::GetDIPSwitchState(u32 index)
@@ -418,6 +407,58 @@ void ACJV::ToggleDIPSwitchState(u32 index)
 	s_dip_switch_state ^= mask;
 }
 
+// Fixed JVS switches a macro can fire (configurable without a running game).
+static constexpr ACJV::JvsMacroSwitch s_jvs_macro_switches[] = {
+	{"Button1", "Button 1", JVS_BTN_1},
+	{"Button2", "Button 2", JVS_BTN_2},
+	{"Button3", "Button 3", JVS_BTN_3},
+	{"Button4", "Button 4", JVS_BTN_4},
+	{"Button5", "Button 5", JVS_BTN_5},
+	{"Button6", "Button 6", JVS_BTN_6},
+};
+std::span<const ACJV::JvsMacroSwitch> ACJV::GetMacroSwitches() { return s_jvs_macro_switches; }
+
+// Per-layout macros: config keys carry the layout key (button-name prefix).
+std::string ACJV::LayoutKey(std::span<const InputBindingInfo> buttons)
+{
+	if (buttons.empty())
+		return {};
+	std::string n(buttons[0].name);
+	const size_t pos = n.find('_');
+	return (pos == std::string::npos) ? n : n.substr(0, pos);
+}
+std::string ACJV::GetCurrentLayoutKey()
+{
+	std::string k = LayoutKey(GetFightingButtons());
+	if (k.empty()) k = LayoutKey(GetRacingButtons());
+	if (k.empty()) k = LayoutKey(GetStandardButtons());
+	return k;
+}
+std::string ACJV::MacroConfigKey(const std::string& layoutKey, u32 player, u32 index, const char* suffix)
+{
+	return "Macro_" + layoutKey + "_P" + std::to_string(player + 1) + "_" + std::to_string(index + 1) + suffix;
+}
+
+// JVS macros (combo): fire switch bits for one player; masks pushed via SetMacroMask.
+struct JvsMacro { u16 mask = 0; bool active = false; };
+static JvsMacro s_jvs_macros[JVS_PLAYER_COUNT][ACJV::NUM_JVS_MACROS];
+static u16 m_jvsMacroButtonState[JVS_PLAYER_COUNT] = {};
+static void RecomputeMacroState(u32 player)
+{
+	u16 state = 0;
+	for (u32 i = 0; i < ACJV::NUM_JVS_MACROS; i++)
+		if (s_jvs_macros[player][i].active)
+			state |= s_jvs_macros[player][i].mask;
+	m_jvsMacroButtonState[player] = state;
+}
+void ACJV::SetMacroMask(u32 player, u32 index, u16 mask)
+{
+	if (player >= JVS_PLAYER_COUNT || index >= NUM_JVS_MACROS)
+		return;
+	s_jvs_macros[player][index] = {mask, false};
+	RecomputeMacroState(player);
+}
+
 void ACJV::LoadConfig(const SettingsInterface& si)
 {
 	u16 state = 0;
@@ -444,6 +485,10 @@ void ACJV::CopyConfiguration(SettingsInterface* dest_si, const SettingsInterface
 		dest_si->CopyBoolValue(src_si, CONFIG_SECTION, "SindenBorderEnabled");
 		dest_si->CopyIntValue(src_si, CONFIG_SECTION, "SindenBorderMode");
 		dest_si->CopyIntValue(src_si, CONFIG_SECTION, "SindenBorderThickness");
+		dest_si->CopyFloatValue(src_si, CONFIG_SECTION, "AnalogDeadzone");
+		dest_si->CopyFloatValue(src_si, CONFIG_SECTION, "AnalogSensitivity");
+		dest_si->CopyFloatValue(src_si, CONFIG_SECTION, "TriggerDeadzone");
+		dest_si->CopyBoolValue(src_si, CONFIG_SECTION, "InvertSteering");
 	}
 
 	if (copy_bindings)
@@ -456,6 +501,43 @@ void ACJV::CopyConfiguration(SettingsInterface* dest_si, const SettingsInterface
 			dest_si->CopyStringListValue(src_si, CONFIG_SECTION, bi.name);
 		for (const InputBindingInfo& bi : s_jvs_coin_bindings)
 			dest_si->CopyStringListValue(src_si, CONFIG_SECTION, bi.name);
+		// Peripheral binds (drum/wheel/twinstick) have no pad-mirror fallback, so they must travel with a profile too.
+		for (const InputBindingInfo& bi : s_jvs_drum_bindings)
+			dest_si->CopyStringListValue(src_si, CONFIG_SECTION, bi.name);
+		for (const InputBindingInfo& bi : s_jvs_wheel_bindings)
+			dest_si->CopyStringListValue(src_si, CONFIG_SECTION, bi.name);
+		for (const InputBindingInfo& bi : s_twinstick_p1_button_bindings)
+			dest_si->CopyStringListValue(src_si, CONFIG_SECTION, bi.name);
+		// Per-layout hub binds use {base}_P1/_P2 keys (racing: _P1 only, 1 player).
+		for (const LayoutInfo& fl : s_fighting_layout_ui)
+			for (const InputBindingInfo& bi : fl.buttons)
+			{
+				dest_si->CopyStringListValue(src_si, CONFIG_SECTION, (std::string(bi.name) + "_P1").c_str());
+				dest_si->CopyStringListValue(src_si, CONFIG_SECTION, (std::string(bi.name) + "_P2").c_str());
+			}
+		for (const LayoutInfo& sl : s_standard_layout_ui)
+			for (const InputBindingInfo& bi : sl.buttons)
+			{
+				dest_si->CopyStringListValue(src_si, CONFIG_SECTION, (std::string(bi.name) + "_P1").c_str());
+				dest_si->CopyStringListValue(src_si, CONFIG_SECTION, (std::string(bi.name) + "_P2").c_str());
+			}
+		for (const RacingLayoutInfo& rl : s_racing_layout_ui)
+			for (const InputBindingInfo& bi : rl.buttons)
+				dest_si->CopyStringListValue(src_si, CONFIG_SECTION, (std::string(bi.name) + "_P1").c_str());
+		const auto copy_macros = [&](std::span<const InputBindingInfo> buttons) {
+			const std::string lk = LayoutKey(buttons);
+			if (lk.empty())
+				return;
+			for (u32 p = 0; p < JVS_PLAYER_COUNT; p++)
+				for (u32 i = 0; i < NUM_JVS_MACROS; i++)
+				{
+					dest_si->CopyStringListValue(src_si, CONFIG_SECTION, MacroConfigKey(lk, p, i, "").c_str());
+					dest_si->CopyStringListValue(src_si, CONFIG_SECTION, MacroConfigKey(lk, p, i, "Binds").c_str());
+				}
+		};
+		for (const LayoutInfo& fl : s_fighting_layout_ui) copy_macros(fl.buttons);
+		for (const RacingLayoutInfo& rl : s_racing_layout_ui)     copy_macros(rl.buttons);
+		for (const LayoutInfo& sl : s_standard_layout_ui) copy_macros(sl.buttons);
 	}
 }
 
@@ -501,10 +583,10 @@ static u16 m_jvsButtonState[JVS_PLAYER_COUNT] = {};
 static u8 m_testButtonState = 0;
 static u16 m_coin1 = 0;
 static u16 m_coin2 = 0;
-static u16 m_jvsScreenPosX = 0;
-static u16 m_jvsScreenPosY = 0;
-static float m_jvsLightgunDX = -1.0f;  // normalized display X (-1 = off-screen)
-static float m_jvsLightgunDY = -1.0f;  // normalized display Y (-1 = off-screen)
+static u16 m_jvsScreenPosX[JVS_PLAYER_COUNT] = {};
+static u16 m_jvsScreenPosY[JVS_PLAYER_COUNT] = {};
+static float m_jvsLightgunDX[JVS_PLAYER_COUNT] = {-1.0f, -1.0f};  // per-player normalized display X (-1 = off-screen)
+static float m_jvsLightgunDY[JVS_PLAYER_COUNT] = {-1.0f, -1.0f};  // per-player normalized display Y (-1 = off-screen)
 static u16 m_jvsWheelChannels[JVS_WHEEL_CHANNEL_MAX] = {};
 static u16 m_jvsDrumChannels[JVS_DRUM_CHANNEL_MAX] = {};
 
@@ -516,7 +598,6 @@ static float m_wheelBrake  = 0.0f; // left trigger  (L2)
 // Per-game JVS button mapping for lightgun games, keyed by NM game ID (see issue #9).
 // Field order: pedal, sensor, sensor_active_high, p1_start, p2_start, p1_trigger, p2_trigger
 // Each value is a JVS bit from JVSButton enum. 0 = not used for this game.
-// This table serves as template for future per-game configs (fighting, driving, drum, etc).
 static const GunMapping s_default_gun_mapping = {JVS_BTN_3, JVS_BTN_RIGHT, false, 0, 0, JVS_BTN_2, 0};
 static const std::map<std::string, GunMapping> s_gun_mappings = {
 	{"NM00003", {0,            0x200,         true,  JVS_BTN_3,  JVS_BTN_6, JVS_BTN_2,    JVS_BTN_5}}, // Vampire Night
@@ -533,15 +614,14 @@ static const std::map<std::string, FightingLayout> s_fighting_layouts = {
 	{"NM00007", FightingLayout::SOULCAL},    // Soul Calibur II
 	{"NM00031", FightingLayout::SOULCAL},    // Soul Calibur III
 	{"NM00002", FightingLayout::BLOODYROAR}, // Bloody Roar 3
-	{"NM00048", FightingLayout::SOULCAL},    // Fate Unlimited Codes
-	{"NM00027", FightingLayout::TEKKEN},     // Super Dragon Ball Z
-	{"NM00029", FightingLayout::SOULCAL},    // Kinnikuman MGP
-	{"NM00035", FightingLayout::GUNDAM},     // YuYu Hakusho
-	{"NM00030", FightingLayout::GUNDAM},     // Mobile Suit Gundam Quiz Warrior (quiz, same 4-button layout)
-	{"NM00040", FightingLayout::SOULCAL},    // Kinnikuman MGP 2
-	{"NM00011", FightingLayout::TEKKEN},     // Pride GP 2003
+	{"NM00048", FightingLayout::FATE},       // Fate Unlimited Codes
+	{"NM00027", FightingLayout::SDBZ},       // Super Dragon Ball Z
+	{"NM00029", FightingLayout::KINNIKUMAN}, // Kinnikuman MGP 1
+	{"NM00035", FightingLayout::YUYU},       // YuYu Hakusho: Deathmatch
+	{"NM00040", FightingLayout::KINNIKUMAN}, // Kinnikuman MGP 2
+	{"NM00011", FightingLayout::PRIDEGP},    // Pride GP 2003
 	{"NM00018", FightingLayout::SIX_BUTTON}, // Capcom Fighting Jam
-	{"NM00042", FightingLayout::SOULCAL},    // Sengoku Basara X
+	{"NM00042", FightingLayout::BASARA},     // Sengoku Basara X
 	{"NM00013", FightingLayout::GUNDAM},     // Z-Gundam: A.E.U.G. vs Titans
 	{"NM00017", FightingLayout::GUNDAM},     // Z-Gundam: A.E.U.G. vs Titans DX
 	{"NM00024", FightingLayout::GUNDAM},     // Gundam SEED: Federation vs Z.A.F.T.
@@ -551,19 +631,107 @@ static const std::map<std::string, FightingLayout> s_fighting_layouts = {
 };
 
 static const std::map<std::string, RacingLayout> s_racing_layouts = {
-	{"NM00047", RacingLayout::ACEDRIVER3},   // Ace Driver 3: Final Turn
-	{"NM00010", RacingLayout::BG3},          // Battle Gear 3
-	{"NM00015", RacingLayout::BG3},          // Battle Gear 3 Tuned
-	{"NM00008", RacingLayout::WANGAN},       // Wangan Midnight
-	{"NM00005", RacingLayout::WANGAN},       // Wangan Midnight R
-	{"NM00001", RacingLayout::RRV},          // Ridge Racer V (discovery sweep)
+	{"NM00047", RacingLayout::UNIVERSAL},   // Ace Driver 3: Final Turn
+	{"NM00010", RacingLayout::BG3},         // Battle Gear 3
+	{"NM00015", RacingLayout::BG3},         // Battle Gear 3 Tuned
+	{"NM00008", RacingLayout::UNIVERSAL},   // Wangan Midnight
+	{"NM00005", RacingLayout::UNIVERSAL},   // Wangan Midnight R
+	{"NM00001", RacingLayout::UNIVERSAL},   // Ridge Racer V
+	{"NM00039", RacingLayout::UNIVERSAL},   // MotoGP
 };
 
 static const std::map<std::string, StandardLayout> s_standard_layouts = {
 	{"NM00009", StandardLayout::BASEBALL},    // Netchu Pro Baseball 2002
 	{"NM00006", StandardLayout::SMASHCOURT},  // Smash Court Pro Tournament
-	{"NM00003", StandardLayout::TECHNICBEAT}, // Technic Beat (shares gameid with VPN)
+	{"NM10003", StandardLayout::TECHNICBEAT}, // Technic Beat (unique unofficial gameid; NM00003 = Vampire Night, GameIndex PR #92)
+	{"NM00030", StandardLayout::GUNDAMQUIZ},  // Gundam Quiz Warrior (moved from Fighting: a quiz, not a fighter)
 };
+
+// Drum (Taiko) and twin-stick (Zoids) gameids for ResolveModeFromGameId (no per-button table).
+static constexpr const char* s_drum_games[] = {
+	"NM00023", "NM00033", "NM00038", "NM00041", "NM00044", "NM00045",
+	"NM00046", "NM00051", "NM00053", "NM00054", "NM00056", "NM00057",
+};
+static constexpr const char* s_twinstick_games[] = {"NM00016", "NM00025"};
+
+// Derive the JVS device mode from the gameid alone (jvsmode= is an optional override, see VMManager).
+JVS_MODE ACJV::ResolveModeFromGameId(const std::string& gameid)
+{
+	if (s_racing_layouts.count(gameid))   return JVS_MODE::DRIVE;
+	if (s_fighting_layouts.count(gameid)) return JVS_MODE::FIGHTING;
+	if (s_standard_layouts.count(gameid)) return JVS_MODE::STANDARD;
+	if (s_gun_mappings.count(gameid))     return JVS_MODE::LIGHTGUN;
+	if (std::ranges::find(s_drum_games, gameid) != std::ranges::end(s_drum_games))
+		return JVS_MODE::DRUM;
+	if (std::ranges::find(s_twinstick_games, gameid) != std::ranges::end(s_twinstick_games))
+		return JVS_MODE::TWINSTICK;
+	return JVS_MODE::DEFAULT;
+}
+
+std::span<const InputBindingInfo> ACJV::GetFightingButtons()
+{
+	auto it = s_fighting_layouts.find(s_gameid);
+	if (it == s_fighting_layouts.end())
+		return {};
+	switch (it->second)
+	{
+		case FightingLayout::TEKKEN:     return s_fight_tekken;
+		case FightingLayout::SOULCAL:    return s_fight_soulcal;
+		case FightingLayout::SIX_BUTTON: return s_fight_sixbutton;
+		case FightingLayout::GUNDAM:     return s_fight_gundam;
+		case FightingLayout::BLOODYROAR: return s_fight_bloodyroar;
+		case FightingLayout::FATE:       return s_fight_fate;
+		case FightingLayout::KINNIKUMAN: return s_fight_kinnikuman;
+		case FightingLayout::PRIDEGP:    return s_fight_pridegp;
+		case FightingLayout::BASARA:     return s_fight_basara;
+		case FightingLayout::SDBZ:       return s_fight_sdbz;
+		case FightingLayout::YUYU:       return s_fight_yuyu;
+	}
+	return {};
+}
+
+std::span<const ACJV::LayoutInfo> ACJV::GetFightingLayouts()
+{
+	return s_fighting_layout_ui;
+}
+
+std::span<const InputBindingInfo> ACJV::GetStandardButtons()
+{
+	auto it = s_standard_layouts.find(s_gameid);
+	if (it == s_standard_layouts.end())
+		return {};
+	switch (it->second)
+	{
+		case StandardLayout::BASEBALL:    return s_standard_baseball;
+		case StandardLayout::SMASHCOURT:  return s_standard_smashcourt;
+		case StandardLayout::TECHNICBEAT: return s_standard_technicbeat;
+		case StandardLayout::GUNDAMQUIZ:  return s_standard_gundamquiz;
+	}
+	return {};
+}
+
+std::span<const ACJV::LayoutInfo> ACJV::GetStandardLayouts()
+{
+	return s_standard_layout_ui;
+}
+
+std::span<const InputBindingInfo> ACJV::GetRacingButtons()
+{
+	auto it = s_racing_layouts.find(s_gameid);
+	if (it == s_racing_layouts.end())
+		return {};
+	switch (it->second)
+	{
+		case RacingLayout::UNIVERSAL: return s_race_universal;
+		case RacingLayout::BG3:       return s_race_bg3;
+	}
+	return {};
+}
+
+std::span<const ACJV::RacingLayoutInfo> ACJV::GetRacingLayouts()
+{
+	return s_racing_layout_ui;
+}
 
 // Gamepad input -> JVS button state: set or clear a button bit for a player
 void ACJV::SetButtonState(u32 player, u16 mask, bool pressed)
@@ -574,6 +742,14 @@ void ACJV::SetButtonState(u32 player, u16 mask, bool pressed)
 		m_jvsButtonState[player] |= mask;
 	else
 		m_jvsButtonState[player] &= ~mask;
+}
+
+void ACJV::SetMacroState(u32 player, u32 index, bool active)
+{
+	if (player >= JVS_PLAYER_COUNT || index >= NUM_JVS_MACROS)
+		return;
+	s_jvs_macros[player][index].active = active;
+	RecomputeMacroState(player);
 }
 
 // Gamepad coin button -> increment JVS coin counter for P1 (slot 0) or P2 (slot 1)
@@ -639,8 +815,8 @@ int ACJV::GetSindenBorderThickness()
 
 void ACJV::SetScreenPos(u16 x, u16 y)
 {
-	m_jvsScreenPosX = x;
-	m_jvsScreenPosY = y;
+	m_jvsScreenPosX[0] = x;
+	m_jvsScreenPosY[0] = y;
 }
 
 // Called from VMManager on game boot. Resets all JVS state and selects per-game I/O config.
@@ -657,12 +833,21 @@ void ACJV::SetGameId(const std::string& gameid)
 	m_jvsButtonState[1] = 0;
 	m_jvsSystemButtonState = 0;
 	m_testButtonState = 0;
-	m_jvsScreenPosX = 0;
-	m_jvsScreenPosY = 0;
-	m_jvsLightgunDX = -1.0f;
-	m_jvsLightgunDY = -1.0f;
+	for (u32 p = 0; p < JVS_PLAYER_COUNT; p++)
+	{
+		m_jvsScreenPosX[p] = 0;
+		m_jvsScreenPosY[p] = 0;
+		m_jvsLightgunDX[p] = -1.0f;
+		m_jvsLightgunDY[p] = -1.0f;
+	}
 	std::memset(m_jvsWheelChannels, 0, sizeof(m_jvsWheelChannels));
 	std::memset(m_jvsDrumChannels, 0, sizeof(m_jvsDrumChannels));
+	for (u32 p = 0; p < JVS_PLAYER_COUNT; p++) // clear macro state; InputManager repushes masks on the input reload
+	{
+		m_jvsMacroButtonState[p] = 0;
+		for (u32 i = 0; i < NUM_JVS_MACROS; i++)
+			s_jvs_macros[p][i].active = false;
+	}
 
 	// Select per-game gun mapping, or fall back to default
 	auto it = s_gun_mappings.find(gameid);
@@ -674,32 +859,9 @@ void ACJV::SetGameId(const std::string& gameid)
 	else
 		m_gunMapping = &s_default_gun_mapping;
 
-	auto fit = s_fighting_layouts.find(gameid);
-	auto rit = s_racing_layouts.find(gameid);
-	auto sit = s_standard_layouts.find(gameid);
-	if (fit != s_fighting_layouts.end())
-	{
-		constexpr const char* layout_names[] = {"tekken", "gundam", "6-button", "soulcalibur", "bloodyroar"};
-		Console.WriteLn("ACJV: fighting layout for %s: %s", gameid.c_str(), layout_names[static_cast<int>(fit->second)]);
-		UpdateFightingBindings(fit->second);
-	}
-	else if (rit != s_racing_layouts.end())
-	{
-		constexpr const char* racing_names[] = {"acedriver3", "bg3", "wangan", "rrv"};
-		Console.WriteLn("ACJV: racing layout for %s: %s", gameid.c_str(), racing_names[static_cast<int>(rit->second)]);
-		UpdateRacingBindings(rit->second);
-	}
-	else if (sit != s_standard_layouts.end())
-	{
-		constexpr const char* standard_names[] = {"baseball", "smashcourt", "technicbeat"};
-		Console.WriteLn("ACJV: standard layout for %s: %s", gameid.c_str(), standard_names[static_cast<int>(sit->second)]);
-		UpdateStandardBindings(sit->second);
-	}
-	else
-	{
-		s_active_p1_bindings = s_jvs_p1_button_bindings;
-		s_active_p2_bindings = s_jvs_p2_button_bindings;
-	}
+	// Log the running game's layout (buttons come from GetFighting/Racing/StandardButtons).
+	if (const std::string lk = GetCurrentLayoutKey(); !lk.empty())
+		Console.WriteLn("ACJV: layout for %s: %s", gameid.c_str(), lk.c_str());
 
 	// TC3 has 3 I/O boards: TSS-I/O (white flash), MIU-I/O (640x224), RAYS PCB (0xFFFF).
 	// MIU-I/O chosen: no flash artifact, calibration uses JVS trigger debounce directly.
@@ -717,30 +879,47 @@ const GunMapping& ACJV::GetGunMapping()
 	return *m_gunMapping;
 }
 
+// Per-player lightgun aim source: shared mouse by default, or the player's own controller stick when its
+// Aim Device is set to the pad (GunCon2 has_relative_binds pushes that stick's screen pos here).
+static bool s_gunAimJoystick[JVS_PLAYER_COUNT] = {};
+static float s_gunRelativeDX[JVS_PLAYER_COUNT] = {-1.0f, -1.0f};
+static float s_gunRelativeDY[JVS_PLAYER_COUNT] = {-1.0f, -1.0f};
+void ACJV::SetGunAimSource(u32 player, bool joystick) { if (player < JVS_PLAYER_COUNT) s_gunAimJoystick[player] = joystick; }
+void ACJV::SetGunRelativeAim(u32 player, float dx, float dy)
+{
+	if (player < JVS_PLAYER_COUNT) { s_gunRelativeDX[player] = dx; s_gunRelativeDY[player] = dy; }
+}
+
 static void UpdateLightgunFromMouse()
 {
+	float mdx, mdy;
 	const auto& [mx, my] = InputManager::GetPointerAbsolutePosition(0);
-	float dx, dy;
-	GSTranslateWindowToDisplayCoordinates(mx, my, &dx, &dy);
+	GSTranslateWindowToDisplayCoordinates(mx, my, &mdx, &mdy);
+
 	constexpr float edge_margin = 0.01f;
-	bool on_screen = (dx >= 0.0f && dy >= 0.0f && dx < (1.0f - edge_margin) && dy < (1.0f - edge_margin));
-	if (on_screen)
-	{
-		m_jvsLightgunDX = dx;
-		m_jvsLightgunDY = dy;
-		m_jvsScreenPosX = static_cast<u16>((1.0f - dx) * 0xFFFF);
-		m_jvsScreenPosY = static_cast<u16>(dy * 0xFFFF);
-	}
-	else
-	{
-		m_jvsLightgunDX = -1.0f;
-		m_jvsLightgunDY = -1.0f;
-		m_jvsScreenPosX = 0;
-		m_jvsScreenPosY = 0;
-	}
 	const auto& gm = ACJV::GetGunMapping();
-	if (gm.sensor)
-		ACJV::SetButtonState(0, gm.sensor, gm.sensor_active_high ? on_screen : !on_screen);
+	for (u32 p = 0; p < JVS_PLAYER_COUNT; p++)
+	{
+		const float dx = s_gunAimJoystick[p] ? s_gunRelativeDX[p] : mdx;
+		const float dy = s_gunAimJoystick[p] ? s_gunRelativeDY[p] : mdy;
+		const bool on_screen = (dx >= 0.0f && dy >= 0.0f && dx < (1.0f - edge_margin) && dy < (1.0f - edge_margin));
+		if (on_screen)
+		{
+			m_jvsLightgunDX[p] = dx;
+			m_jvsLightgunDY[p] = dy;
+			m_jvsScreenPosX[p] = static_cast<u16>((1.0f - dx) * 0xFFFF);
+			m_jvsScreenPosY[p] = static_cast<u16>(dy * 0xFFFF);
+		}
+		else
+		{
+			m_jvsLightgunDX[p] = -1.0f;
+			m_jvsLightgunDY[p] = -1.0f;
+			m_jvsScreenPosX[p] = 0;
+			m_jvsScreenPosY[p] = 0;
+		}
+		if (gm.sensor)
+			ACJV::SetButtonState(p, gm.sensor, gm.sensor_active_high ? on_screen : !on_screen);
+	}
 }
 
 // Combine host axes into the 3 JVS analog channels (steer/gas/brake). Steering encoding is per-game.
@@ -928,8 +1107,9 @@ void do_jvs_packet(const u8* input, u8* output) {
 			(*output++) = m_testButtonState|(s_dip_switch_state & TESTMODE);
 			//(*output++) = (m_jvsSystemButtonState == 0x03) ? 0x80 : 0;  //Test
 
-			(*output++) = static_cast<u8>(m_jvsButtonState[0]);      //Player 1
-			(*output++) = static_cast<u8>(m_jvsButtonState[0] >> 8); //Player 1
+			const u16 p1btn = m_jvsButtonState[0] | m_jvsMacroButtonState[0];
+			(*output++) = static_cast<u8>(p1btn);      //Player 1
+			(*output++) = static_cast<u8>(p1btn >> 8); //Player 1
 			(*dstSize) += 4;
 
 			//if (m_jvsButtonState[0])
@@ -937,8 +1117,9 @@ void do_jvs_packet(const u8* input, u8* output) {
 
 			if(playerCount == 2)
 			{
-				(*output++) = static_cast<u8>(m_jvsButtonState[1]);      //Player 2
-				(*output++) = static_cast<u8>(m_jvsButtonState[1] >> 8); //Player 2
+				const u16 p2btn = m_jvsButtonState[1] | m_jvsMacroButtonState[1];
+				(*output++) = static_cast<u8>(p2btn);      //Player 2
+				(*output++) = static_cast<u8>(p2btn >> 8); //Player 2
 				(*dstSize) += 2;
 			}
 		}
@@ -1024,10 +1205,10 @@ void do_jvs_packet(const u8* input, u8* output) {
 			{
 				JVS_ASSERT(channel == 2);
 				UpdateLightgunFromMouse();
-				(*output++) = static_cast<u8>(m_jvsScreenPosX >> 8); //Pos X MSB
-				(*output++) = static_cast<u8>(m_jvsScreenPosX);      //Pos X LSB
-				(*output++) = static_cast<u8>(m_jvsScreenPosY >> 8); //Pos Y MSB
-				(*output++) = static_cast<u8>(m_jvsScreenPosY);      //Pos Y LSB
+				(*output++) = static_cast<u8>(m_jvsScreenPosX[0] >> 8); //Pos X MSB
+				(*output++) = static_cast<u8>(m_jvsScreenPosX[0]);      //Pos X LSB
+				(*output++) = static_cast<u8>(m_jvsScreenPosY[0] >> 8); //Pos Y MSB
+				(*output++) = static_cast<u8>(m_jvsScreenPosY[0]);      //Pos Y LSB
 			}
 			else if(m_jvsMode == JVS_MODE::DRUM)
 			{
@@ -1070,28 +1251,28 @@ void do_jvs_packet(const u8* input, u8* output) {
 			// - MIU-I/O (TC3): native 640x224, Y inverted (bottom-up)
 			// - RAYS PCB (TC4, Cobra, VPN): full 16-bit range 0xFFFF, Y inverted (bottom-up)
 			// pos=0 means off-screen in JVS, so on-screen values are clamped to minimum 1
+			// JVS SCREENPOS: 'channel' is the 1-based gun index (Vampire Night reads channel=1 then =2 each
+			// frame), so return that one gun's player position - gun 1 -> P1, gun 2 -> P2.
+			const u32 pl = (channel >= 1 && channel <= JVS_PLAYER_COUNT) ? (channel - 1u) : 0u;
 			u16 posX = 0, posY = 0;
-			if(m_jvsMode == JVS_MODE::LIGHTGUN && m_jvsLightgunDX >= 0.0f)
+			if(m_jvsMode == JVS_MODE::LIGHTGUN && m_jvsLightgunDX[pl] >= 0.0f)
 			{
 				const float scaleX = (ACJV::CurrentBoardID == MIU_IO_JPN_GUN_EXTENTI) ? 640.0f : 0xFFFF;
 				const float scaleY = (ACJV::CurrentBoardID == MIU_IO_JPN_GUN_EXTENTI) ? 224.0f : 0xFFFF;
-				posX = static_cast<u16>(m_jvsLightgunDX * scaleX);
+				posX = static_cast<u16>(m_jvsLightgunDX[pl] * scaleX);
 				if (ACJV::CurrentBoardID == RAYS_PCB || ACJV::CurrentBoardID == MIU_IO_JPN_GUN_EXTENTI)
-					posY = static_cast<u16>((1.0f - m_jvsLightgunDY) * scaleY);
+					posY = static_cast<u16>((1.0f - m_jvsLightgunDY[pl]) * scaleY);
 				else
-					posY = static_cast<u16>(m_jvsLightgunDY * scaleY);
+					posY = static_cast<u16>(m_jvsLightgunDY[pl] * scaleY);
 				if (posX == 0) posX = 1;
 				if (posY == 0) posY = 1;
 			}
-			for (u8 ch = 0; ch < channel; ch++)
-			{
-				(*output++) = static_cast<u8>(posX >> 8);
-				(*output++) = static_cast<u8>(posX);
-				(*output++) = static_cast<u8>(posY >> 8);
-				(*output++) = static_cast<u8>(posY);
-			}
+			(*output++) = static_cast<u8>(posX >> 8);
+			(*output++) = static_cast<u8>(posX);
+			(*output++) = static_cast<u8>(posY >> 8);
+			(*output++) = static_cast<u8>(posY);
 
-			(*dstSize) += 1 + (4 * channel);
+			(*dstSize) += 1 + 4; // status + one position (X, Y) for the requested gun
 		}
 		break;
 		// GPIO output — game sends byte values to control physical outputs (e.g. gun recoil solenoids).
@@ -1135,9 +1316,14 @@ void do_jvs_packet(const u8* input, u8* output) {
 
 
 // based on https://github.com/search?q=repo%3Ajpd002/Play-%20CSys246%3A%3AProcessJvsPacket&type=code by Jean-Philip Desjardins
+// JVFIRM version n246Jvio checks against its own (mismatch stalls boot): BG3=0x210, BG3T=0x213, others 0x208.
+static u16 JvFirmwareVersion() {
+	return (s_gameid == "NM00015") ? 0x213 : (s_gameid == "NM00010") ? 0x210 : 0x208;
+}
+
 // Prime the JVS board firmware-version register when ACJV starts (BG3 Tuned polls it before any command).
 void ACJV::OnBoardStart() {
-	rdbuf_getu16()[1] = (s_gameid == "NM00015") ? 0x213 : (s_gameid == "NM00010") ? 0x210 : 0x208;
+	rdbuf_getu16()[1] = JvFirmwareVersion();
 }
 
 void do_acjv_packet() {
@@ -1146,8 +1332,7 @@ void do_acjv_packet() {
 	rd16[0] = wr16[0];
 	u16 RootPacketID = wr16[8];
 	if(rd16[0] == 0x3E6F) {
-		// JVFIRM version n246Jvio checks against its own (mismatch stalls boot): BG3=0x210, BG3T=0x213, others 0x208.
-		rd16[1]      = (s_gameid == "NM00015") ? 0x213 : (s_gameid == "NM00010") ? 0x210 : 0x208;
+		rd16[1]      = JvFirmwareVersion();
 		rd16[0x14]   = RootPacketID; // Xored with value at 0x10 in send packet, needs to be the same
 		rd16[0x21]   = wr16[0x0D];
 		rd16[0x30]  = s_dip_switch_state; // here the game polls the dip switch values?
@@ -1206,7 +1391,7 @@ void ACJV::UpdateFcaFrame()
 	rdbuf[0x85] = (u8)(brakeRaw >> 8);
 
 	// Buttons (FCA-1 digital inputs, active-high; bit assignments RE'd from I/O TEST FUN_0022bba8).
-	const u16 btn = m_jvsButtonState[0];
+	const u16 btn = m_jvsButtonState[0] | m_jvsMacroButtonState[0];
 	u8 b40 = 0, b41 = 0;
 	if (btn & JVS_BTN_3)       b40 |= 0x80; // R1       -> UP SHIFT (gear up)
 	if (btn & JVS_BTN_4)       b40 |= 0x40; // L1       -> DOWN SHIFT (gear down)

--- a/pcsx2/DEV9/ACJV.h
+++ b/pcsx2/DEV9/ACJV.h
@@ -49,24 +49,30 @@ enum class JVS_MODE {
 
 // Sw -> pad order per layout, mirroring each game's official PS2 port.
 enum class FightingLayout {
-	TEKKEN,     // Sw1,2,4,5: Square, Triangle, Cross, Circle         — TK4, TK5, TK5DR, SDBZ, PrideGP
-	GUNDAM,     // Sw1,2,3,4: Square, Triangle, Cross, Circle         — YuYu + Gundam VS (zgundm/dx, SEED/Dest, GvG/NEXT)
+	TEKKEN,     // Sw1,2,4,5: Square, Triangle, Cross, Circle         — TK4, TK5, TK5DR
+	GUNDAM,     // Sw1,2,3,4: Square, Triangle, Cross, Circle         — Gundam VS (zgundm/dx, SEED/Dest, GvG/NEXT)
 	SIX_BUTTON, // Sw1-6:     Square, Triangle, L1, Cross, Circle, R1 — JAM
-	SOULCAL,    // Sw1,2,3,4: Square, Triangle, Circle, Cross         — SC2, SC3, KN1, KN2, BAX, FUD
+	SOULCAL,    // Sw1,2,3,4: Square, Triangle, Circle, Cross         — SC2, SC3
 	BLOODYROAR, // Sw1,2,3,4: Square, Cross, Circle, Triangle         — BR3
+	// Per-game splits: same scheme as the parent franchise, own config keys so each maps independently.
+	FATE,       // NM00048: Fate Unlimited Codes (Weak/Medium/Strong + Reflect Guard)
+	KINNIKUMAN, // NM00029/40: Kinnikuman MGP 1 & 2 (Left/Right Fist, Special, Guard)
+	PRIDEGP,    // NM00011: Pride GP 2003 (Left/Right Punch + Kick, limb-based)
+	BASARA,     // NM00042: Sengoku Basara X (Weak/Medium/Strong + Striker)
+	SDBZ,       // NM00027: Super Dragon Ball Z (Light/Heavy Attack, Jump, Block)
+	YUYU,       // NM00035: YuYu Hakusho Deathmatch (versus, 3 buttons: Punch/Kick/Guard)
 };
 
 enum class RacingLayout {
-	ACEDRIVER3, // NM00047: GEAR UP=Sw3(L1), GEAR DOWN=Sw4(R1), VIEW CHANGE=Push9(Triangle), ENTER=Sw1
-	BG3,        // NM00010/15: SHIFT UP=R1, SHIFT DOWN=L1, VIEW=Triangle, SIDEBRAKE=Square, HAZARD=Circle
-	WANGAN,     // NM00008/05: SHIFT UP=R1, SHIFT DOWN=L1, SELECT=D-pad, SERVICE=Select
-	RRV,        // NM00001: SHIFT UP=R1, SHIFT DOWN=L1, VIEW=Triangle, ENTER=Square, SELECT=D-pad, SERVICE=Select
+	UNIVERSAL,  // Wangan/RRV/MotoGP/Ace Driver 3 (View = Sw2|Push9)
+	BG3,        // NM00010/15: D-pad-wired + Sidebrake + Hazard (Taito board)
 };
 
 enum class StandardLayout {
 	BASEBALL,    // NM00009: Netchu Pro Baseball (Sw1-6 superset)
 	SMASHCOURT,  // NM00006: Smash Court Pro (2 buttons)
-	TECHNICBEAT, // NM00003: Technic Beat (3 buttons)
+	TECHNICBEAT, // NM10003: Technic Beat (3 buttons)
+	GUNDAMQUIZ,  // NM00030: Gundam Quiz Warrior (4-button Gundam wiring)
 };
 
 #define JVS_WHEEL_CHANNEL_MAX 3
@@ -86,6 +92,7 @@ namespace ACJV {
     enum : u32
     {
         NUM_DIP_SWITCHES = 4,
+        NUM_JVS_MACROS = 8,
     };
 
     static constexpr const char* CONFIG_SECTION = "JVS";
@@ -118,7 +125,23 @@ namespace ACJV {
     std::span<const InputBindingInfo> GetCoinBindings();
     std::span<const InputBindingInfo> GetWheelBindings();
     std::span<const InputBindingInfo> GetDrumBindings();
+    std::span<const InputBindingInfo> GetTwinstickBindings(); // Zoids
+    std::span<const InputBindingInfo> GetFightingButtons(); // empty if none
+    struct LayoutInfo { const char* name; std::span<const InputBindingInfo> buttons; bool one_player; const char* note = nullptr; }; // Fighting/Standard share this; note = optional hint under the buttons
+    std::span<const LayoutInfo> GetFightingLayouts();
+    std::span<const InputBindingInfo> GetStandardButtons(); // empty if none
+    std::span<const LayoutInfo> GetStandardLayouts();
+    std::span<const InputBindingInfo> GetRacingButtons(); // empty if none
+    struct RacingLayoutInfo { const char* name; std::span<const InputBindingInfo> buttons; };
+    std::span<const RacingLayoutInfo> GetRacingLayouts();
+    struct JvsMacroSwitch { const char* name; const char* label; u16 bit; };
+    std::span<const JvsMacroSwitch> GetMacroSwitches(); // fixed JVS switches a macro can fire (game-independent)
+    std::string LayoutKey(std::span<const InputBindingInfo> buttons); // stable per-layout config key (button-name prefix)
+    std::string GetCurrentLayoutKey();                  // running game's layout key, or empty
+    std::string MacroConfigKey(const std::string& layoutKey, u32 player, u32 index, const char* suffix);
     void SetButtonState(u32 player, u16 mask, bool pressed);
+    void SetMacroState(u32 player, u32 index, bool active); // JVS input macro trigger: fire its switch set for the player
+    void SetMacroMask(u32 player, u32 index, u16 mask);     // set a macro's combined switch mask (pushed by InputManager)
     void SetWheelAxis(u32 axis, float value);
     void SetDrumHit(u32 channel, bool pressed); // Taiko drum sensor -> JVS analog channel (0=off, else above DAI threshold)
     float GetSteer(); // host steering, -1 (full left)...+1 (full right); used by the BG3 drive-board responder (acuart)
@@ -138,7 +161,10 @@ namespace ACJV {
     BOARDID GetCurrentBoardID();
     void SetMode(JVS_MODE mode);
     JVS_MODE GetMode();
+    JVS_MODE ResolveModeFromGameId(const std::string& gameid); // device mode from the gameid alone; jvsmode= is an optional override
     void SetScreenPos(u16 x, u16 y);
+    void SetGunAimSource(u32 player, bool joystick);        // lightgun aim source: false = shared mouse, true = player's stick
+    void SetGunRelativeAim(u32 player, float dx, float dy); // player's stick-driven screen position from the GunCon2 (display coords)
     void SetGameId(const std::string& gameid);
     const std::string& GetGameId();
     const GunMapping& GetGunMapping();

--- a/pcsx2/ImGui/ImGuiManager.cpp
+++ b/pcsx2/ImGui/ImGuiManager.cpp
@@ -130,6 +130,16 @@ static bool s_scale_changed = false;
 static std::array<ImGuiManager::SoftwareCursor, InputManager::MAX_SOFTWARE_CURSORS> s_software_cursors = {};
 static ImGuiManager::BezelOverlay s_bezel_overlay = {};
 
+// Durable CPU-side record of each software cursor, so a dropped GS texture command self-heals (see DrawSoftwareCursors).
+struct DesiredSoftwareCursor
+{
+	std::string image_path;
+	float scale = 1.0f;
+	u32 color = 0xFF000000;
+};
+static std::array<DesiredSoftwareCursor, InputManager::MAX_SOFTWARE_CURSORS> s_software_cursor_desired = {};
+static std::mutex s_software_cursor_lock;
+
 void ImGuiManager::SetFonts(std::vector<FontInfo> info)
 {
 	s_font_info = std::move(info);
@@ -1233,7 +1243,8 @@ bool ImGuiManager::IsGamepadNorthWestSwapped()
 
 void ImGuiManager::CreateSoftwareCursorTextures()
 {
-	for (u32 i = 0; i < InputManager::MAX_POINTER_DEVICES; i++)
+	// All slots, not just the mouse pointer: gun crosshairs occupy slots >= MAX_POINTER_DEVICES.
+	for (u32 i = 0; i < InputManager::MAX_SOFTWARE_CURSORS; i++)
 	{
 		if (!s_software_cursors[i].image_path.empty())
 			UpdateSoftwareCursorTexture(i);
@@ -1242,7 +1253,7 @@ void ImGuiManager::CreateSoftwareCursorTextures()
 
 void ImGuiManager::DestroySoftwareCursorTextures()
 {
-	for (u32 i = 0; i < InputManager::MAX_POINTER_DEVICES; i++)
+	for (u32 i = 0; i < InputManager::MAX_SOFTWARE_CURSORS; i++)
 	{
 		s_software_cursors[i].texture.reset();
 	}
@@ -1305,6 +1316,23 @@ void ImGuiManager::DrawSoftwareCursor(const SoftwareCursor& sc, const std::pair<
 
 void ImGuiManager::DrawSoftwareCursors()
 {
+	// Rebuild each cursor from its saved record every frame, so a lost crosshair comes back on its own.
+	{
+		std::unique_lock<std::mutex> lock(s_software_cursor_lock);
+		for (u32 i = 0; i < InputManager::MAX_SOFTWARE_CURSORS; i++)
+		{
+			SoftwareCursor& sc = s_software_cursors[i];
+			const DesiredSoftwareCursor& d = s_software_cursor_desired[i];
+			sc.color = d.color;
+			const bool want_texture = !d.image_path.empty();
+			if (sc.image_path == d.image_path && sc.scale == d.scale && (!want_texture || sc.texture))
+				continue;
+			sc.image_path = d.image_path;
+			sc.scale = d.scale;
+			UpdateSoftwareCursorTexture(i);
+		}
+	}
+
 	// This one's okay to race, worst that happens is we render the wrong number of cursors for a frame.
 	const u32 pointer_count = InputManager::MAX_POINTER_DEVICES;
 
@@ -1317,6 +1345,15 @@ void ImGuiManager::DrawSoftwareCursors()
 
 void ImGuiManager::SetSoftwareCursor(u32 index, std::string image_path, float image_scale, u32 multiply_color)
 {
+	if (index >= InputManager::MAX_SOFTWARE_CURSORS)
+		return;
+
+	{
+		// Save the desired cursor (CPU-side) so it survives if the GS command below is dropped.
+		std::unique_lock<std::mutex> lock(s_software_cursor_lock);
+		s_software_cursor_desired[index] = {image_path, image_scale, multiply_color | 0xFF000000};
+	}
+
 	MTGS::RunOnGSThread([index, image_path = std::move(image_path), image_scale, multiply_color]() {
 		pxAssert(index < std::size(s_software_cursors));
 

--- a/pcsx2/Input/InputManager.cpp
+++ b/pcsx2/Input/InputManager.cpp
@@ -882,74 +882,65 @@ void InputManager::AddJVSBindings(SettingsInterface& si, bool is_profile)
 		}}, InputBindingInfo::Type::Button, si, ACJV::CONFIG_SECTION, bi.name, is_profile);
 	}
 
-	// P1 and P2 button bindings + auto-mirror from Pad1/Pad2
 	const std::span<const InputBindingInfo> player_bindings[] = {
 		ACJV::GetButtonBindings(),
 		ACJV::GetP2ButtonBindings(),
+	};
+
+	// Skip the generic P*_Button2..6 (games bind per-layout keys); keep P*_Button1 = the System ENTER switch.
+	const auto is_stale_generic_button = [](const char* name) {
+		const std::string_view n(name);
+		return (n.starts_with("P1_Button") || n.starts_with("P2_Button")) && !n.ends_with("1");
 	};
 
 	for (u32 player = 0; player < 2; player++)
 	{
 		for (const InputBindingInfo& bi : player_bindings[player])
 		{
+			if (is_stale_generic_button(bi.name))
+				continue;
 			const std::vector<std::string> bindings(si.GetStringList(ACJV::CONFIG_SECTION, bi.name));
 			if (bindings.empty())
 				continue;
 
-			AddBindings(bindings, InputAxisEventHandler{[player, mask = static_cast<u16>(bi.bind_index)](InputBindingKey key, float value) {
-				ACJV::SetButtonState(player, mask, value > 0.5f);
+			u16 mask = static_cast<u16>(bi.bind_index);
+			u32 target_player = player;
+			// Lightgun: send the System Start to the game's start bit (both guns on a 2-player cabinet).
+			if (ACJV::GetMode() == JVS_MODE::LIGHTGUN && mask == JVS_BTN_START)
+			{
+				const u16 gun_start = (player == 0) ? ACJV::GetGunMapping().p1_start : ACJV::GetGunMapping().p2_start;
+				if (gun_start)
+				{
+					mask = gun_start;
+					target_player = 0;
+				}
+			}
+			AddBindings(bindings, InputAxisEventHandler{[target_player, mask](InputBindingKey key, float value) {
+				ACJV::SetButtonState(target_player, mask, value > 0.5f);
 			}}, bi.bind_type, si, ACJV::CONFIG_SECTION, bi.name, is_profile);
 		}
-
-		// Mirror PadN gamepad bindings to JVS player N via matching GenericInputBinding.
-		// Real S246 cabinets have no DS2 — the arcade panel wires directly to JVS.
-		// We read the user's Pad bindings and route them to JVS as the sole input path.
-		const Pad::ControllerInfo* pad_ci = Pad::GetControllerInfo(EmuConfig.Pad.Ports[player].Type);
-		if (!pad_ci)
-			continue;
-
-		const std::string pad_section = Pad::GetConfigSection(player);
-		// Taiko (drum) uses only the drum sensors + coin; don't mirror the gamepad to JVS player buttons.
-		if (ACJV::GetMode() != JVS_MODE::DRUM)
-		for (const InputBindingInfo& jvs_bi : player_bindings[player])
-		{
-			if (jvs_bi.generic_mapping == GenericInputBinding::Unknown ||
-				jvs_bi.generic_mapping == GenericInputBinding::Select)
-				continue;
-
-			for (const InputBindingInfo& pad_bi : pad_ci->bindings)
-			{
-				if (pad_bi.generic_mapping != jvs_bi.generic_mapping)
-					continue;
-
-				const std::vector<std::string> pad_bindings(si.GetStringList(pad_section.c_str(), pad_bi.name));
-				for (const std::string& pb : pad_bindings)
-				{
-					AddBinding(pb, InputAxisEventHandler{[player, mask = static_cast<u16>(jvs_bi.bind_index)](InputBindingKey key, float value) {
-						ACJV::SetButtonState(player, mask, value > 0.5f);
-					}});
-				}
-				break;
-			}
-		}
-
-		// Mirror PadN Select -> Coin insert for player N
-		for (const InputBindingInfo& pad_bi : pad_ci->bindings)
-		{
-			if (pad_bi.generic_mapping != GenericInputBinding::Select)
-				continue;
-
-			const std::vector<std::string> pad_bindings(si.GetStringList(pad_section.c_str(), pad_bi.name));
-			for (const std::string& pb : pad_bindings)
-			{
-				AddBinding(pb, InputButtonEventHandler{[player](s32 pressed) {
-					if (pressed > 0)
-						ACJV::InsertCoin(player);
-				}});
-			}
-			break;
-		}
 	}
+
+	// Per-layout action buttons (hub): bind {base}_P1/_P2 to the JVS bit. Fighting and standard wire both
+	// players (the generic P1_Button* are skipped above); racing is 1 player per cabinet, so P1 only.
+	const auto bind_layout_buttons = [&](std::span<const InputBindingInfo> buttons, bool two_players) {
+		for (const InputBindingInfo& bi : buttons)
+		{
+			for (u32 player = 0; player < (two_players ? 2u : 1u); player++)
+			{
+				const std::string cfgkey = std::string(bi.name) + (player == 0 ? "_P1" : "_P2");
+				const std::vector<std::string> bindings(si.GetStringList(ACJV::CONFIG_SECTION, cfgkey.c_str()));
+				if (bindings.empty())
+					continue;
+				AddBindings(bindings, InputAxisEventHandler{[player, mask = static_cast<u16>(bi.bind_index)](InputBindingKey, float value) {
+					ACJV::SetButtonState(player, mask, value > 0.5f);
+				}}, bi.bind_type, si, ACJV::CONFIG_SECTION, cfgkey.c_str(), is_profile);
+			}
+		}
+	};
+	bind_layout_buttons(ACJV::GetFightingButtons(), true);
+	bind_layout_buttons(ACJV::GetStandardButtons(), true);
+	bind_layout_buttons(ACJV::GetRacingButtons(), false);
 
 	for (const InputBindingInfo& bi : ACJV::GetCoinBindings())
 	{
@@ -963,15 +954,49 @@ void InputManager::AddJVSBindings(SettingsInterface& si, bool is_profile)
 		}}, InputBindingInfo::Type::Button, si, ACJV::CONFIG_SECTION, bi.name, is_profile);
 	}
 
-	// driving analog axes (steer/gas/brake) -> JVS wheel channels, mirroring the button bindings above
+	// JVS macros: push the running layout's macro switch masks to ACJV and register each trigger.
+	const std::string macro_layout = ACJV::GetCurrentLayoutKey();
+	if (!macro_layout.empty())
+	{
+		for (u32 p = 0; p < 2; p++) // JVS P1/P2
+		{
+			for (u32 i = 0; i < ACJV::NUM_JVS_MACROS; i++)
+			{
+				u16 mask = 0;
+				for (const std::string& n : si.GetStringList(ACJV::CONFIG_SECTION, ACJV::MacroConfigKey(macro_layout, p, i, "Binds").c_str()))
+					for (const ACJV::JvsMacroSwitch& sw : ACJV::GetMacroSwitches())
+						if (n == sw.name) { mask |= sw.bit; break; }
+				ACJV::SetMacroMask(p, i, mask);
+
+				const std::string key = ACJV::MacroConfigKey(macro_layout, p, i, "");
+				const std::vector<std::string> bindings(si.GetStringList(ACJV::CONFIG_SECTION, key.c_str()));
+				if (bindings.empty())
+					continue;
+
+				AddBindings(bindings, InputButtonEventHandler{[p, i](s32 pressed) {
+					ACJV::SetMacroState(p, i, pressed > 0);
+				}}, InputBindingInfo::Type::Macro, si, ACJV::CONFIG_SECTION, key.c_str(), is_profile);
+			}
+		}
+	}
+
+	// Racing analog axes -> JVS wheel channels, with deadzone/sensitivity applied.
+	const float analog_deadzone = si.GetFloatValue(ACJV::CONFIG_SECTION, "AnalogDeadzone", 0.0f);
+	const float analog_sensitivity = si.GetFloatValue(ACJV::CONFIG_SECTION, "AnalogSensitivity", 1.33f);
+	const float trigger_deadzone = si.GetFloatValue(ACJV::CONFIG_SECTION, "TriggerDeadzone", 0.0f);
+	const bool invert_steering = si.GetBoolValue(ACJV::CONFIG_SECTION, "InvertSteering", false);
 	for (const InputBindingInfo& bi : ACJV::GetWheelBindings())
 	{
 		const std::vector<std::string> bindings(si.GetStringList(ACJV::CONFIG_SECTION, bi.name));
 		if (bindings.empty())
 			continue;
 
-		AddBindings(bindings, InputAxisEventHandler{[axis = static_cast<u32>(bi.bind_index)](InputBindingKey key, float value) {
-			ACJV::SetWheelAxis(axis, value);
+		const bool is_steering = (bi.bind_index <= 1);
+		const float deadzone = is_steering ? analog_deadzone : trigger_deadzone;
+		const float sensitivity = is_steering ? analog_sensitivity : 1.0f;
+		const bool invert = is_steering && invert_steering;
+		AddBindings(bindings, InputAxisEventHandler{[axis = static_cast<u32>(bi.bind_index), sensitivity, deadzone, invert](InputBindingKey key, float value) {
+			ACJV::SetWheelAxis(axis, ApplySingleBindingScale(sensitivity, deadzone, invert ? -value : value));
 		}}, bi.bind_type, si, ACJV::CONFIG_SECTION, bi.name, is_profile);
 	}
 
@@ -985,33 +1010,6 @@ void InputManager::AddJVSBindings(SettingsInterface& si, bool is_profile)
 		AddBindings(bindings, InputAxisEventHandler{[channel = static_cast<u32>(bi.bind_index)](InputBindingKey key, float value) {
 			ACJV::SetDrumHit(channel, value > 0.5f);
 		}}, bi.bind_type, si, ACJV::CONFIG_SECTION, bi.name, is_profile);
-	}
-
-	if (const Pad::ControllerInfo* pad_ci = Pad::GetControllerInfo(EmuConfig.Pad.Ports[0].Type))
-	{
-		const std::string pad_section = Pad::GetConfigSection(0);
-		// apply Port 1's deadzone to the auto-mirrored wheel (the JVS path skips the pad's own, so a worn stick drifts)
-		const float stick_deadzone = si.GetFloatValue(pad_section.c_str(), "Deadzone", Pad::DEFAULT_STICK_DEADZONE);
-		const float trig_deadzone = si.GetFloatValue(pad_section.c_str(), "ButtonDeadzone", Pad::DEFAULT_BUTTON_DEADZONE);
-		for (const InputBindingInfo& jvs_bi : ACJV::GetWheelBindings())
-		{
-			for (const InputBindingInfo& pad_bi : pad_ci->bindings)
-			{
-				if (pad_bi.generic_mapping != jvs_bi.generic_mapping)
-					continue;
-
-				// steering (axes 0/1) uses the analog deadzone; gas/brake (2/3) the trigger deadzone
-				const float deadzone = (jvs_bi.bind_index <= 1) ? stick_deadzone : trig_deadzone;
-				const std::vector<std::string> pad_bindings(si.GetStringList(pad_section.c_str(), pad_bi.name));
-				for (const std::string& pb : pad_bindings)
-				{
-					AddBinding(pb, InputAxisEventHandler{[axis = static_cast<u32>(jvs_bi.bind_index), deadzone](InputBindingKey key, float value) {
-						ACJV::SetWheelAxis(axis, ApplySingleBindingScale(1.0f, deadzone, value));
-					}});
-				}
-				break;
-			}
-		}
 	}
 }
 

--- a/pcsx2/USB/usb-lightgun/guncon2.cpp
+++ b/pcsx2/USB/usb-lightgun/guncon2.cpp
@@ -498,6 +498,15 @@ namespace usb_lightgun
 		return nullptr;
 	}
 
+	// Send where the player is aiming (with a stick, not a mouse) to the arcade lightgun.
+	static void ForwardRelativeAimToJVS(GunCon2State* s)
+	{
+		const auto& [wx, wy] = s->GetAbsolutePositionFromRelativeAxes();
+		float dx, dy;
+		GSTranslateWindowToDisplayCoordinates(wx, wy, &dx, &dy);
+		ACJV::SetGunRelativeAim(s->port, dx, dy);
+	}
+
 	void GunCon2Device::UpdateSettings(USBDevice* dev, SettingsInterface& si) const
 	{
 		GunCon2State* s = USB_CONTAINER_OF(dev, GunCon2State, dev);
@@ -537,6 +546,12 @@ namespace usb_lightgun
 			USB::ConfigKeyExists(si, s->port, TypeName(), "RelativeUp") ||
 			USB::ConfigKeyExists(si, s->port, TypeName(), "RelativeDown"));
 
+		// Arcade aim goes through ACJV; the Aim Device is either the mouse (Pointer-N) or a controller stick.
+		const bool joystick_aim = !pointer_binding.empty() && !StringUtil::StartsWithNoCase(pointer_binding, "Pointer-");
+		ACJV::SetGunAimSource(s->port, joystick_aim);
+		if (joystick_aim)
+			ForwardRelativeAimToJVS(s);
+
 		const s32 new_pointer_index = s->GetSoftwarePointerIndex();
 
 		const bool cursor_changed =
@@ -547,7 +562,9 @@ namespace usb_lightgun
 
 		if (cursor_changed)
 		{
-			if (prev_pointer_index != new_pointer_index)
+			// Only clear a gun's own dedicated slot; slot 0 is the shared mouse pointer (another player/gun
+			// may be aiming with it), so switching this gun off it must not yank slot 0 out from under them.
+			if (prev_pointer_index != new_pointer_index && prev_pointer_index >= static_cast<s32>(InputManager::MAX_POINTER_DEVICES))
 				ImGuiManager::ClearSoftwareCursor(prev_pointer_index);
 
 			const bool had_software_cursor = !s->cursor_path.empty();
@@ -640,6 +657,8 @@ namespace usb_lightgun
 			{
 				s->relative_pos[rel_index] = value;
 				s->UpdateSoftwarePointerPosition();
+				if (ACJV::enabled)
+					ForwardRelativeAimToJVS(s);
 			}
 		}
 	}

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -732,6 +732,10 @@ bool VMManager::HasAnyBindingsForPad(const SettingsInterface& si, u32 port)
 
 void VMManager::WarnAboutUnconfiguredController()
 {
+	// Arcade input is over JVS, so skip the "no controller bindings configured" warning for arcade games.
+	if (!s_acgame.empty())
+		return;
+
 	std::unique_lock<std::mutex> lock = Host::GetSettingsLock();
 	SettingsInterface* si = Host::GetSettingsInterface();
 	if (!si || HasAnyBindingsForPad(*si, 0))
@@ -1401,46 +1405,28 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				s_elf_override = Path::Combine(basedir, INI.GetStringValue("data", "elf"));
 				EmuConfig.CurrentGameArgs = INI.GetStringValue("data", "args");
 				ACSRAM::filepath = Path::Combine(basedir, INI.GetStringValue("data", "sram", "sram.bin"));
+				// JVS device mode: an explicit jvsmode= in the .acgame overrides (force/legacy); otherwise it is
+				// derived from the gameid alone (ACJV::ResolveModeFromGameId), so a .acgame needs only its gameid.
 				std::string jvsmode = INI.GetStringValue("data", "jvsmode", "");
-				if (jvsmode == "lightgun")
-				{
-					Host::SetBaseStringSettingValue("USB1", "Type", "guncon2");
-					Host::SetBaseStringSettingValue("USB2", "Type", "guncon2");
-					ACJV::SetMode(JVS_MODE::LIGHTGUN);
-					Console.WriteLn(Color_Green, "ACGAME: jvsmode=lightgun -> GunCon2 on USB1+USB2");
-				}
-				else
-				{
-					Host::SetBaseStringSettingValue("USB1", "Type", "None");
-					Host::SetBaseStringSettingValue("USB2", "Type", "None");
-					if (jvsmode == "fighting")
-					{
-						ACJV::SetMode(JVS_MODE::FIGHTING);
-						Console.WriteLn(Color_Green, "ACGAME: jvsmode=fighting");
-					}
-					else if (jvsmode == "drum")
-					{
-						ACJV::SetMode(JVS_MODE::DRUM);
-						Console.WriteLn(Color_Green, "ACGAME: jvsmode=drum");
-					}
-					else if (jvsmode == "racing")
-					{
-						ACJV::SetMode(JVS_MODE::DRIVE);
-						Console.WriteLn(Color_Green, "ACGAME: jvsmode=racing");
-					}
-					else if (jvsmode == "standard")
-					{
-						ACJV::SetMode(JVS_MODE::STANDARD);
-						Console.WriteLn(Color_Green, "ACGAME: jvsmode=standard");
-					}
-					else if (jvsmode == "twinstick")
-					{
-						ACJV::SetMode(JVS_MODE::TWINSTICK);
-						Console.WriteLn(Color_Green, "ACGAME: jvsmode=twinstick");
-					}
-					else
-						ACJV::SetMode(JVS_MODE::DEFAULT);
-				}
+				JVS_MODE mode;
+				if (jvsmode.empty())             mode = ACJV::ResolveModeFromGameId(s_serial);
+				else if (jvsmode == "lightgun")  mode = JVS_MODE::LIGHTGUN;
+				else if (jvsmode == "fighting")  mode = JVS_MODE::FIGHTING;
+				else if (jvsmode == "drum")      mode = JVS_MODE::DRUM;
+				else if (jvsmode == "racing")    mode = JVS_MODE::DRIVE;
+				else if (jvsmode == "standard")  mode = JVS_MODE::STANDARD;
+				else if (jvsmode == "twinstick") mode = JVS_MODE::TWINSTICK;
+				else                             mode = JVS_MODE::DEFAULT; // unknown override string
+
+				// Attach the 2nd GunCon2 only for 2-player games, so 1-player cabinets show no extra crosshair.
+				const bool lightgun = (mode == JVS_MODE::LIGHTGUN);
+				const bool two_gun = lightgun && ACJV::GetGunMapping().p2_start != 0;
+				Host::SetBaseStringSettingValue("USB1", "Type", lightgun ? "guncon2" : "None");
+				Host::SetBaseStringSettingValue("USB2", "Type", two_gun ? "guncon2" : "None");
+				ACJV::SetMode(mode);
+				Console.WriteLn(Color_Green, "ACGAME: jvsmode=%s -> JVS device mode %d%s",
+					jvsmode.empty() ? "(derived from gameid)" : jvsmode.c_str(),
+					static_cast<int>(mode), lightgun ? (two_gun ? " -> GunCon2 on USB1+USB2" : " -> GunCon2 on USB1") : "");
 
 				ACATA::SetEnv(basedir, s_imgname, s_acmedia);
 				int R;


### PR DESCRIPTION
NEED TESTERS. PLEASE TEST AND REPORT BACK

**IMPORTANT: you must re-bind your arcade controls in the new JVS Controls tab. The DualShock2 pad-mapping was retired, previous bindings won't carry over. Tip: use the per-page Automatic Mapping button to fill them from a controller in one click, same default layout as before.**

This is a QOL commit overhauling the JVS tab in UI. Most notable changes:

New features:
 - New unified JVS Controls tab for all arcade inputs with 7 layout pages:
   - System with all the arcade system buttons (coins, start, enter sw, service sw, etc.)
   - Fighting, racing, taiko drum, twinstick, lightgun, standard layout pages fully customizable (fixes #29 fixes #77)
 - JVS mode is now auto-derived from `gameid`. 
   - `Jvsmode=` is now an optional override (not needed in .acgame files)
 - Removed the hardcoded DualShock2 inputs
   - all arcade input is set in the JVS tab; per-page _Automatic Mapping_ from a host device (based on PS2 port of the game layout)
 - JVS macros (per-layout combos) and analog steering settings (deadzone / sensitivity / invert).
 - Lightgun page: adding per-player aim device (https://github.com/PS2Homebrew-arcade/pcsx2x6/issues/84), preparing groundwork for future RawInput (Windows) / evdev (linux) support
 - USB Port tab hides arcade-managed devices (GunCon2 / Wheel / Rock Band drums); controller-port rows hidden for arcade.

Fixes
 - Crosshair fix: per-gun crosshairs shown reliably and no "phantom" P2 crosshair (sometimes not showing)
 - Keyboard should now work properly
 - Controller relative-aim fix: a controller stick can control lightgun aim, not just the mouse (fixes #84)

Some clean up of older/dead code.