### PR TITLE
JVS: fix crosshair stuck at center after aim relative rebinds

### DIFF
--- a/pcsx2-qt/Settings/JVSControlsWidget.cpp
+++ b/pcsx2-qt/Settings/JVSControlsWidget.cpp
@@ -650,23 +650,28 @@ void JVSControlsWidget::buildLightgunPage()
 			if (dev.isEmpty())
 				return;
 			m_dialog->setStringValue(section, "guncon2_Pointer", dev.toUtf8().constData());
-			// A controller -> auto-fill this player's Relative Aim from its left stick. Mouse needs nothing.
+			InputManager::GenericInputBindingMapping mapping; // stays empty for Mouse -> clears the stick binds below
 			if (!dev.startsWith(QStringLiteral("Pointer-")))
+				mapping = InputManager::GetGenericBindingMapping(dev.toStdString());
+			static constexpr std::pair<const char*, GenericInputBinding> axes[] = {
+				{"RelativeLeft", GenericInputBinding::LeftStickLeft},
+				{"RelativeRight", GenericInputBinding::LeftStickRight},
+				{"RelativeUp", GenericInputBinding::LeftStickUp},
+				{"RelativeDown", GenericInputBinding::LeftStickDown}};
+			for (const auto& [key, gen] : axes)
 			{
-				const auto mapping = InputManager::GetGenericBindingMapping(dev.toStdString());
-				const auto host = [&](GenericInputBinding g) -> std::string {
-					for (const auto& [gg, h] : mapping)
-						if (gg == g)
-							return h;
-					return std::string();
-				};
-				m_dialog->setStringValue(section, USB::GetConfigSubKey("guncon2", "RelativeLeft").c_str(),  host(GenericInputBinding::LeftStickLeft).c_str());
-				m_dialog->setStringValue(section, USB::GetConfigSubKey("guncon2", "RelativeRight").c_str(), host(GenericInputBinding::LeftStickRight).c_str());
-				m_dialog->setStringValue(section, USB::GetConfigSubKey("guncon2", "RelativeUp").c_str(),    host(GenericInputBinding::LeftStickUp).c_str());
-				m_dialog->setStringValue(section, USB::GetConfigSubKey("guncon2", "RelativeDown").c_str(),  host(GenericInputBinding::LeftStickDown).c_str());
-				for (InputBindingWidget* w : findChildren<InputBindingWidget*>())
-					w->reloadBinding();
+				std::string host;
+				for (const auto& [gg, h] : mapping)
+					if (gg == gen)
+						host = h;
+				const std::string k = USB::GetConfigSubKey("guncon2", key);
+				if (host.empty())
+					m_dialog->clearSettingValue(section, k.c_str());
+				else
+					m_dialog->setStringValue(section, k.c_str(), host.c_str());
 			}
+			for (InputBindingWidget* w : findChildren<InputBindingWidget*>())
+				w->reloadBinding();
 			g_emu_thread->applySettings(); // re-read so the GunCon2 picks up the new aim source
 		});
 		ag->addWidget(combo, 1, col, Qt::AlignLeft);

--- a/pcsx2/USB/usb-lightgun/guncon2.cpp
+++ b/pcsx2/USB/usb-lightgun/guncon2.cpp
@@ -541,10 +541,10 @@ namespace usb_lightgun
 
 		const s32 prev_pointer_index = s->GetSoftwarePointerIndex();
 
-		s->has_relative_binds = (USB::ConfigKeyExists(si, s->port, TypeName(), "RelativeLeft") ||
-			USB::ConfigKeyExists(si, s->port, TypeName(), "RelativeRight") ||
-			USB::ConfigKeyExists(si, s->port, TypeName(), "RelativeUp") ||
-			USB::ConfigKeyExists(si, s->port, TypeName(), "RelativeDown"));
+		s->has_relative_binds = (!USB::GetConfigString(si, s->port, TypeName(), "RelativeLeft").empty() ||
+			!USB::GetConfigString(si, s->port, TypeName(), "RelativeRight").empty() ||
+			!USB::GetConfigString(si, s->port, TypeName(), "RelativeUp").empty() ||
+			!USB::GetConfigString(si, s->port, TypeName(), "RelativeDown").empty()); // empty/cleared binds must not latch relative aim
 
 		// Arcade aim goes through ACJV; the Aim Device is either the mouse (Pointer-N) or a controller stick.
 		const bool joystick_aim = !pointer_binding.empty() && !StringUtil::StartsWithNoCase(pointer_binding, "Pointer-");
@@ -562,10 +562,13 @@ namespace usb_lightgun
 
 		if (cursor_changed)
 		{
-			// Only clear a gun's own dedicated slot; slot 0 is the shared mouse pointer (another player/gun
-			// may be aiming with it), so switching this gun off it must not yank slot 0 out from under them.
-			if (prev_pointer_index != new_pointer_index && prev_pointer_index >= static_cast<s32>(InputManager::MAX_POINTER_DEVICES))
-				ImGuiManager::ClearSoftwareCursor(prev_pointer_index);
+			const u32 other_port = s->port ^ 1u;
+			const bool other_aims_mouse = USB::GetConfigDevice(si, other_port) == TypeName() &&
+				StringUtil::StartsWithNoCase(USB::GetConfigString(si, other_port, TypeName(), "Pointer"), "Pointer-") &&
+				!USB::GetConfigString(si, other_port, TypeName(), "cursor_path").empty();
+			if (prev_pointer_index != new_pointer_index &&
+				(prev_pointer_index >= static_cast<s32>(InputManager::MAX_POINTER_DEVICES) || !other_aims_mouse))
+				ImGuiManager::ClearSoftwareCursor(prev_pointer_index); // shared slot 0: keep only while the other gun aims with it
 
 			const bool had_software_cursor = !s->cursor_path.empty();
 


### PR DESCRIPTION
Fixes #104: clearing `Relative Aim` bindings now actually returns aim to the mouse (not only `Clear mapping` button). Switching aim device (pointer) no longer leaves a stuck crosshair on screen.