### PR TITLE
Arcade: consistent per-game settings and patches with unique gameID

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -312,12 +312,16 @@ NM00045:
   bootprog: TEALOAD
   media: DVD
   input: drum
+  gsHWFixes:
+    alignSprite: 1
 NM00046:
   name: Taiko Drum Master 11 - Asian Edition
   region: System256
   bootprog: TEBLOAD
   media: DVD
   input: drum
+  gsHWFixes:
+    alignSprite: 1
 NM00047:
   name: Ace Driver 3 - Final Turn
   region: System256
@@ -350,12 +354,16 @@ NM00053:
   bootprog: TECLOAD
   media: HDD
   input: drum
+  gsHWFixes:
+    alignSprite: 1
 NM00054:
   name: Taiko Drum Master 12 - Asian Edition
   region: System256
   bootprog: TEDLOAD
   media: HDD
   input: drum
+  gsHWFixes:
+    alignSprite: 1
 NM00056:
   name: Taiko Drum Master 13
   region: System256

--- a/pcsx2-qt/GameList/GameListWidget.cpp
+++ b/pcsx2-qt/GameList/GameListWidget.cpp
@@ -245,6 +245,7 @@ void GameListWidget::initialize()
 	connect(m_ui.filterType, &QComboBox::currentIndexChanged, this, [this](int index) {
 		m_sort_model->setFilterType((index == 0) ? GameList::EntryType::Count : static_cast<GameList::EntryType>(index - 1));
 	});
+	m_ui.filterType->setCurrentIndex(static_cast<int>(GameList::EntryType::ARCADE) + 1); // default to Arcade (index 0 = All Types)
 	connect(m_ui.filterRegion, &QComboBox::currentIndexChanged, this, [this](int index) {
 		m_sort_model->setFilterRegion((index == 0) ? GameList::Region::Count : static_cast<GameList::Region>(index - 1));
 	});

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -2977,24 +2977,17 @@ void MainWindow::doGameSettings(const char* category)
 		}
 	}
 
-	// open properties for the current running file (isn't in the game list)
-	if (s_current_disc_crc == 0)
+	// open properties for the current running file (isn't in the game list).
+	// Arcade has an elf override (proverb.elf) but a valid serial (NMxxxxx) at crc 0, so key by it.
+	if (s_current_disc_crc == 0 && s_current_disc_serial.isEmpty())
 	{
 		QMessageBox::critical(this, tr("Game Properties"), tr("Game properties is unavailable for the current game."));
 		return;
 	}
 
-	// can't use serial for ELFs, because they might have a disc set
-	if (s_current_elf_override.isEmpty())
-	{
-		SettingsWindow::openGamePropertiesDialog(
-			nullptr, s_current_title.toStdString(), s_current_disc_serial.toStdString(), s_current_disc_crc, false, category);
-	}
-	else
-	{
-		SettingsWindow::openGamePropertiesDialog(
-			nullptr, s_current_title.toStdString(), std::string(), s_current_disc_crc, true, category);
-	}
+	SettingsWindow::openGamePropertiesDialog(
+		nullptr, s_current_title.toStdString(), s_current_disc_serial.toStdString(), s_current_disc_crc,
+		!s_current_elf_override.isEmpty() && s_current_disc_serial.isEmpty(), category);
 }
 
 void MainWindow::openDebugger()

--- a/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/GamePatchSettingsWidget.cpp
@@ -174,9 +174,9 @@ void GamePatchSettingsWidget::reloadList()
 				{
 					check_state = Qt::CheckState::Checked;
 				}
-				else
+				else // WS/NI follow the global toggle (partial); other arcade patches default on
 				{
-					check_state = Qt::CheckState::PartiallyChecked;
+					check_state = Patch::IsGlobalSettingPatch(pi) ? Qt::CheckState::PartiallyChecked : Qt::CheckState::Checked;
 				}
 			}
 

--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -102,6 +102,7 @@ const char* GameList::EntryTypeToString(EntryType type, bool translate)
 		TRANSLATE_NOOP("GameList", "PS2 Disc"),
 		TRANSLATE_NOOP("GameList", "PS1 Disc"),
 		TRANSLATE_NOOP("GameList", "ELF"),
+		TRANSLATE_NOOP("GameList", "Arcade"),
 		TRANSLATE_NOOP("GameList", "Invalid"),
 	};
 
@@ -234,8 +235,8 @@ const char* GameList::EntryCompatibilityRatingToString(CompatibilityRating ratin
 
 bool GameList::IsScannableFilename(const std::string_view path)
 {
-	return // VMManager::IsDiscFileName(path) || 
-		VMManager::IsElfFileName(path) || 
+	return // VMManager::IsDiscFileName(path) ||
+		VMManager::IsElfFileName(path) ||
 		VMManager::isArcadeManifest(path);
 }
 

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -325,7 +325,9 @@ std::string Patch::GetPnachTemplate(const std::string_view serial, u32 crc, bool
 		if (all_crcs)
 			return fmt::format("{}_*.pnach", serial);
 		else if (include_serial)
-			return fmt::format("{}_{:08X}{}.pnach", serial, crc, add_wildcard ? "*" : "");
+			return crc == 0 // arcade: the gameid is the identity, crc is always 0 -> drop the suffix
+				? fmt::format("{}{}.pnach", serial, add_wildcard ? "*" : "")
+				: fmt::format("{}_{:08X}{}.pnach", serial, crc, add_wildcard ? "*" : "");
 	}
 	return fmt::format("{:08X}{}.pnach", crc, add_wildcard ? "*" : "");
 }
