### PR TITLE
CI: rebrand the Linux AppImage desktop identity to PCSX2x6

### DIFF
--- a/.github/workflows/scripts/linux/appimage-qt.sh
+++ b/.github/workflows/scripts/linux/appimage-qt.sh
@@ -99,8 +99,8 @@ for i in $(find "$DEPSDIR" -iname '*.so'); do
 done
 
 echo "Copying desktop file..."
-cp "$PCSX2DIR/.github/workflows/scripts/linux/pcsx2-qt.desktop" "net.pcsx2.PCSX2.desktop"
-cp "$PCSX2DIR/bin/resources/icons/AppIconLarge.png" "PCSX2.png"
+cp "$PCSX2DIR/.github/workflows/scripts/linux/pcsx2-qt.desktop" "io.github.PS2Homebrew_arcade.PCSX2x6.desktop"
+cp "$PCSX2DIR/bin/resources/icons/AppIconLarge.png" "PCSX2x6.png"
 
 echo "Running linuxdeploy to create AppDir..."
 # The wayland platform plugin requires the plugins deployed for the waylandcompositor module
@@ -112,7 +112,7 @@ DEPLOY_PLATFORM_THEMES="1" \
 QMAKE="$DEPSDIR/bin/qmake" \
 NO_STRIP="1" \
 $LINUXDEPLOY --plugin qt --appdir="$OUTDIR" --executable="$BUILDDIR/bin/pcsx2-qt" ${EXTRA_LIBS_ARGS[@]} \
---desktop-file="net.pcsx2.PCSX2.desktop" --icon-file="PCSX2.png"
+--desktop-file="io.github.PS2Homebrew_arcade.PCSX2x6.desktop" --icon-file="PCSX2x6.png"
 
 echo "Copying resources into AppDir..."
 cp -a "$BUILDDIR/bin/resources" "$OUTDIR/usr/bin"
@@ -128,7 +128,7 @@ cp -a "$BUILDDIR/bin/translations" "$OUTDIR/usr/bin"
 # Generate AppStream meta-info.
 echo "Generating AppStream metainfo..."
 mkdir -p "$OUTDIR/usr/share/metainfo"
-"$SCRIPTDIR/generate-metainfo.sh" "$OUTDIR/usr/share/metainfo/net.pcsx2.PCSX2.appdata.xml"
+"$SCRIPTDIR/generate-metainfo.sh" "$OUTDIR/usr/share/metainfo/io.github.PS2Homebrew_arcade.PCSX2x6.appdata.xml"
 
 echo "Generating AppImage..."
 GIT_VERSION=$(git tag --points-at HEAD)

--- a/.github/workflows/scripts/linux/pcsx2-qt.desktop
+++ b/.github/workflows/scripts/linux/pcsx2-qt.desktop
@@ -2,11 +2,11 @@
 Version=1.0
 Terminal=false
 Type=Application
-Name=PCSX2
-StartupWMClass=PCSX2
-GenericName=PlayStation 2 Emulator
-Comment=Sony PlayStation 2 emulator
+Name=PCSX2x6
+StartupWMClass=pcsx2-qt
+GenericName=Arcade PlayStation 2 Emulator
+Comment=PCSX2 fork emulating Namco System 246/256 arcade hardware
 Exec=pcsx2-qt
-Icon=PCSX2
-Keywords=game;emulator;
+Icon=PCSX2x6
+Keywords=game;emulator;arcade;
 Categories=Game;Emulator;

--- a/.github/workflows/scripts/linux/pcsx2-qt.metainfo.xml.in
+++ b/.github/workflows/scripts/linux/pcsx2-qt.metainfo.xml.in
@@ -5,30 +5,26 @@
   <launchable type="desktop-id">io.github.PS2Homebrew_arcade.PCSX2x6.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0+</project_license>
-  <name>PCSX2</name>
+  <name>PCSX2x6</name>
   <developer id="io.github.PS2Homebrew_arcade">
-    <name>PCSX2 Team</name>
+    <name>PS2Homebrew-arcade</name>
   </developer>
-  <summary>PlayStation 2 emulator</summary>
+  <summary>Arcade PlayStation 2 emulator (Namco System 246/256)</summary>
   <description>
-    <p>PCSX2 is a free and open-source PlayStation 2 (PS2) emulator. Its purpose is to emulate the PS2's hardware, using a combination of MIPS CPU Interpreters, Recompilers, and a Virtual Machine which manages hardware states and PS2 system memory. This allows you to play PS2 games on your PC, with many additional features and benefits.</p>
-    <p>PlayStation 2 and PS2 are registered trademarks of Sony Interactive Entertainment. This application is not affiliated in any way with Sony Interactive Entertainment.</p>
+    <p>PCSX2x6 is a free and open-source PCSX2 fork dedicated to the Namco System 246 and 256, the PlayStation 2 based arcade hardware. It emulates the arcade-specific boards (JVS I/O, security dongles, ATA media) on top of PCSX2's PS2 core so the arcade titles can run on your PC.</p>
+    <p>PlayStation 2 and PS2 are registered trademarks of Sony Interactive Entertainment. This application is not affiliated in any way with Sony Interactive Entertainment or Namco.</p>
   </description>
-  <url type="homepage">https://pcsx2.net/</url>
+  <url type="homepage">https://ps2homebrew-arcade.github.io/pcsx2x6/</url>
   <url type="vcs-browser">https://github.com/PS2Homebrew-arcade/pcsx2x6</url>
   <url type="bugtracker">https://github.com/PS2Homebrew-arcade/pcsx2x6/issues</url>
-  <url type="faq">https://pcsx2.net/docs/</url>
-  <url type="help">https://pcsx2.net/discord</url>
-  <url type="contribute">https://pcsx2.net/docs/category/contributing</url>
-  <url type="translate">https://crowdin.com/project/pcsx2-emulator</url>
-  <url type="contact">https://mastodon.social/@PCSX2</url>
+  <url type="contribute">https://github.com/PS2Homebrew-arcade/pcsx2x6</url>
   <screenshots>
     <screenshot type="default">
       <image>
         https://raw.githubusercontent.com/PS2Homebrew-arcade/pcsx2x6/master/.github/workflows/scripts/linux/flatpak/screenshots/screenshot1.png
       </image>
       <caption>
-        The main PCSX2 Qt interface
+        The main PCSX2x6 Qt interface
       </caption>
     </screenshot>
     <screenshot>
@@ -36,7 +32,7 @@
         https://raw.githubusercontent.com/PS2Homebrew-arcade/pcsx2x6/master/.github/workflows/scripts/linux/flatpak/screenshots/screenshot2.png
       </image>
       <caption>
-        PCSX2 running a game
+        PCSX2x6 running a game
       </caption>
     </screenshot>
   </screenshots>
@@ -61,7 +57,6 @@
     <display_length compare="ge">768</display_length>
   </requires>
   <content_rating type="oars-1.1"/>
-  <update_contact>pcsx2_AT_pcsx2.net</update_contact>
   <releases>
     <release version="@GIT_VERSION@" date="@GIT_DATE@" />
   </releases>


### PR DESCRIPTION
Fixes #82: the Linux AppImage now ships its own desktop identity instead of mainline PCSX2's, so both can be installed side by side.