### PR TITLE
implement logging for ACATA/ACATAPI and ACSRAM

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -403,13 +403,13 @@ void MainWindow::connectSignals()
 #endif
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableEEConsoleLogging, "Logging", "EnableEEConsole", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableIOPConsoleLogging, "Logging", "EnableIOPConsole", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_ACATA_Read_Logging, "Logging",  "ArcadeATAVerboseReads", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_SRAM_Access_Logging, "Logging", "ArcadeSRAMVerboseReads", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_RAM_Access_Logging, "Logging",  "ArcadeRAMVerboseReads", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableLogWindow, "Logging", "EnableLogWindow", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableFileLogging, "Logging", "EnableFileLogging", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableLogTimestamps, "Logging", "EnableTimestamps", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableCDVDVerboseReads, "EmuCore", "CdvdVerboseReads", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_ACATA_Read_Logging, "Arcade/Debug", "ArcadeATAVerboseReads", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_SRAM_Access_Logging, "Arcade/Debug", "ArcadeSRAMVerboseReads", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_RAM_Access_Logging, "Arcade/Debug", "ArcadeRAMVerboseReads", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionSaveBlockDump, "EmuCore", "CdvdDumpBlocks", false);
 	m_ui.actionShowAdvancedSettings->setChecked(QtHost::ShouldShowAdvancedSettings());
 	connect(m_ui.actionSaveBlockDump, &QAction::toggled, this, &MainWindow::onBlockDumpActionToggled);

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -406,6 +406,7 @@ void MainWindow::connectSignals()
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_ACATA_Read_Logging, "Arcade",  "ATAVerboseReads", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_SRAM_Access_Logging, "Arcade", "SRAMVerboseReads", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_RAM_Access_Logging, "Arcade",  "RAMVerboseReads", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_UART_Access_Logging, "Arcade",  "UARTVerbose", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableLogWindow, "Logging", "EnableLogWindow", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableFileLogging, "Logging", "EnableFileLogging", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableLogTimestamps, "Logging", "EnableTimestamps", true);

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -403,9 +403,9 @@ void MainWindow::connectSignals()
 #endif
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableEEConsoleLogging, "Logging", "EnableEEConsole", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableIOPConsoleLogging, "Logging", "EnableIOPConsole", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_ACATA_Read_Logging, "Logging",  "ArcadeATAVerboseReads", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_SRAM_Access_Logging, "Logging", "ArcadeSRAMVerboseReads", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_RAM_Access_Logging, "Logging",  "ArcadeRAMVerboseReads", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_ACATA_Read_Logging, "Arcade",  "ATAVerboseReads", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_SRAM_Access_Logging, "Arcade", "SRAMVerboseReads", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_RAM_Access_Logging, "Arcade",  "RAMVerboseReads", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableLogWindow, "Logging", "EnableLogWindow", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableFileLogging, "Logging", "EnableFileLogging", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableLogTimestamps, "Logging", "EnableTimestamps", true);

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -407,8 +407,9 @@ void MainWindow::connectSignals()
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableFileLogging, "Logging", "EnableFileLogging", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableLogTimestamps, "Logging", "EnableTimestamps", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableCDVDVerboseReads, "EmuCore", "CdvdVerboseReads", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_ACATA_Read_Logging, "EmuCore", "ArcadeATAVerboseReads", false);
-	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_SRAM_Access_Logging, "EmuCore", "ArcadeSRAMVerboseReads", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_ACATA_Read_Logging, "Arcade/Debug", "ArcadeATAVerboseReads", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_SRAM_Access_Logging, "Arcade/Debug", "ArcadeSRAMVerboseReads", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_RAM_Access_Logging, "Arcade/Debug", "ArcadeRAMVerboseReads", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionSaveBlockDump, "EmuCore", "CdvdDumpBlocks", false);
 	m_ui.actionShowAdvancedSettings->setChecked(QtHost::ShouldShowAdvancedSettings());
 	connect(m_ui.actionSaveBlockDump, &QAction::toggled, this, &MainWindow::onBlockDumpActionToggled);

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -407,6 +407,8 @@ void MainWindow::connectSignals()
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableFileLogging, "Logging", "EnableFileLogging", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableLogTimestamps, "Logging", "EnableTimestamps", true);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableCDVDVerboseReads, "EmuCore", "CdvdVerboseReads", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_ACATA_Read_Logging, "EmuCore", "ArcadeATAVerboseReads", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_SRAM_Access_Logging, "EmuCore", "ArcadeSRAMVerboseReads", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionSaveBlockDump, "EmuCore", "CdvdDumpBlocks", false);
 	m_ui.actionShowAdvancedSettings->setChecked(QtHost::ShouldShowAdvancedSettings());
 	connect(m_ui.actionSaveBlockDump, &QAction::toggled, this, &MainWindow::onBlockDumpActionToggled);

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -149,6 +149,8 @@
     <addaction name="actionEnableEEConsoleLogging"/>
     <addaction name="actionEnableIOPConsoleLogging"/>
     <addaction name="actionEnableCDVDVerboseReads"/>
+    <addaction name="actionEnable_ACATA_Read_Logging"/>
+    <addaction name="actionEnable_SRAM_Access_Logging"/>
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
@@ -1073,6 +1075,22 @@
    </property>
    <property name="text">
     <string>Edit &amp;Patches...</string>
+   </property>
+  </action>
+  <action name="actionEnable_ACATA_Read_Logging">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Enable ACATA Read Logging</string>
+   </property>
+  </action>
+  <action name="actionEnable_SRAM_Access_Logging">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Enable SRAM Access Logging</string>
    </property>
   </action>
  </widget>

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -152,6 +152,7 @@
     <addaction name="actionEnable_ACATA_Read_Logging"/>
     <addaction name="actionEnable_SRAM_Access_Logging"/>
     <addaction name="actionEnable_RAM_Access_Logging"/>
