### PR TITLE
system256 iLinkID override for asian games

### DIFF
--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -2620,8 +2620,9 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 				break;
 
 			case 0x13: // sceCdWriteILinkID (8:1)
+				Console.Warning("INVESTIGATE: sceCdWriteILinkID called");
 				SetSCMDResultSize(1);
-				cdvdWriteILinkID(&cdvd.SCMDParamBuff[1]);
+				cdvdWriteILinkID(&cdvd.SCMDParamBuff[0]);
 				break;
 
 			case 0x14: // CdCtrlAudioDigitalOut (1:1)

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -2595,6 +2595,16 @@ static void cdvdWrite16(u8 rt) // SCOMMAND
 			case 0x12: // sceCdReadILinkId (0:9)
 				SetSCMDResultSize(9);
 				cdvdReadILinkID(&cdvd.SCMDResultBuff[1]);
+				extern std::string ArcadeiLinkID;
+				if (!ArcadeiLinkID.empty()) {
+					constexpr u8 s256Region_ASIA4[8] = {0x32, 0x1F, 0xC7, 0xFA, 0xD6, 0xEE, 0xF0, 0x1C};
+					constexpr u8 s256Region_ASIA5[8] = {0x41, 0x46, 0x53, 0x2F, 0x1E, 0xFD, 0x0F, 0xE0};
+					constexpr u8 s256Region_JAPAN[8] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+					if (ArcadeiLinkID == "ASIA4") std::memcpy(cdvd.SCMDResultBuff, s256Region_ASIA4, 8);
+					else if (ArcadeiLinkID == "ASIA5") std::memcpy(cdvd.SCMDResultBuff, s256Region_ASIA5, 8);
+					else if (ArcadeiLinkID == "JAPAN") std::memcpy(cdvd.SCMDResultBuff, s256Region_JAPAN, 8);
+					break;
+				}
 				if ((!cdvd.SCMDResultBuff[3]) && (!cdvd.SCMDResultBuff[4])) // nvm file is missing correct iLinkId, return hardcoded one
 				{
 					cdvd.SCMDResultBuff[0] = 0x00;

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -192,6 +192,7 @@ static bool s_elf_executed = false;
 static std::string s_elf_override;
 static std::string s_acgame;
 static std::string s_acgame_serial;
+std::string ArcadeiLinkID;
 static std::string s_input_profile_name;
 static u32 s_frame_advance_count = 0;
 static bool s_fast_boot_requested = false;
@@ -1350,6 +1351,12 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				std::string s_acmedia, s_imgname, s_serial;
 				s_acmedia = INI.GetStringValue("data", "media");
 				s_imgname = INI.GetStringValue("data", "mediasrc");
+				ArcadeiLinkID = INI.GetStringValue("data", "256Region", "");
+				if (!ArcadeiLinkID.empty() &&
+					(ArcadeiLinkID == "ASIA4" || ArcadeiLinkID == "ASIA5" || ArcadeiLinkID == "JAPAN")) {
+					Error::SetStringFmt(error, "Invalid SYSTEM256 regional signature override! '{}'", ArcadeiLinkID);
+					return false;
+				} else Console.WriteLnFmt(Color_Green, "system256 Region: changing iLinkID to {}", ArcadeiLinkID);
 				s_title = s_serial = INI.GetStringValue("game", "name");
 				s_arcade_gameid = s_disc_serial = s_serial = INI.GetStringValue("game", "gameid");
 				s_acgame_serial = s_serial;
@@ -1874,6 +1881,7 @@ void VMManager::Shutdown(bool save_resume_state)
 	s_elf_override = {};
 	s_acgame = {};
 	s_acgame_serial = {};
+	ArcadeiLinkID = {};
 	PS2CLK = PS2CLK_DEFAULT;
 	PSXCLK = 36864000;
 	s_sys256_mode = false;


### PR DESCRIPTION
### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
this feature allows user to define a specific signature to trick to the game, that way, asian games work regardless of what the nvram file contents

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->

### Did you use AI to help find, test, or implement this issue or feature?
<!-- Answer yes or no. If you answer yes, please provide a brief explanation as to how you used it. Please see the Large Language Model (LLM) Usage Policy for more information: https://pcsx2.net/docs/contributing/#large-language-model-llm-usage-policy -->

### Related GameIDs
> IF your PR aims to deal with issues/features specific to specific games, please list the related gameIDs
NM00046, NM00054, NM00053