### PR TITLE
JVS: relabel Gundam Quiz Warrior binds to the on-screen answers A-D

### DIFF
--- a/pcsx2/DEV9/ACJV_Inputs.h
+++ b/pcsx2/DEV9/ACJV_Inputs.h
@@ -206,12 +206,12 @@ static constexpr InputBindingInfo s_standard_baseball[] = {
 	{"Baseball_B", TRANSLATE_NOOP("JVS", "Full Swing / Run"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Square},
 	{"Baseball_C", TRANSLATE_NOOP("JVS", "Relay Throw"),      nullptr, InputBindingInfo::Type::Button, JVS_BTN_3, GenericInputBinding::Triangle},
 };
-// Gundam Quiz Warrior (NM00030): a quiz, but on the same 4-button wiring as the Gundam VS games (own keys).
+// Gundam Quiz Warrior (NM00030): answers as labelled on screen (A-D), on the Gundam VS 4-button wiring (keys kept for saved binds).
 static constexpr InputBindingInfo s_standard_gundamquiz[] = {
-	{"GundamQuiz_Shoot",  TRANSLATE_NOOP("JVS", "Shoot"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_1, GenericInputBinding::Square},
-	{"GundamQuiz_Melee",  TRANSLATE_NOOP("JVS", "Melee"),  nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Triangle},
-	{"GundamQuiz_Jump",   TRANSLATE_NOOP("JVS", "Jump"),   nullptr, InputBindingInfo::Type::Button, JVS_BTN_3, GenericInputBinding::Cross},
-	{"GundamQuiz_Target", TRANSLATE_NOOP("JVS", "Target"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_4, GenericInputBinding::Circle},
+	{"GundamQuiz_Target", TRANSLATE_NOOP("JVS", "Answer A"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_4, GenericInputBinding::Circle},
+	{"GundamQuiz_Shoot",  TRANSLATE_NOOP("JVS", "Answer B"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_1, GenericInputBinding::Square},
+	{"GundamQuiz_Melee",  TRANSLATE_NOOP("JVS", "Answer C"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Triangle},
+	{"GundamQuiz_Jump",   TRANSLATE_NOOP("JVS", "Answer D"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_3, GenericInputBinding::Cross},
 };
 
 // Standard page: section title + action buttons per layout.


### PR DESCRIPTION
Relabels the Gundam Quiz Warrior (NM00030) binds to the answers as shown on screen (A-D). Reported by SK91.