+    <addaction name="actionEnable_UART_Access_Logging"/>
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
@@ -1100,6 +1101,14 @@
    </property>
    <property name="text">
     <string>Enable Arcade RAM Access Logging</string>
+   </property>
+  </action>
+  <action name="actionEnable_UART_Access_Logging">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Enable Arcade UART RX/TX Logging</string>
    </property>
   </action>
  </widget>

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -151,6 +151,7 @@
     <addaction name="actionEnableCDVDVerboseReads"/>
     <addaction name="actionEnable_ACATA_Read_Logging"/>
     <addaction name="actionEnable_SRAM_Access_Logging"/>
+    <addaction name="actionEnable_RAM_Access_Logging"/>
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
@@ -1082,7 +1083,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Enable ACATA Read Logging</string>
+    <string>Enable Arcade ATA Read Logging</string>
    </property>
   </action>
   <action name="actionEnable_SRAM_Access_Logging">
@@ -1090,7 +1091,15 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Enable SRAM Access Logging</string>
+    <string>Enable Arcade SRAM Access Logging</string>
+   </property>
+  </action>
+  <action name="actionEnable_RAM_Access_Logging">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Enable Arcade RAM Access Logging</string>
    </property>
   </action>
  </widget>

--- a/pcsx2-qt/Settings/JVSControlsWidget.cpp
+++ b/pcsx2-qt/Settings/JVSControlsWidget.cpp
@@ -133,7 +133,7 @@ JVSControlsWidget::JVSControlsWidget(QWidget* parent, ControllerSettingsWindow* 
 	m_ui.systemPageLayout->addStretch(1); // top-pack so the page doesn't inherit the tallest page's height
 
 	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(m_dialog->getProfileSettingsInterface(), m_ui.suppressDaemon,
-		ACJV::CONFIG_SECTION, "SuppressDaemon", true);
+		"Arcade", "SuppressDaemon", true);
 
 	// Item order MUST match the QStackedWidget page order in the .ui.
 	m_ui.pageSelector->addItem(tr("System"));

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1357,12 +1357,16 @@ struct Pcsx2Config
 	};
 
 	// ------------------------------------------------------------------------
+	struct ArcadeOptions {
+		bool SRAMVerboseReads{false};
+		bool RAMVerboseReads{false};
+		bool ATAVerboseReads{false};
+		
+		void LoadSave(SettingsWrapper& wrap);
 
-	struct _ArcadeLogs {
-		bool SRAMVerboseReads;
-		bool RAMVerboseReads;
-		bool ATAVerboseReads;
-	} ArcadeLogs;
+		bool operator==(const ArcadeOptions& right) const;
+		bool operator!=(const ArcadeOptions& right) const;
+	};
 
 	BITFIELD32()
 	bool
@@ -1411,6 +1415,8 @@ struct Pcsx2Config
 	FilenameOptions BaseFilenames;
 
 	AchievementsOptions Achievements;
+
+	ArcadeOptions Arcade;
 
 	// Memorycard options - first 2 are default slots, last 6 are multitap 1 and 2
 	// slots (3 each)

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1361,6 +1361,7 @@ struct Pcsx2Config
 	BITFIELD32()
 	bool
 		ArcadeSRAMVerboseReads : 1,
+		ArcadeRAMVerboseReads : 1,
 		ArcadeATAVerboseReads : 1;
 	BITFIELD_END
 

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1361,6 +1361,7 @@ struct Pcsx2Config
 		bool SRAMVerboseReads{false};
 		bool RAMVerboseReads{false};
 		bool ATAVerboseReads{false};
+		bool UARTVerbose{false};
 		
 		void LoadSave(SettingsWrapper& wrap);
 

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1360,6 +1360,12 @@ struct Pcsx2Config
 
 	BITFIELD32()
 	bool
+		ArcadeSRAMVerboseReads : 1,
+		ArcadeATAVerboseReads : 1;
+	BITFIELD_END
+
+	BITFIELD32()
+	bool
 		CdvdVerboseReads : 1, // enables cdvd read activity verbosely dumped to the console
 		CdvdDumpBlocks : 1, // enables cdvd block dumping
 		CdvdPrecache : 1, // enables cdvd precaching of compressed images

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1358,12 +1358,11 @@ struct Pcsx2Config
 
 	// ------------------------------------------------------------------------
 
-	BITFIELD32()
-	bool
-		ArcadeSRAMVerboseReads : 1,
-		ArcadeRAMVerboseReads : 1,
-		ArcadeATAVerboseReads : 1;
-	BITFIELD_END
+	struct _ArcadeLogs {
+		bool SRAMVerboseReads;
+		bool RAMVerboseReads;
+		bool ATAVerboseReads;
+	} ArcadeLogs;
 
 	BITFIELD32()
 	bool

