### PR TITLE
JVS: add Quiz Suku Suku Inufuku 2 (NM00037) standard layout

### DIFF
--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -419,6 +419,7 @@ static const std::map<std::string, StandardLayout> s_standard_layouts = {
 	{"NM00006", StandardLayout::SMASHCOURT},  // Smash Court Pro Tournament
 	{"NM10003", StandardLayout::TECHNICBEAT}, // Technic Beat (unique unofficial gameid; NM00003 = Vampire Night, GameIndex PR #92)
 	{"NM00030", StandardLayout::GUNDAMQUIZ},  // Gundam Quiz Warrior (moved from Fighting: a quiz, not a fighter)
+	{"NM00037", StandardLayout::INUFUKU},     // Quiz Suku Suku Inufuku 2
 };
 
 // Drum (Taiko) and twin-stick (Zoids) gameids for ResolveModeFromGameId (no per-button table).
@@ -480,6 +481,7 @@ std::span<const InputBindingInfo> ACJV::GetStandardButtons()
 		case StandardLayout::SMASHCOURT:  return s_standard_smashcourt;
 		case StandardLayout::TECHNICBEAT: return s_standard_technicbeat;
 		case StandardLayout::GUNDAMQUIZ:  return s_standard_gundamquiz;
+		case StandardLayout::INUFUKU:     return s_standard_inufuku;
 	}
 	return {};
 }

--- a/pcsx2/DEV9/ACJV.h
+++ b/pcsx2/DEV9/ACJV.h
@@ -73,6 +73,7 @@ enum class StandardLayout {
 	SMASHCOURT,  // NM00006: Smash Court Pro (2 buttons)
 	TECHNICBEAT, // NM10003: Technic Beat (3 buttons)
 	GUNDAMQUIZ,  // NM00030: Gundam Quiz Warrior (4-button Gundam wiring)
+	INUFUKU,     // NM00037: Quiz Inufuku 2 (answer buttons 1-4 on the directional bits)
 };
 
 #define JVS_WHEEL_CHANNEL_MAX 3

--- a/pcsx2/DEV9/ACJV_Inputs.h
+++ b/pcsx2/DEV9/ACJV_Inputs.h
@@ -206,6 +206,13 @@ static constexpr InputBindingInfo s_standard_baseball[] = {
 	{"Baseball_B", TRANSLATE_NOOP("JVS", "Full Swing / Run"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Square},
 	{"Baseball_C", TRANSLATE_NOOP("JVS", "Relay Throw"),      nullptr, InputBindingInfo::Type::Button, JVS_BTN_3, GenericInputBinding::Triangle},
 };
+// Quiz Inufuku 2 (NM00037): answer buttons 1-4, wired on the Up/Down/Left/Right switch bits.
+static constexpr InputBindingInfo s_standard_inufuku[] = {
+	{"Inufuku_1", TRANSLATE_NOOP("JVS", "Button 1"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_UP,    GenericInputBinding::Triangle},
+	{"Inufuku_2", TRANSLATE_NOOP("JVS", "Button 2"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_DOWN,  GenericInputBinding::Cross},
+	{"Inufuku_3", TRANSLATE_NOOP("JVS", "Button 3"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_LEFT,  GenericInputBinding::Square},
+	{"Inufuku_4", TRANSLATE_NOOP("JVS", "Button 4"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_RIGHT, GenericInputBinding::Circle},
+};
 // Gundam Quiz Warrior (NM00030): a quiz, but on the same 4-button wiring as the Gundam VS games (own keys).
 static constexpr InputBindingInfo s_standard_gundamquiz[] = {
 	{"GundamQuiz_Shoot",  TRANSLATE_NOOP("JVS", "Shoot"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_1, GenericInputBinding::Square},
@@ -220,6 +227,7 @@ static constexpr ACJV::LayoutInfo s_standard_layout_ui[] = {
 	{"Technic Beat",               s_standard_technicbeat, false},
 	{"Necchuu! Pro Yakyuu 2002",   s_standard_baseball,    false},
 	{"Gundam Quiz Warrior",        s_standard_gundamquiz,  false},
+	{"Quiz Suku Suku Inufuku 2",   s_standard_inufuku,     false, TRANSLATE_NOOP("JVS", "Answer buttons 1-4 sit on the Up/Down/Left/Right switches")},
 };
 
 static constexpr const std::array<InputBindingInfo, 2> s_jvs_coin_bindings = {{


### PR DESCRIPTION
Promote Quiz & Variety Suku Suku Inufuku 2 (NM00037) to playable for real this time.

Buttons are very simple: answer buttons 1-4. It uses the up/down/left/right bytes.

2 players.

Fixes https://github.com/PS2Homebrew-arcade/pcsx2x6/issues/103