@@ -608,6 +610,18 @@ void Patch::ReloadEnabledLists()
 				[](const std::string& it) { return (it == NI_PATCH_NAME); }))
 		{
 			s_enabled_patches.emplace_back(NI_PATCH_NAME);
+		}
+	}
+
+	// arcade: labeled game patches are on by default (uncheck disables via the disabled list below)
+	for (const PatchGroup& group : s_game_patches)
+	{
+		if (group.name.empty() || group.name == WS_PATCH_NAME || group.name == NI_PATCH_NAME)
+			continue;
+		if (std::none_of(s_enabled_patches.begin(), s_enabled_patches.end(),
+				[&group](const std::string& it) { return (it == group.name); }))
+		{
+			s_enabled_patches.emplace_back(group.name);
 		}
 	}
 
@@ -1182,6 +1196,11 @@ u32 Patch::GetAllActivePatchesCount()
 }
 
 bool Patch::IsGloballyToggleablePatch(const PatchInfo& patch_info)
+{
+	return !patch_info.name.empty(); // arcade: every labeled patch is individually toggleable
+}
+
+bool Patch::IsGlobalSettingPatch(const PatchInfo& patch_info)
 {
 	return patch_info.name == WS_PATCH_NAME || patch_info.name == NI_PATCH_NAME;
 }

--- a/pcsx2/Patch.h
+++ b/pcsx2/Patch.h
@@ -197,6 +197,7 @@ namespace Patch
 	extern u32 GetAllActivePatchesCount();
 
 	extern bool IsGloballyToggleablePatch(const PatchInfo& patch_info);
+	extern bool IsGlobalSettingPatch(const PatchInfo& patch_info); // WS/NI: default follows a global toggle
 
 	extern const char* PlaceToString(std::optional<patch_place_type> place);
 } // namespace Patch

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1016,11 +1016,11 @@ std::string VMManager::GetSerialForGameSettings()
 bool VMManager::UpdateGameSettingsLayer()
 {
 	std::unique_ptr<INISettingsInterface> new_interface;
-	if (s_disc_crc != 0)
+	if (s_disc_crc != 0 || !s_acgame.empty()) // arcade: crc 0, keyed by the .acgame gameid
 	{
 		const std::string game_serial = GetSerialForGameSettings();
 		std::string filename(GetGameSettingsPath(game_serial, s_disc_crc));
-		if (!FileSystem::FileExists(filename.c_str()))
+		if (!FileSystem::FileExists(filename.c_str()) && s_acgame.empty()) // arcade: only {gameid}_0, no shared crc-only fallback
 		{
 			if (!game_serial.empty())
 				filename = GetGameSettingsPath(game_serial, 0);
@@ -1138,6 +1138,10 @@ void VMManager::UpdateDiscDetails(bool booting)
 		// If we're booting an ELF, use its CRC, not the disc (if any).
 		if (!s_elf_override.empty())
 			s_disc_crc = cdvdGetElfCRC(s_elf_override);
+
+		// Arcade identity is crc 0 for every media (CD/DVD/HDD); the .acgame gameid is the serial.
+		if (!s_acgame.empty())
+			s_disc_crc = 0;
 
 		if (!booting && s_disc_serial == old_serial && s_disc_crc == old_crc)
 		{
@@ -1268,7 +1272,7 @@ void VMManager::UpdateELFInfo(std::string elf_path)
 	}
 
 	elfo.LoadHeaders();
-	s_current_crc = elfo.GetCRC();
+	s_current_crc = s_acgame.empty() ? elfo.GetCRC() : 0; // arcade: identity is the .acgame (crc 0), proverb.elf or boot.elf alike
 	s_elf_entry_point = elfo.GetEntryPoint();
 	s_elf_text_range = elfo.GetTextRange();
 	s_elf_path = std::move(elf_path);


### PR DESCRIPTION
Makes arcade game identity uniform across .acgame files, plus a few arcade-only conveniences.

- Uniform `{GameID}` identity on all medias (CRC forced to 0, becoming useless for now). Per-game settings and patches now resolve (patches will always work with gameid). Simplicity above all.
  - With [installed patches.zip](https://github.com/ps2homebrew-arcade/pcsx2x6_patches), promote the following games to PLAYABLE:
    - NM00045 | Taiko Drum Master 11 - Taiwan Edition
    - NM00046 | Taiko Drum Master 11 - Asian Edition
    - NM00053 | Taiko Drum Master 12 - Taiwan Edition
    - NM00054 | Taiko Drum Master 12 - Asian Edition
- Labeled game patches are **on** by default, each individually toggleable with a simple checkbox
- Gamelists all, Arcade selected by default which only shows `.acgame` files, typed as "Arcade" (was "Invalid")
  - Hiding bloating files like Proverb.elf and boot.elf from the list by default if user has not set a clean folder
- Game Properties opens for the running arcade game and keeps the same gameid as on main interface

Bonus fix:
- Add `alignSprite` game fix along other Taiko games.

TO DO:
- Add revision for some games of the same gameID like RRV (and add widescreen patches).