--- a/pcsx2/DEV9/ACATA.cpp
+++ b/pcsx2/DEV9/ACATA.cpp
@@ -227,7 +227,7 @@ void ACATA::handle_cmd(u16 val) {
         // here, the ata busy flag must be present at least once, on the following checks to this addr
         break;
     case ATA_C_IDENTIFY_PACKET_DEVICE:
-        Console.Warning("ATA_C_IDENTIFY_PACKET_DEVICE");
+        ACATA_LOG("ATA_C_IDENTIFY_PACKET_DEVICE");
         ACATA::cmd_handled = val;
         ACATA::cmd_handledc = 0;
         R_STATUS |= ATA_STAT_DRQ;
@@ -245,7 +245,7 @@ void ACATA::handle_cmd(u16 val) {
         ACCORE::intr(ACCORE::INTRN_ATA);
     break;
     case ATA_C_IDENTIFY_DEVICE:
-        Console.Warning("ATA_C_IDENTIFY_DEVICE");
+        ACATA_LOG("ATA_C_IDENTIFY_DEVICE");
         ata_build_identify();
         ACATA::cmd_handled = val;
         ACATA::cmd_handledc = 0;
@@ -257,6 +257,7 @@ void ACATA::handle_cmd(u16 val) {
         u32 lba = R_SECTOR | (R_LCYL << 8) | (R_HCYL << 16) | ((R_SELECT & 0x0F) << 24);
         u32 count = R_NSECTOR ? R_NSECTOR : 256;
         u32 total = count * ATA_SECTORSIZE;
+        ACATA_LOG("CMD:ATA_C_READ_SECTOR lba:%08X sectors:%02X", lba, count);
         if (!ACATA::TH::IMAGE || total > sizeof(ata_pio_buf)) {
             R_STATUS |= ATA_STAT_ERR;
             R_ERROR = ATA_ERR_ABORT;
@@ -293,10 +294,12 @@ void ACATA::handle_cmd(u16 val) {
         ACATA::cmd_handled = val;
         R_STATUS |= ATA_STAT_BUSY;
         CLRB(R_STATUS, ATA_STAT_DRQ);
+        ACATA_LOG("CMD:%s lba:%08X sectors:%02X", 
+            (val == ATA_C_READ_DMA) ? "ATA_C_READ_DMA" : "ATA_C_READ_DMA_WITHOUT_RETRIES", lba, count);
         break;
     }
     case ATA_C_SET_FEATURES:
-        Console.Warning("ATA_C_SET_FEATURES: FEATURE:%04X, R_NSECTOR:%04X, R_SECTOR:%04X, R_LCYL:%04X, R_HCYL:%04X",
+        ACATA_LOG("ATA_C_SET_FEATURES: FEATURE:%04X, R_NSECTOR:%04X, R_SECTOR:%04X, R_LCYL:%04X, R_HCYL:%04X",
             R_FEATURE, R_NSECTOR, R_SECTOR, R_LCYL, R_HCYL);
         CLRB(R_STATUS, ATA_STAT_ERR);
         R_STATUS |= ATA_STAT_READY;
@@ -313,6 +316,8 @@ void ACATA::handle_cmd(u16 val) {
         ACATA::cmd_handled = val;
         R_STATUS |= ATA_STAT_BUSY;
         CLRB(R_STATUS, ATA_STAT_DRQ);
+        ACATA_LOG("CMD:%s lba:%08X sectors:%02X", 
+            (val == ATA_C_WRITE_DMA) ? "ATA_C_WRITE_DMA" : "ATA_C_WRITE_DMA_WITHOUT_RETRIES", lba, count);
         break;
     }
     case ATA_C_SMART:
@@ -403,6 +408,7 @@ void ACATA::handle_cmd(u16 val) {
         ACCORE::intr(ACCORE::INTRN_ATA);
         break;
     case ATA_C_DEVICE_RESET:
+        ACATA_LOG("ATA_C_DEVICE_RESET");
         R_ERROR = 0x01;
         R_NSECTOR = 0x01;
         R_SECTOR = 0x01;

--- a/pcsx2/DEV9/ACATA.h
+++ b/pcsx2/DEV9/ACATA.h
@@ -25,7 +25,7 @@
 #include "ACATA_internal.h"
 #include "ACATAPI.h"
 
-#define ACATA_LOG(fmt, ...) if (EmuConfig.ArcadeATAVerboseReads) Console.WriteLn(Color_Gray, "ACATA:" fmt __VA_OPT__(,) __VA_ARGS__)
+#define ACATA_LOG(fmt, ...) if (EmuConfig.ArcadeLogs.ATAVerboseReads) Console.WriteLn(Color_Gray, "ACATA:" fmt __VA_OPT__(,) __VA_ARGS__)
 
 #define ACATA_R_DATA                0x16000000  // Read/Write PIO data bytes
 #define ACATA_R_FEATURE             0x16010000  // [W] Used to control command specific interface features.

--- a/pcsx2/DEV9/ACATA.h
+++ b/pcsx2/DEV9/ACATA.h
@@ -6,6 +6,7 @@
  * used by ACATA.IRX, which is used by ACDVDV and ACATAD for using disc readers or hard drives on system2x6 units
  */
 
+#include "Config.h"
 #include "MemoryTypes.h"
 #include "common/Pcsx2Types.h"
 #include "common/Pcsx2Defs.h"
@@ -23,6 +24,8 @@
 
 #include "ACATA_internal.h"
 #include "ACATAPI.h"
+
+#define ACATA_LOG(fmt, ...) if (EmuConfig.ArcadeATAVerboseReads) Console.WriteLn(Color_Gray, "ACATA:" fmt __VA_OPT__(,) __VA_ARGS__)
 
 #define ACATA_R_DATA                0x16000000  // Read/Write PIO data bytes
 #define ACATA_R_FEATURE             0x16010000  // [W] Used to control command specific interface features.

--- a/pcsx2/DEV9/ACATA.h
+++ b/pcsx2/DEV9/ACATA.h
@@ -25,7 +25,7 @@
 #include "ACATA_internal.h"
 #include "ACATAPI.h"
 
-#define ACATA_LOG(fmt, ...) if (EmuConfig.ArcadeLogs.ATAVerboseReads) Console.WriteLn(Color_Gray, "ACATA:" fmt __VA_OPT__(,) __VA_ARGS__)
+#define ACATA_LOG(fmt, ...) if (EmuConfig.Arcade.ATAVerboseReads) Console.WriteLn(Color_Gray, "ACATA:" fmt __VA_OPT__(,) __VA_ARGS__)
 
 #define ACATA_R_DATA                0x16000000  // Read/Write PIO data bytes
 #define ACATA_R_FEATURE             0x16010000  // [W] Used to control command specific interface features.

--- a/pcsx2/DEV9/ACATAPI.cpp
+++ b/pcsx2/DEV9/ACATAPI.cpp
@@ -171,6 +171,7 @@ void ACATAPI::handle_cmd(atapi_packet_t P) {
         break;
 
     case ATAPICMD::INQUIRY: {
+        ACATA_LOG("ATAPI INQUIRY");
         // The disc driver sends INQUIRY to check the drive is a CD/DVD-ROM before it
         // mounts "cdrom:". Answer as a DVD-ROM drive or the mount never happens.
         u8 alloc_len = P.raw8[4];
@@ -258,6 +259,7 @@ void ACATAPI::handle_cmd(atapi_packet_t P) {
             atapi_complete_nodata();
             break;
         }
+        ACATA_LOG("ATAPI READ_10 lba:%08X sectors:%02X dma:%s", transf_lba, nsec, ACATA_ISDMA);
         if (ACATA_ISDMA) {
             u32 total = nsec * ACATAPI::CONSTANTS::DVD_SECTORSIZE;
             bool ok = false;

--- a/pcsx2/DEV9/ACATAPI.cpp
+++ b/pcsx2/DEV9/ACATAPI.cpp
@@ -259,7 +259,7 @@ void ACATAPI::handle_cmd(atapi_packet_t P) {
             atapi_complete_nodata();
             break;
         }
-        ACATA_LOG("ATAPI READ_10 lba:%08X sectors:%02X dma:%s", transf_lba, nsec, ACATA_ISDMA);
+        ACATA_LOG("ATAPI READ_10 lba:%08X sectors:%02X dma:%d", transf_lba, nsec, ACATA_ISDMA);
         if (ACATA_ISDMA) {
             u32 total = nsec * ACATAPI::CONSTANTS::DVD_SECTORSIZE;
             bool ok = false;

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -469,7 +469,7 @@ void ACJV::LoadConfig(const SettingsInterface& si)
 			state |= s_dip_switch_masks[i];
 	}
 	s_dip_switch_state = state;
-	s_suppress_daemon = si.GetBoolValue(CONFIG_SECTION, "SuppressDaemon", true);
+	s_suppress_daemon = si.GetBoolValue("Arcade", "SuppressDaemon", true);
 	s_sinden_border_enabled = si.GetBoolValue(CONFIG_SECTION, "SindenBorderEnabled", false);
 	s_sinden_border_mode = si.GetIntValue(CONFIG_SECTION, "SindenBorderMode", 0);
 	s_sinden_border_thickness = si.GetIntValue(CONFIG_SECTION, "SindenBorderThickness", 10);
@@ -481,7 +481,7 @@ void ACJV::CopyConfiguration(SettingsInterface* dest_si, const SettingsInterface
 	{
 		for (const DIPSwitchInfo& dip_switch : s_dip_switch_info)
 			dest_si->CopyBoolValue(src_si, CONFIG_SECTION, dip_switch.name);
-		dest_si->CopyBoolValue(src_si, CONFIG_SECTION, "SuppressDaemon");
+		dest_si->CopyBoolValue(src_si, "Arcade", "SuppressDaemon");
 		dest_si->CopyBoolValue(src_si, CONFIG_SECTION, "SindenBorderEnabled");
 		dest_si->CopyIntValue(src_si, CONFIG_SECTION, "SindenBorderMode");
 		dest_si->CopyIntValue(src_si, CONFIG_SECTION, "SindenBorderThickness");
@@ -546,7 +546,7 @@ void ACJV::SetDefaultConfiguration(SettingsInterface& si)
 	si.ClearSection(CONFIG_SECTION);
 	for (const DIPSwitchInfo& dip_switch : s_dip_switch_info)
 		si.SetBoolValue(CONFIG_SECTION, dip_switch.name, dip_switch.default_value);
-	si.SetBoolValue(CONFIG_SECTION, "SuppressDaemon", true);
+	si.SetBoolValue("Arcade", "SuppressDaemon", true);
 	si.SetBoolValue(CONFIG_SECTION, "SindenBorderEnabled", false);
 	si.SetIntValue(CONFIG_SECTION, "SindenBorderMode", 0);
 	si.SetIntValue(CONFIG_SECTION, "SindenBorderThickness", 10);

--- a/pcsx2/DEV9/ACRAM.cpp
+++ b/pcsx2/DEV9/ACRAM.cpp
@@ -6,7 +6,7 @@
 #include <cstring>
 
 #include "Config.h"
-#define ACRAM_LOG(fmt, ...) if (EmuConfig.ArcadeRAMVerboseReads) Console.WriteLn(Color_Gray, "ACRAM:" fmt __VA_OPT__(,) __VA_ARGS__)
+#define ACRAM_LOG(fmt, ...) if (EmuConfig.ArcadeLogs.RAMVerboseReads) Console.WriteLn(Color_Gray, "ACRAM:" fmt __VA_OPT__(,) __VA_ARGS__)
 
 #define OOB_REPORT(T) Console.Error("%s: out of bound index: %08X", __FUNCTION__, T)
 #define GET_RAM_OFF(addr) (((addr) - ACRAM_ADDR_BASE) / 2) // u8 buffer on u16 MMIO, halve the address to get real offset

--- a/pcsx2/DEV9/ACRAM.cpp
+++ b/pcsx2/DEV9/ACRAM.cpp
@@ -3,8 +3,10 @@
 #include "ACRAM.h"
 #include "MemoryTypes.h"
 #include "IopMem.h"
-
 #include <cstring>
+
+#include "Config.h"
+#define ACRAM_LOG(fmt, ...) if (EmuConfig.ArcadeRAMVerboseReads) Console.WriteLn(Color_Gray, "ACRAM:" fmt __VA_OPT__(,) __VA_ARGS__)
 
 #define OOB_REPORT(T) Console.Error("%s: out of bound index: %08X", __FUNCTION__, T)
 #define GET_RAM_OFF(addr) (((addr) - ACRAM_ADDR_BASE) / 2) // u8 buffer on u16 MMIO, halve the address to get real offset
@@ -62,6 +64,7 @@ int ACRAM::BankFromDmaTarget(u32 dma_target) { // same bank select as Write16
 void ACRAM::DmaRead(u32* iop_buf, u32 size_bytes, int bank) {
     u32& addr = banks[bank].read_addr;
     addr &= (ACRAM_MAX_SIZE - 1);
+    ACRAM_LOG("DMARead  addr:%8X size:%8X bank:%d", addr, size_bytes, bank);
     if (addr + size_bytes <= ACRAM_MAX_SIZE) {
         std::memcpy(iop_buf, &iopMem->ACRAM[addr], size_bytes);
     } else {
@@ -75,6 +78,7 @@ void ACRAM::DmaRead(u32* iop_buf, u32 size_bytes, int bank) {
 void ACRAM::DmaWrite(u32* iop_buf, u32 size_bytes, int bank) {
     u32& addr = banks[bank].write_addr;
     addr &= (ACRAM_MAX_SIZE - 1);
+    ACRAM_LOG("DMAWrite addr:%8X size:%8X bank:%d", addr, size_bytes, bank);
     if (addr + size_bytes <= ACRAM_MAX_SIZE) {
         std::memcpy(&iopMem->ACRAM[addr], iop_buf, size_bytes);
     } else {

--- a/pcsx2/DEV9/ACRAM.cpp
+++ b/pcsx2/DEV9/ACRAM.cpp
@@ -6,7 +6,7 @@
 #include <cstring>
 
 #include "Config.h"
-#define ACRAM_LOG(fmt, ...) if (EmuConfig.ArcadeLogs.RAMVerboseReads) Console.WriteLn(Color_Gray, "ACRAM:" fmt __VA_OPT__(,) __VA_ARGS__)
+#define ACRAM_LOG(fmt, ...) if (EmuConfig.Arcade.RAMVerboseReads) Console.WriteLn(Color_Gray, "ACRAM:" fmt __VA_OPT__(,) __VA_ARGS__)
 
 #define OOB_REPORT(T) Console.Error("%s: out of bound index: %08X", __FUNCTION__, T)
 #define GET_RAM_OFF(addr) (((addr) - ACRAM_ADDR_BASE) / 2) // u8 buffer on u16 MMIO, halve the address to get real offset

--- a/pcsx2/DEV9/ACSRAM.cpp
+++ b/pcsx2/DEV9/ACSRAM.cpp
@@ -104,7 +104,6 @@ void ACSRAM::Write16(u32 addr, u16 val) {
     u32 T = GET_SRAM_OFF(addr);
     if (T < ACSRAM_MAX_SIZE) {
         ACSRAM_LOG("write16 [%04X]=%02X", T, val);
-        //Console.WriteLn(Color_StrongCyan, "%-16s %04X = %02X", __FUNCTION__, T, val);
         ACSRAM::buffer[T] = val;
     } else OOB_REPORT(T);
 }

--- a/pcsx2/DEV9/ACSRAM.cpp
+++ b/pcsx2/DEV9/ACSRAM.cpp
@@ -85,7 +85,7 @@ void ACSRAM::Clear(u8 fillerbyte) {
 u8 ACSRAM::Read8(u32 addr) {
     u32 T = GET_SRAM_OFF(addr);
     if (T < ACSRAM_MAX_SIZE) {
-        //Console.WriteLn(Color_StrongCyan, "%-16s %04X:  %02X", __FUNCTION__, T, ACSRAM::buffer[T]);
+        ACSRAM_LOG("read8  [%04X]:%02X", T, ACSRAM::buffer[T]);
         return ACSRAM::buffer[T];
     } else OOB_REPORT(T);
     return 0;
@@ -94,7 +94,7 @@ u8 ACSRAM::Read8(u32 addr) {
 u16 ACSRAM::Read16(u32 addr) {
     u32 T = GET_SRAM_OFF(addr);
     if (T < ACSRAM_MAX_SIZE) {
-        //Console.WriteLn(Color_StrongCyan, "%-16s %04X:  %02X", __FUNCTION__, T, ACSRAM::buffer[T]);
+        ACSRAM_LOG("read16 [%04X]:%02X", T, ACSRAM::buffer[T]);
         return ACSRAM::buffer[T];
     } else OOB_REPORT(T);
     return 0;
@@ -103,6 +103,7 @@ u16 ACSRAM::Read16(u32 addr) {
 void ACSRAM::Write16(u32 addr, u16 val) {
     u32 T = GET_SRAM_OFF(addr);
     if (T < ACSRAM_MAX_SIZE) {
+        ACSRAM_LOG("write16 [%04X]=%02X", T, val);
         //Console.WriteLn(Color_StrongCyan, "%-16s %04X = %02X", __FUNCTION__, T, val);
         ACSRAM::buffer[T] = val;
     } else OOB_REPORT(T);

--- a/pcsx2/DEV9/ACSRAM.h
+++ b/pcsx2/DEV9/ACSRAM.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "MemoryTypes.h"
+#include "Config.h"
 #include "common/Pcsx2Types.h"
 #include "common/Pcsx2Defs.h"
 #include <string>
@@ -8,6 +9,8 @@
 #define ACSRAM_ADDR_BASE 0x12500000
 #define ACSRAM_RANGE     0x1250
 #define ACSRAM_MAX_SIZE  _32kb // size of the SRAM
+
+#define ACSRAM_LOG(fmt, ...) if (EmuConfig.ArcadeSRAMVerboseReads) Console.WriteLn(Color_Gray, "SRAM:" fmt __VA_OPT__(,) __VA_ARGS__)
 
 namespace ACSRAM
 {

--- a/pcsx2/DEV9/ACSRAM.h
+++ b/pcsx2/DEV9/ACSRAM.h
@@ -10,7 +10,7 @@
 #define ACSRAM_RANGE     0x1250
 #define ACSRAM_MAX_SIZE  _32kb // size of the SRAM
 
-#define ACSRAM_LOG(fmt, ...) if (EmuConfig.ArcadeLogs.SRAMVerboseReads) Console.WriteLn(Color_Gray, "SRAM:" fmt __VA_OPT__(,) __VA_ARGS__)
+#define ACSRAM_LOG(fmt, ...) if (EmuConfig.Arcade.SRAMVerboseReads) Console.WriteLn(Color_Gray, "SRAM:" fmt __VA_OPT__(,) __VA_ARGS__)
 
 namespace ACSRAM
 {

--- a/pcsx2/DEV9/ACSRAM.h
+++ b/pcsx2/DEV9/ACSRAM.h
@@ -10,7 +10,7 @@
 #define ACSRAM_RANGE     0x1250
 #define ACSRAM_MAX_SIZE  _32kb // size of the SRAM
 
-#define ACSRAM_LOG(fmt, ...) if (EmuConfig.ArcadeSRAMVerboseReads) Console.WriteLn(Color_Gray, "SRAM:" fmt __VA_OPT__(,) __VA_ARGS__)
+#define ACSRAM_LOG(fmt, ...) if (EmuConfig.ArcadeLogs.SRAMVerboseReads) Console.WriteLn(Color_Gray, "SRAM:" fmt __VA_OPT__(,) __VA_ARGS__)
 
 namespace ACSRAM
 {

--- a/pcsx2/DEV9/ACUART.cpp
+++ b/pcsx2/DEV9/ACUART.cpp
@@ -1,9 +1,13 @@
+#include "Config.h"
 #include "ACUART.h"
 #include "ACJV.h"
 #include "ACCORE.h"
 #include "common/Console.h"
 #include <deque>
 #include <string>
+
+#define ACUART_LOG(fmt, ...) if (EmuConfig.Arcade.UARTVerbose) Console.WriteLn(Color_Gray, "ACUART:" fmt __VA_OPT__(,) __VA_ARGS__)
+#define ACUART_WARN(fmt, ...) if (EmuConfig.Arcade.UARTVerbose) Console.Warning("ACUART:" fmt __VA_OPT__(,) __VA_ARGS__)
 
 // 16550 UART register emulation for Namco System 246 arcade I/O
 // Ref: ps2sdk iop/arcade/acuart/src/uart.c
@@ -37,6 +41,7 @@ static constexpr u8 V257_STATUS[3] = {'C', '0', '1'}; // drive-board OK status; 
 
 u16 ACUART::Read16(u32 addr) {
 	const u32 reg = addr & 0xFFF;
+	ACUART_LOG("Read16  %03X", reg);
 	switch (reg) {
 	case 0x000: // RBR or DLL
 		if (uart_lcr & 0x80)
@@ -69,6 +74,7 @@ u16 ACUART::Read16(u32 addr) {
 	case 0x00E: // SCR
 		return uart_scr;
 	default:
+		ACUART_WARN("Unhandled read: %03X", reg);
 		return 0;
 	}
 }
@@ -101,12 +107,14 @@ static void Bg3HandleReply(u8 curTx)
 	}
 	s_v257RxFifo.push_back(hi); // byte0 = busy/ready status
 	s_v257RxFifo.push_back(0);  // byte1
+	ACUART_LOG("INTR");
 	ACCORE::intr(ACCORE::INTRN_UART);
 	s_bg3PrevTx = curTx;
 }
 
 void ACUART::Write16(u32 addr, u16 val) {
 	const u32 reg = addr & 0xFFF;
+	ACUART_LOG("Write16 %03X:%04X", reg, val);
 	switch (reg) {
 	case 0x000: // THR or DLL
 		if (uart_lcr & 0x80)
@@ -137,6 +145,7 @@ void ACUART::Write16(u32 addr, u16 val) {
 		uart_scr = val;
 		break;
 	default:
+		ACUART_WARN("Unhandled write:%03X:%04X", reg, val);
 		break;
 	}
 }
@@ -171,5 +180,6 @@ void ACUART::StreamV257(u32 cycles)
 	// Keep raising the RX IRQ every tick; reload the status only once the ISR has drained the previous copy.
 	if (s_v257RxFifo.empty())
 		s_v257RxFifo.assign(V257_STATUS, V257_STATUS + 3);
+	ACUART_LOG("INTR");
 	ACCORE::intr(ACCORE::INTRN_UART); // raise the UART RX interrupt
 }

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -4929,9 +4929,10 @@ void FullscreenUI::DrawAdvancedSettingsPage()
 			"Logging", "EnableIOPConsole", true);
 		DrawToggleSetting(
 			bsi, FSUI_ICONSTR(ICON_FA_COMPACT_DISC, "CDVD Verbose Reads"), FSUI_CSTR("Logs disc reads from games."), "EmuCore", "CdvdVerboseReads", false);
-		DrawToggleSetting( bsi, FSUI_ICONSTR(ICON_FA_MICROCHIP, "Arcade ATA Verbose Reads"), FSUI_CSTR("Logs Arcade ATA reads from games."), "Logging", "ArcadeATAVerboseReads", false);
-		DrawToggleSetting( bsi, FSUI_ICONSTR(ICON_FA_MICROCHIP, "Arcade SRAM Verbose Reads"), FSUI_CSTR("Logs Arcade SRAM reads/writes from games."), "Logging", "ArcadeSRAMVerboseReads", false);
-		DrawToggleSetting( bsi, FSUI_ICONSTR(ICON_FA_MICROCHIP, "Arcade RAM Verbose Reads"), FSUI_CSTR("Logs Arcade RAM transfers from games."), "Logging", "ArcadeRAMVerboseReads", false);
+		DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_MICROCHIP, "Arcade ATA Verbose Reads"), FSUI_CSTR("Logs Arcade ATA reads from games."), "Arcade", "ATAVerboseReads", false);
+		DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_MICROCHIP, "Arcade SRAM Verbose Reads"), FSUI_CSTR("Logs Arcade SRAM reads/writes from games."), "Arcade", "SRAMVerboseReads", false);
+		DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_MICROCHIP, "Arcade RAM Verbose Reads"), FSUI_CSTR("Logs Arcade RAM transfers from games."), "Arcade", "RAMVerboseReads", false);
+		DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_MICROCHIP, "Arcade UART Verbose Reads"), FSUI_CSTR("Logs TX/RX from the arcade UART"), "Arcade", "UARTVerbose", false);
 	}
 
 

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -4929,7 +4929,11 @@ void FullscreenUI::DrawAdvancedSettingsPage()
 			"Logging", "EnableIOPConsole", true);
 		DrawToggleSetting(
 			bsi, FSUI_ICONSTR(ICON_FA_COMPACT_DISC, "CDVD Verbose Reads"), FSUI_CSTR("Logs disc reads from games."), "EmuCore", "CdvdVerboseReads", false);
+		DrawToggleSetting( bsi, FSUI_ICONSTR(ICON_FA_MICROCHIP, "Arcade ATA Verbose Reads"), FSUI_CSTR("Logs Arcade ATA reads from games."), "Logging", "ArcadeATAVerboseReads", false);
+		DrawToggleSetting( bsi, FSUI_ICONSTR(ICON_FA_MICROCHIP, "Arcade SRAM Verbose Reads"), FSUI_CSTR("Logs Arcade SRAM reads/writes from games."), "Logging", "ArcadeSRAMVerboseReads", false);
+		DrawToggleSetting( bsi, FSUI_ICONSTR(ICON_FA_MICROCHIP, "Arcade RAM Verbose Reads"), FSUI_CSTR("Logs Arcade RAM transfers from games."), "Logging", "ArcadeRAMVerboseReads", false);
 	}
+
 
 	static constexpr const char* s_savestate_compression_type[] = {
 		FSUI_NSTR("Uncompressed"),

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -2026,9 +2026,6 @@ void Pcsx2Config::LoadSaveCore(SettingsWrapper& wrap)
 	SettingsWrapBitBool(ManuallySetRealTimeClock);
 	SettingsWrapBitBool(UseSystemLocaleFormat);
 
-	SettingsWrapBitBool(ArcadeATAVerboseReads);
-	SettingsWrapBitBool(ArcadeSRAMVerboseReads);
-	SettingsWrapBitBool(ArcadeRAMVerboseReads);
 
 	// Process various sub-components:
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -2028,6 +2028,7 @@ void Pcsx2Config::LoadSaveCore(SettingsWrapper& wrap)
 
 	SettingsWrapBitBool(ArcadeATAVerboseReads);
 	SettingsWrapBitBool(ArcadeSRAMVerboseReads);
+	SettingsWrapBitBool(ArcadeRAMVerboseReads);
 
 	// Process various sub-components:
 

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -2026,6 +2026,9 @@ void Pcsx2Config::LoadSaveCore(SettingsWrapper& wrap)
 	SettingsWrapBitBool(ManuallySetRealTimeClock);
 	SettingsWrapBitBool(UseSystemLocaleFormat);
 
+	SettingsWrapBitBool(ArcadeATAVerboseReads);
+	SettingsWrapBitBool(ArcadeSRAMVerboseReads);
+
 	// Process various sub-components:
 
 	Speedhacks.LoadSave(wrap);

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -2034,6 +2034,7 @@ void Pcsx2Config::LoadSaveCore(SettingsWrapper& wrap)
 	GS.LoadSave(wrap);
 	SPU2.LoadSave(wrap);
 	DEV9.LoadSave(wrap);
+	Arcade.LoadSave(wrap);
 	Gamefixes.LoadSave(wrap);
 	Profiler.LoadSave(wrap);
 	Savestate.LoadSave(wrap);
@@ -2413,4 +2414,27 @@ std::string EmuFolders::GetOverridableResourcePath(std::string_view name)
 	}
 
 	return upath;
+}
+
+
+void Pcsx2Config::ArcadeOptions::LoadSave(SettingsWrapper& wrap)
+{
+	{
+		SettingsWrapSection("Arcade");
+		SettingsWrapEntry(ATAVerboseReads);
+		SettingsWrapEntry(RAMVerboseReads);
+		SettingsWrapEntry(ATAVerboseReads);
+	}
+}
+
+bool Pcsx2Config::ArcadeOptions::operator!=(const ArcadeOptions& right) const
+{
+	return !this->operator==(right);
+}
+
+bool Pcsx2Config::ArcadeOptions::operator==(const ArcadeOptions& right) const
+{
+	return OpEqu(ATAVerboseReads) &&
+		   OpEqu(RAMVerboseReads) &&
+		   OpEqu(ATAVerboseReads);
 }

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -2423,7 +2423,8 @@ void Pcsx2Config::ArcadeOptions::LoadSave(SettingsWrapper& wrap)
 		SettingsWrapSection("Arcade");
 		SettingsWrapEntry(ATAVerboseReads);
 		SettingsWrapEntry(RAMVerboseReads);
-		SettingsWrapEntry(ATAVerboseReads);
+		SettingsWrapEntry(SRAMVerboseReads);
+		SettingsWrapEntry(UARTVerbose);
 	}
 }
 
@@ -2436,5 +2437,6 @@ bool Pcsx2Config::ArcadeOptions::operator==(const ArcadeOptions& right) const
 {
 	return OpEqu(ATAVerboseReads) &&
 		   OpEqu(RAMVerboseReads) &&
-		   OpEqu(ATAVerboseReads);
+		   OpEqu(UARTVerbose) &&
+		   OpEqu(SRAMVerboseReads);
 }

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -529,6 +529,11 @@ void VMManager::UpdateLoggingSettings(SettingsInterface& si)
 	TraceLogging.IOP.Memory.Enabled = true;
 	TraceLogging.SIF.Enabled = true;
 
+
+	EmuConfig.ArcadeLogs.ATAVerboseReads  = si.GetBoolValue("Logging", "ArcadeATAVerboseReads", false);
+	EmuConfig.ArcadeLogs.SRAMVerboseReads = si.GetBoolValue("Logging", "ArcadeSRAMVerboseReads", false);
+	EmuConfig.ArcadeLogs.RAMVerboseReads  = si.GetBoolValue("Logging", "ArcadeRAMVerboseReads", false);
+
 	// Input Recording Logs
 	ConsoleLogging.recordingConsole.Enabled = any_logging_sinks && si.GetBoolValue("Logging", "EnableInputRecordingLogs", true);
 	ConsoleLogging.controlInfo.Enabled = any_logging_sinks && si.GetBoolValue("Logging", "EnableControllerLogs", false);
@@ -554,6 +559,10 @@ void VMManager::SetDefaultLoggingSettings(SettingsInterface& si)
 	si.SetBoolValue("Logging", "EnableIOPConsole", false);
 	si.SetBoolValue("Logging", "EnableInputRecordingLogs", true);
 	si.SetBoolValue("Logging", "EnableControllerLogs", false);
+	
+	si.SetBoolValue("Logging", "ArcadeATAVerboseReads", false);
+	si.SetBoolValue("Logging", "ArcadeSRAMVerboseReads", false);
+	si.SetBoolValue("Logging", "ArcadeRAMVerboseReads", false);
 
 	EmuConfig.Trace.Enabled = false;
 	EmuConfig.Trace.EE.bitset = 0;

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -530,10 +530,6 @@ void VMManager::UpdateLoggingSettings(SettingsInterface& si)
 	TraceLogging.SIF.Enabled = true;
 
 
-	EmuConfig.ArcadeLogs.ATAVerboseReads  = si.GetBoolValue("Logging", "ArcadeATAVerboseReads", false);
-	EmuConfig.ArcadeLogs.SRAMVerboseReads = si.GetBoolValue("Logging", "ArcadeSRAMVerboseReads", false);
-	EmuConfig.ArcadeLogs.RAMVerboseReads  = si.GetBoolValue("Logging", "ArcadeRAMVerboseReads", false);
-
 	// Input Recording Logs
 	ConsoleLogging.recordingConsole.Enabled = any_logging_sinks && si.GetBoolValue("Logging", "EnableInputRecordingLogs", true);
 	ConsoleLogging.controlInfo.Enabled = any_logging_sinks && si.GetBoolValue("Logging", "EnableControllerLogs", false);
@@ -560,9 +556,9 @@ void VMManager::SetDefaultLoggingSettings(SettingsInterface& si)
 	si.SetBoolValue("Logging", "EnableInputRecordingLogs", true);
 	si.SetBoolValue("Logging", "EnableControllerLogs", false);
 	
-	si.SetBoolValue("Logging", "ArcadeATAVerboseReads", false);
-	si.SetBoolValue("Logging", "ArcadeSRAMVerboseReads", false);
-	si.SetBoolValue("Logging", "ArcadeRAMVerboseReads", false);
+	si.SetBoolValue("Arcade", "ATAVerboseReads", false);
+	si.SetBoolValue("Arcade", "SRAMVerboseReads", false);
+	si.SetBoolValue("Arcade", "RAMVerboseReads", false);
 
 	EmuConfig.Trace.Enabled = false;
 	EmuConfig.Trace.EE.bitset = 0;

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -559,6 +559,7 @@ void VMManager::SetDefaultLoggingSettings(SettingsInterface& si)
 	si.SetBoolValue("Arcade", "ATAVerboseReads", false);
 	si.SetBoolValue("Arcade", "SRAMVerboseReads", false);
 	si.SetBoolValue("Arcade", "RAMVerboseReads", false);
+	si.SetBoolValue("Arcade", "UARTVerbose", false);
 
 	EmuConfig.Trace.Enabled = false;
 	EmuConfig.Trace.EE.bitset = 0;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
two new options on the debug tab to log relevant ACATA/ACATAPI commands, as well as r/w to the SRAM

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
in case we need more info for debugging/troubleshooting. and the SRAM change more like an utility for modders

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
enable the checkboxes and see if it does not explode

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation as to how you used it. Please see the Large Language Model (LLM) Usage Policy for more information: https://pcsx2.net/docs/contributing/#large-language-model-llm-usage-policy -->

### Related GameIDs
> IF your PR aims to deal with issues/features specific to specific games, please list the related gameIDs (eg: `NM00007`)