### PR TITLE
JVS: initial support for touch panel JVS controls

### DIFF
--- a/pcsx2-qt/Settings/JVSControlsWidget.cpp
+++ b/pcsx2-qt/Settings/JVSControlsWidget.cpp
@@ -90,6 +90,7 @@ JVSControlsWidget::JVSControlsWidget(QWidget* parent, ControllerSettingsWindow* 
 	buildTwinstickPage();
 	buildLightgunPage();
 	buildStandardPage();
+	buildTouchPage();
 
 	// Settings view: analog tuning (deadzone/sensitivity) for the JVS steering and pedals.
 	{
@@ -143,6 +144,7 @@ JVSControlsWidget::JVSControlsWidget(QWidget* parent, ControllerSettingsWindow* 
 	m_ui.pageSelector->addItem(tr("Twinstick"));
 	m_ui.pageSelector->addItem(tr("Lightgun"));
 	m_ui.pageSelector->addItem(tr("Standard"));
+	m_ui.pageSelector->addItem(tr("Touch Panel"));
 	connect(m_ui.pageSelector, QOverload<int>::of(&QComboBox::currentIndexChanged),
 		m_ui.pageStack, &QStackedWidget::setCurrentIndex);
 
@@ -329,6 +331,7 @@ void JVSControlsWidget::autoPickInputPage()
 		case JVS_MODE::TWINSTICK: page = 4; break;
 		case JVS_MODE::LIGHTGUN:  page = 5; break;
 		case JVS_MODE::STANDARD:  page = 6; break;
+		case JVS_MODE::TOUCH:     page = 7; break;
 		default:                  page = 0; break;
 	}
 	m_ui.pageSelector->setCurrentIndex(page);
@@ -606,6 +609,95 @@ void JVSControlsWidget::buildTwinstickPage()
 	addJvsAutomapButton(this, m_dialog, m_ui.twinstickPageLayout, std::move(binds), {});
 }
 
+// One crosshair config box (image path + scale + color) bound to the given settings keys.
+static QGroupBox* makeCrosshairBox(JVSControlsWidget* w, SettingsInterface* sif, const QString& title,
+	const std::string& section, const std::string& pathKey, const std::string& scaleKey, const std::string& colorKey)
+{
+	QGroupBox* box = new QGroupBox(title, w);
+	QGridLayout* cg = new QGridLayout(box);
+	cg->setColumnStretch(1, 1);
+
+	QLineEdit* path = new QLineEdit(box);
+	QPushButton* browse = new QPushButton(JVSControlsWidget::tr("Browse..."), box);
+	ControllerSettingWidgetBinder::BindWidgetToInputProfileString(sif, path, section, pathKey, "");
+	QObject::connect(browse, &QPushButton::clicked, w, [w, path]() {
+		const QString p(QDir::toNativeSeparators(QFileDialog::getOpenFileName(w, JVSControlsWidget::tr("Select Crosshair Image"))));
+		if (!p.isEmpty())
+			path->setText(p);
+	});
+	QHBoxLayout* ph = new QHBoxLayout();
+	ph->addWidget(path, 1);
+	ph->addWidget(browse);
+	cg->addWidget(new QLabel(JVSControlsWidget::tr("Image"), box), 0, 0);
+	cg->addLayout(ph, 0, 1);
+
+	QDoubleSpinBox* scale = new QDoubleSpinBox(box);
+	scale->setMinimum(1);
+	scale->setMaximum(1000);
+	scale->setSingleStep(1);
+	scale->setDecimals(0);
+	scale->setSuffix(QStringLiteral("%"));
+	ControllerSettingWidgetBinder::BindWidgetToInputProfileFloat(sif, scale, section, scaleKey, 1.0f, 100.0f);
+	cg->addWidget(new QLabel(JVSControlsWidget::tr("Scale"), box), 1, 0);
+	cg->addWidget(scale, 1, 1);
+
+	QLineEdit* color = new QLineEdit(box);
+	ControllerSettingWidgetBinder::BindWidgetToInputProfileString(sif, color, section, colorKey, "#ffffff");
+	cg->addWidget(new QLabel(JVSControlsWidget::tr("Color"), box), 2, 0);
+	cg->addWidget(color, 2, 1);
+	return box;
+}
+
+// Fill an aim-device combo: system pointers first, then bindable controllers; select `current`.
+static void populateAimCombo(QComboBox* combo, ControllerSettingsWindow* dialog, const QString& current)
+{
+	combo->blockSignals(true);
+	combo->clear();
+	for (u32 j = 0; j < InputManager::MAX_POINTER_DEVICES; j++)
+	{
+		const QString name = (InputManager::MAX_POINTER_DEVICES == 1)
+			? JVSControlsWidget::tr("Mouse (system)") : QString::fromStdString(InputManager::GetPointerDeviceName(j));
+		combo->addItem(name, QString::fromStdString(InputManager::GetPointerDeviceName(j)));
+	}
+	for (const QPair<QString, QString>& dev : dialog->getDeviceList())
+	{
+		// Skip the "Mouse"/"Keyboard" pseudo-devices: no aim stick, and the mouse is already the pointer above.
+		if (dev.first == QLatin1String("Mouse") || dev.first == QLatin1String("Keyboard"))
+			continue;
+		combo->addItem(dev.second, dev.first);
+	}
+	const int idx = combo->findData(current);
+	combo->setCurrentIndex((idx >= 0) ? idx : 0);
+	combo->blockSignals(false);
+}
+
+// Store the chosen aim device and mirror its left stick into the 4 relative-aim binding keys
+// (cleared when the device is a system pointer, i.e. the mouse).
+static void applyAimDevice(JVSControlsWidget* w, ControllerSettingsWindow* dialog, const QString& dev,
+	const std::string& section, const char* pointerKey, const std::array<std::string, 4>& axisKeys)
+{
+	dialog->setStringValue(section.c_str(), pointerKey, dev.toUtf8().constData());
+	InputManager::GenericInputBindingMapping mapping; // stays empty for a system pointer -> clears the stick binds
+	if (!dev.startsWith(QStringLiteral("Pointer-")))
+		mapping = InputManager::GetGenericBindingMapping(dev.toStdString());
+	static constexpr GenericInputBinding stick[4] = {GenericInputBinding::LeftStickLeft,
+		GenericInputBinding::LeftStickRight, GenericInputBinding::LeftStickUp, GenericInputBinding::LeftStickDown};
+	for (int i = 0; i < 4; i++)
+	{
+		std::string host;
+		for (const auto& [gg, h] : mapping)
+			if (gg == stick[i])
+				host = h;
+		if (host.empty())
+			dialog->clearSettingValue(section.c_str(), axisKeys[i].c_str());
+		else
+			dialog->setStringValue(section.c_str(), axisKeys[i].c_str(), host.c_str());
+	}
+	for (InputBindingWidget* bw : w->findChildren<InputBindingWidget*>())
+		bw->reloadBinding();
+	g_emu_thread->applySettings();
+}
+
 // Lightgun (GunCon2) page: bind the gun's USB1/USB2 guncon2_* button keys directly here.
 void JVSControlsWidget::buildLightgunPage()
 {
@@ -649,30 +741,9 @@ void JVSControlsWidget::buildLightgunPage()
 			const QString dev = combo->currentData().toString();
 			if (dev.isEmpty())
 				return;
-			m_dialog->setStringValue(section, "guncon2_Pointer", dev.toUtf8().constData());
-			InputManager::GenericInputBindingMapping mapping; // stays empty for Mouse -> clears the stick binds below
-			if (!dev.startsWith(QStringLiteral("Pointer-")))
-				mapping = InputManager::GetGenericBindingMapping(dev.toStdString());
-			static constexpr std::pair<const char*, GenericInputBinding> axes[] = {
-				{"RelativeLeft", GenericInputBinding::LeftStickLeft},
-				{"RelativeRight", GenericInputBinding::LeftStickRight},
-				{"RelativeUp", GenericInputBinding::LeftStickUp},
-				{"RelativeDown", GenericInputBinding::LeftStickDown}};
-			for (const auto& [key, gen] : axes)
-			{
-				std::string host;
-				for (const auto& [gg, h] : mapping)
-					if (gg == gen)
-						host = h;
-				const std::string k = USB::GetConfigSubKey("guncon2", key);
-				if (host.empty())
-					m_dialog->clearSettingValue(section, k.c_str());
-				else
-					m_dialog->setStringValue(section, k.c_str(), host.c_str());
-			}
-			for (InputBindingWidget* w : findChildren<InputBindingWidget*>())
-				w->reloadBinding();
-			g_emu_thread->applySettings(); // re-read so the GunCon2 picks up the new aim source
+			applyAimDevice(this, m_dialog, dev, section, "guncon2_Pointer",
+				{USB::GetConfigSubKey("guncon2", "RelativeLeft"), USB::GetConfigSubKey("guncon2", "RelativeRight"),
+					USB::GetConfigSubKey("guncon2", "RelativeUp"), USB::GetConfigSubKey("guncon2", "RelativeDown")});
 		});
 		ag->addWidget(combo, 1, col, Qt::AlignLeft);
 	};
@@ -716,42 +787,8 @@ void JVSControlsWidget::buildLightgunPage()
 
 	// Per-player crosshair image (guncon2_cursor_* keys); clearing the path = system cursor.
 	const auto makeCrosshair = [&](const char* section, const QString& title) -> QGroupBox* {
-		QGroupBox* box = new QGroupBox(title, this);
-		QGridLayout* cg = new QGridLayout(box);
-		cg->setColumnStretch(1, 1);
-
-		QLineEdit* path = new QLineEdit(box);
-		QPushButton* browse = new QPushButton(tr("Browse..."), box);
-		ControllerSettingWidgetBinder::BindWidgetToInputProfileString(
-			sif, path, section, USB::GetConfigSubKey("guncon2", "cursor_path"), "");
-		connect(browse, &QPushButton::clicked, this, [this, path]() {
-			const QString p(QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Select Crosshair Image"))));
-			if (!p.isEmpty())
-				path->setText(p);
-		});
-		QHBoxLayout* ph = new QHBoxLayout();
-		ph->addWidget(path, 1);
-		ph->addWidget(browse);
-		cg->addWidget(new QLabel(tr("Image"), box), 0, 0);
-		cg->addLayout(ph, 0, 1);
-
-		QDoubleSpinBox* scale = new QDoubleSpinBox(box);
-		scale->setMinimum(1);
-		scale->setMaximum(1000);
-		scale->setSingleStep(1);
-		scale->setDecimals(0);
-		scale->setSuffix(QStringLiteral("%"));
-		ControllerSettingWidgetBinder::BindWidgetToInputProfileFloat(
-			sif, scale, section, USB::GetConfigSubKey("guncon2", "cursor_scale"), 1.0f, 100.0f);
-		cg->addWidget(new QLabel(tr("Scale"), box), 1, 0);
-		cg->addWidget(scale, 1, 1);
-
-		QLineEdit* color = new QLineEdit(box);
-		ControllerSettingWidgetBinder::BindWidgetToInputProfileString(
-			sif, color, section, USB::GetConfigSubKey("guncon2", "cursor_color"), "#ffffff");
-		cg->addWidget(new QLabel(tr("Color"), box), 2, 0);
-		cg->addWidget(color, 2, 1);
-		return box;
+		return makeCrosshairBox(this, sif, title, section, USB::GetConfigSubKey("guncon2", "cursor_path"),
+			USB::GetConfigSubKey("guncon2", "cursor_scale"), USB::GetConfigSubKey("guncon2", "cursor_color"));
 	};
 	QHBoxLayout* crosshairRow = new QHBoxLayout();
 	crosshairRow->addWidget(makeCrosshair("USB1", tr("Crosshair (P1)")), 1);
@@ -788,6 +825,85 @@ void JVSControlsWidget::buildLightgunPage()
 	addLightgunAutomapButton(this, m_dialog, m_ui.lightgunPageLayout);
 }
 
+// Touch panel page: pointer device (mouse, or a controller stick via relative aim), touch press, crosshair.
+void JVSControlsWidget::buildTouchPage()
+{
+	SettingsInterface* sif = m_dialog->getProfileSettingsInterface();
+
+	QLabel* info = new QLabel(tr("Move the pointer with the mouse or a controller stick, and hold the Touch button "
+		"to press the panel. A tap is press then release inside the target."), this);
+	info->setWordWrap(true);
+	info->setStyleSheet("font-style: italic;");
+	m_ui.touchPageLayout->addWidget(info);
+
+	// Pointer device: mouse, or a controller whose left stick fills the relative-aim binds below.
+	QGroupBox* aimGroup = new QGroupBox(tr("Pointer Device"), this);
+	QGridLayout* ag = new QGridLayout(aimGroup);
+	ag->addWidget(new QLabel(tr("Device"), aimGroup), 0, 0);
+	QComboBox* combo = new QComboBox(aimGroup);
+	combo->setMinimumWidth(160);
+	m_touchAimCombo = combo;
+	connect(combo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this, combo](int) {
+		const QString dev = combo->currentData().toString();
+		if (dev.isEmpty())
+			return;
+		applyAimDevice(this, m_dialog, dev, ACJV::CONFIG_SECTION, "TouchPointer",
+			{"TouchRelativeLeft", "TouchRelativeRight", "TouchRelativeUp", "TouchRelativeDown"});
+	});
+	ag->addWidget(combo, 0, 1, Qt::AlignLeft);
+	ag->setColumnStretch(1, 1);
+	QHBoxLayout* top = new QHBoxLayout();
+	top->addWidget(aimGroup, 1);
+	top->addStretch(1);
+	m_ui.touchPageLayout->addLayout(top);
+
+	QGroupBox* touchGroup = new QGroupBox(tr("Touch"), this);
+	QGridLayout* tg = new QGridLayout(touchGroup);
+	QLabel* pressLabel = new QLabel(tr("Touch (tap)"), touchGroup);
+	tg->addWidget(pressLabel, 0, 0);
+	InputBindingWidget* press = new InputBindingWidget(touchGroup, sif, InputBindingInfo::Type::Button, ACJV::CONFIG_SECTION, "TouchPress");
+	press->setMinimumWidth(140);
+	press->setMaximumWidth(140);
+	tg->addWidget(press, 0, 1);
+	new HoverHighlight(press, pressLabel);
+	QLabel* pressNote = new QLabel(tr("Left mouse button when unbound."), touchGroup);
+	pressNote->setStyleSheet("font-style: italic;");
+	tg->addWidget(pressNote, 1, 0, 1, 2);
+	tg->setColumnStretch(0, 1);
+	tg->setRowStretch(2, 1);
+
+	QGroupBox* rel = new QGroupBox(tr("Relative Aim (stick)"), this);
+	QGridLayout* rg = new QGridLayout(rel);
+	const auto relRow = [&](int r, const QString& label, const char* key) {
+		QLabel* desc = new QLabel(label, rel);
+		rg->addWidget(desc, r, 0);
+		InputBindingWidget* wdg = new InputBindingWidget(rel, sif, InputBindingInfo::Type::HalfAxis, ACJV::CONFIG_SECTION, key);
+		wdg->setMinimumWidth(140);
+		wdg->setMaximumWidth(140);
+		rg->addWidget(wdg, r, 1);
+		new HoverHighlight(wdg, desc);
+	};
+	relRow(0, tr("Up"), "TouchRelativeUp");
+	relRow(1, tr("Down"), "TouchRelativeDown");
+	relRow(2, tr("Left"), "TouchRelativeLeft");
+	relRow(3, tr("Right"), "TouchRelativeRight");
+	rg->setColumnStretch(0, 1);
+
+	QHBoxLayout* mid = new QHBoxLayout();
+	mid->addWidget(touchGroup, 1);
+	mid->addWidget(rel, 1);
+	m_ui.touchPageLayout->addLayout(mid);
+
+	// Crosshair for the touch pointer (needed to see where a controller stick points).
+	QHBoxLayout* crossRow = new QHBoxLayout();
+	crossRow->addWidget(makeCrosshairBox(this, sif, tr("Crosshair"), ACJV::CONFIG_SECTION,
+		"TouchCursorPath", "TouchCursorScale", "TouchCursorColor"), 1);
+	crossRow->addStretch(1);
+	m_ui.touchPageLayout->addLayout(crossRow);
+
+	m_ui.touchPageLayout->addStretch(1);
+}
+
 void JVSControlsWidget::buildStandardPage()
 {
 	buildJvsLayoutPage(this, m_dialog->getProfileSettingsInterface(), m_dialog,
@@ -800,29 +916,15 @@ void JVSControlsWidget::refreshAimDevices()
 	const char* sections[2] = {"USB1", "USB2"};
 	for (int i = 0; i < 2; i++)
 	{
-		QComboBox* combo = m_aimCombos[i];
-		if (!combo)
+		if (!m_aimCombos[i])
 			continue;
-		combo->blockSignals(true);
-		combo->clear();
-		for (u32 j = 0; j < InputManager::MAX_POINTER_DEVICES; j++)
-		{
-			const QString name = (InputManager::MAX_POINTER_DEVICES == 1)
-				? tr("Mouse (system)") : QString::fromStdString(InputManager::GetPointerDeviceName(j));
-			combo->addItem(name, QString::fromStdString(InputManager::GetPointerDeviceName(j)));
-		}
-		for (const QPair<QString, QString>& dev : m_dialog->getDeviceList())
-		{
-			// Skip the "Mouse"/"Keyboard" pseudo-devices: no aim stick, and the mouse is already the pointer above.
-			if (dev.first == QLatin1String("Mouse") || dev.first == QLatin1String("Keyboard"))
-				continue;
-			combo->addItem(dev.second, dev.first);
-		}
-		const QString want = QString::fromStdString(m_dialog->getStringValue(sections[i], "guncon2_Pointer",
-			InputManager::GetPointerDeviceName(0).c_str()));
-		const int idx = combo->findData(want);
-		combo->setCurrentIndex((idx >= 0) ? idx : 0);
-		combo->blockSignals(false);
+		populateAimCombo(m_aimCombos[i], m_dialog, QString::fromStdString(m_dialog->getStringValue(
+			sections[i], "guncon2_Pointer", InputManager::GetPointerDeviceName(0).c_str())));
+	}
+	if (m_touchAimCombo)
+	{
+		populateAimCombo(m_touchAimCombo, m_dialog, QString::fromStdString(m_dialog->getStringValue(
+			ACJV::CONFIG_SECTION, "TouchPointer", InputManager::GetPointerDeviceName(0).c_str())));
 	}
 }
 

--- a/pcsx2-qt/Settings/JVSControlsWidget.h
+++ b/pcsx2-qt/Settings/JVSControlsWidget.h
@@ -38,6 +38,7 @@ private:
 	void buildTwinstickPage();
 	void buildLightgunPage();
 	void buildStandardPage();
+	void buildTouchPage();
 	void refreshAimDevices();
 	void refreshMacrosPage(); // rebuild the Macros view (layout dropdown + per-layout rows)
 	void buildMacroRows(QVBoxLayout* rowsLayout, const std::string& layoutKey, std::span<const InputBindingInfo> lbuttons);
@@ -46,4 +47,5 @@ private:
 	ControllerSettingsWindow* m_dialog;
 	std::string m_autoPickedGameId;
 	QComboBox* m_aimCombos[2] = {}; // [0] = USB1/P1, [1] = USB2/P2
+	QComboBox* m_touchAimCombo = nullptr;
 };

--- a/pcsx2-qt/Settings/JVSControlsWidget.ui
+++ b/pcsx2-qt/Settings/JVSControlsWidget.ui
@@ -268,6 +268,12 @@
                <property name="rightMargin"><number>0</number></property>
               </layout>
              </widget>
+             <widget class="QWidget" name="touchPage">
+              <layout class="QVBoxLayout" name="touchPageLayout">
+               <property name="leftMargin"><number>0</number></property>
+               <property name="rightMargin"><number>0</number></property>
+              </layout>
+             </widget>
             </widget>
            </item>
           </layout>

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -5,6 +5,7 @@
 #include "Config.h"
 #include "Host.h"
 #include "Input/InputManager.h"
+#include "ImGui/ImGuiManager.h"
 #include "GS/GS.h"
 #include "common/SettingsInterface.h"
 #include <algorithm>
@@ -428,6 +429,13 @@ static constexpr const char* s_drum_games[] = {
 	"NM00046", "NM00051", "NM00053", "NM00054", "NM00056", "NM00057",
 };
 static constexpr const char* s_twinstick_games[] = {"NM00016", "NM00025"};
+static constexpr const char* s_touch_games[] = { // V290 FCB touch panel games
+	"NM00014", // Dragon Chronicle
+	"NM00020", // Dragon Chronicle Online
+	"NM00022", // THE IDOLM@STER
+	"NM00028", // Druaga Online
+	"NM00036", // Zenno Training (Whole Brain)
+};
 
 // Derive the JVS device mode from the gameid alone (jvsmode= is an optional override, see VMManager).
 JVS_MODE ACJV::ResolveModeFromGameId(const std::string& gameid)
@@ -440,6 +448,8 @@ JVS_MODE ACJV::ResolveModeFromGameId(const std::string& gameid)
 		return JVS_MODE::DRUM;
 	if (std::ranges::find(s_twinstick_games, gameid) != std::ranges::end(s_twinstick_games))
 		return JVS_MODE::TWINSTICK;
+	if (std::ranges::find(s_touch_games, gameid) != std::ranges::end(s_touch_games))
+		return JVS_MODE::TOUCH;
 	return JVS_MODE::DEFAULT;
 }
 
@@ -646,6 +656,8 @@ void ACJV::SetGameId(const std::string& gameid)
 		CurrentBoardID = MIU_IO_JPN_GUN_EXTENTI;
 	else if (gameid == "NM00010" || gameid == "NM00015")
 		CurrentBoardID = TAITO_BG3_IO_PCB; // BG3/BG3T: real Taito K91X0951A board ID (from the F22 EPROM dump)
+	else if (std::ranges::find(s_touch_games, gameid) != std::ranges::end(s_touch_games))
+		CurrentBoardID = FCB_JPN_TOUCHPANEL; // touch games use the V290 FCB PCB
 	else
 		CurrentBoardID = RAYS_PCB;
 }
@@ -696,6 +708,70 @@ static void UpdateLightgunFromMouse()
 		if (gm.sensor)
 			ACJV::SetButtonState(p, gm.sensor, gm.sensor_active_high ? on_screen : !on_screen);
 	}
+}
+
+static bool m_touchPressed = false;
+static bool m_touchPressBound = false;
+static bool m_touchRelActive = false;
+static float m_touchRel[4] = {}; // Left/Right/Up/Down stick deflection
+static std::string m_touchCursorPath;
+
+void ACJV::SetTouchPressed(bool pressed) { m_touchPressed = pressed; }
+void ACJV::SetTouchPressBound(bool bound) { m_touchPressBound = bound; }
+void ACJV::SetTouchRelativeAxis(u32 axis, float value) { if (axis < std::size(m_touchRel)) m_touchRel[axis] = value; }
+void ACJV::SetTouchRelativeActive(bool active) { m_touchRelActive = active; }
+
+// Relative aim draws on its own software-cursor slot (past the guns' MAX+port slots); the mouse shares slot 0.
+static u32 TouchPointerIndex() { return m_touchRelActive ? (InputManager::MAX_POINTER_DEVICES + 2) : 0; }
+
+void ACJV::SetTouchCursor(std::string path, float scale, u32 color)
+{
+	static bool s_shown = false;
+	static u32 s_prev_index = 0;
+	const bool want = (ACJV::GetMode() == JVS_MODE::TOUCH) && !path.empty();
+	const u32 index = TouchPointerIndex();
+	if (s_shown && (!want || s_prev_index != index))
+		ImGuiManager::ClearSoftwareCursor(s_prev_index);
+	m_touchCursorPath = want ? path : std::string();
+	if (want)
+		ImGuiManager::SetSoftwareCursor(index, std::move(path), scale, color);
+	s_shown = want;
+	s_prev_index = index;
+}
+
+// Touch panel pointer: the mouse, or a controller stick via the relative-aim binds (stick deflection maps to
+// the whole screen, like the lightgun relative aim). Touching = the TouchPress bind, or left click when unbound.
+// FCB reports X=Y=0xFFFF when the panel isn't touched.
+static void UpdateTouchFromPointer()
+{
+	float wx, wy;
+	if (m_touchRelActive)
+	{
+		wx = (((m_touchRel[1] > 0.0f) ? m_touchRel[1] : -m_touchRel[0]) + 1.0f) * 0.5f * ImGuiManager::GetWindowWidth();
+		wy = (((m_touchRel[3] > 0.0f) ? m_touchRel[3] : -m_touchRel[2]) + 1.0f) * 0.5f * ImGuiManager::GetWindowHeight();
+	}
+	else
+	{
+		const auto& [mx, my] = InputManager::GetPointerAbsolutePosition(0);
+		wx = mx;
+		wy = my;
+	}
+	if (!m_touchCursorPath.empty())
+		ImGuiManager::SetSoftwareCursorPosition(TouchPointerIndex(), wx, wy);
+
+	const bool pressed = m_touchPressBound ? m_touchPressed : InputManager::IsPointerButtonDown(0, 0);
+	if (!pressed)
+	{
+		m_jvsScreenPosX[0] = 0xFFFF;
+		m_jvsScreenPosY[0] = 0xFFFF;
+		return;
+	}
+	float mdx, mdy;
+	GSTranslateWindowToDisplayCoordinates(wx, wy, &mdx, &mdy);
+	const float cx = (mdx < 0.0f) ? 0.0f : (mdx > 1.0f ? 1.0f : mdx);
+	const float cy = (mdy < 0.0f) ? 0.0f : (mdy > 1.0f ? 1.0f : mdy);
+	m_jvsScreenPosX[0] = std::min<u16>(static_cast<u16>(cx * 0xFFFF), 0xFFFE);
+	m_jvsScreenPosY[0] = std::min<u16>(static_cast<u16>((1.0f - cy) * 0xFFFF), 0xFFFE); // FCB Y axis is bottom-up
 }
 
 // Combine host axes into the 3 JVS analog channels (steer/gas/brake). Steering encoding is per-game.
@@ -838,8 +914,6 @@ void do_jvs_packet(const u8* input, u8* output) {
 
 				(*dstSize) += 4;
 			}
-			// TODO: touch panel games
-#if 0
 			else if(m_jvsMode == JVS_MODE::TOUCH)
 			{
 				(*output++) = 0x06; //Screen Pos Input
@@ -849,7 +923,6 @@ void do_jvs_packet(const u8* input, u8* output) {
 
 				(*dstSize) += 4;
 			}
-#endif
 			(*output++) = 0x00; //End of features
 
 			(*dstSize) += 10;
@@ -1020,6 +1093,8 @@ void do_jvs_packet(const u8* input, u8* output) {
 
 			if(m_jvsMode == JVS_MODE::LIGHTGUN)
 				UpdateLightgunFromMouse();
+			else if(m_jvsMode == JVS_MODE::TOUCH)
+				UpdateTouchFromPointer();
 
 			(*output++) = JVS_CMD_SUCCESS;
 
@@ -1031,7 +1106,12 @@ void do_jvs_packet(const u8* input, u8* output) {
 			// frame), so return that one gun's player position - gun 1 -> P1, gun 2 -> P2.
 			const u32 pl = (channel >= 1 && channel <= JVS_PLAYER_COUNT) ? (channel - 1u) : 0u;
 			u16 posX = 0, posY = 0;
-			if(m_jvsMode == JVS_MODE::LIGHTGUN && m_jvsLightgunDX[pl] >= 0.0f)
+			if(m_jvsMode == JVS_MODE::TOUCH)
+			{
+				posX = m_jvsScreenPosX[0];
+				posY = m_jvsScreenPosY[0];
+			}
+			else if(m_jvsMode == JVS_MODE::LIGHTGUN && m_jvsLightgunDX[pl] >= 0.0f)
 			{
 				const float scaleX = (ACJV::CurrentBoardID == MIU_IO_JPN_GUN_EXTENTI) ? 640.0f : 0xFFFF;
 				const float scaleY = (ACJV::CurrentBoardID == MIU_IO_JPN_GUN_EXTENTI) ? 224.0f : 0xFFFF;
@@ -1077,6 +1157,31 @@ void do_jvs_packet(const u8* input, u8* output) {
 
 			(*output++) = JVS_CMD_SUCCESS;
 			(*dstSize) += 1;
+		}
+		break;
+		// Namco vendor command: a sub-command byte plus its args (0x60 status = 1 arg, 0x62 touch
+		// initialize = 2 args, 0x18 boot config = 4 args). We echo the sub-command and report 0x01,
+		// which is the "ready" the game waits on to finish INITIALIZE.
+		case JVS::NAMCO_VENDOR:
+		{
+			JVS_ASSERT(inSize != 0);
+			u8 sub = (*input++);
+			inWorkChecksum += sub;
+			inSize--;
+
+			u8 args = (sub == 0x60) ? 1 : (sub == 0x62) ? 2 : (sub == 0x18) ? 4 : inSize;
+			for(u8 i = 0; i < args && inSize != 0; i++)
+			{
+				u8 data = (*input++);
+				inWorkChecksum += data;
+				inSize--;
+			}
+
+			(*output++) = JVS_CMD_SUCCESS;
+			(*output++) = 0x02; //payload length
+			(*output++) = sub;  //sub-command echo
+			(*output++) = 0x01; //status: ready
+			(*dstSize) += 4;
 		}
 		break;
 		default:

--- a/pcsx2/DEV9/ACJV.h
+++ b/pcsx2/DEV9/ACJV.h
@@ -113,6 +113,11 @@ namespace ACJV {
     u16 Read16(u32 addr);
     void Write16(u32 addr, u16 val);
     void UpdateFcaFrame(); // Ridge Racer V: refresh the FCA-1 I/O board's input buffer every frame (steering/pedals/buttons)
+    void SetTouchPressed(bool pressed);
+    void SetTouchPressBound(bool bound);
+    void SetTouchRelativeAxis(u32 axis, float value); // 0..3 = Left/Right/Up/Down stick deflection
+    void SetTouchRelativeActive(bool active);
+    void SetTouchCursor(std::string path, float scale, u32 color);
     void OnBoardStart();   // set the JVS I/O board firmware version at power-on (Battle Gear 3 Tuned reads it before its first command)
     extern enum BOARDID CurrentBoardID;
 
@@ -210,6 +215,7 @@ enum JVS { //https://github.com/TheOnlyJoey/openjvs/wiki/Command-list
     OUTPUT_GENERAL_PURPOSE3 = 0x38, //general-purpose output 3
     /// Manufacturer-specific
     //60-7F	 	reserved for manufacturer-specific commands
+    NAMCO_VENDOR = 0x70, //Namco extended command: sub-command + args (FCB touch panel init/status)
 };
 
 enum COINCOND { // Coin Slot condition

--- a/pcsx2/Input/InputManager.cpp
+++ b/pcsx2/Input/InputManager.cpp
@@ -173,6 +173,7 @@ static std::array<float, 2> s_pointer_axis_dead_zone;
 static std::array<float, 2> s_pointer_axis_range;
 static std::array<float, 2> s_pointer_pos = {0.0f, 0.0f};
 static float s_pointer_inertia = 0.0f;
+static std::array<u32, InputManager::MAX_POINTER_DEVICES> s_pointer_button_state = {};
 
 using PointerMoveCallback = std::function<void(InputBindingKey key, float value)>;
 using KeyboardEventCallback = std::function<void(InputBindingKey key, float value)>;
@@ -1011,6 +1012,38 @@ void InputManager::AddJVSBindings(SettingsInterface& si, bool is_profile)
 			ACJV::SetDrumHit(channel, value > 0.5f);
 		}}, bi.bind_type, si, ACJV::CONFIG_SECTION, bi.name, is_profile);
 	}
+
+	// Touch panel: press bind + relative-aim axes + crosshair
+	{
+		const std::vector<std::string> press(si.GetStringList(ACJV::CONFIG_SECTION, "TouchPress"));
+		ACJV::SetTouchPressBound(!press.empty());
+		if (!press.empty())
+		{
+			AddBindings(press, InputAxisEventHandler{[](InputBindingKey, float value) {
+				ACJV::SetTouchPressed(value > 0.5f);
+			}}, InputBindingInfo::Type::Button, si, ACJV::CONFIG_SECTION, "TouchPress", is_profile);
+		}
+
+		static constexpr const char* touch_axes[] = {"TouchRelativeLeft", "TouchRelativeRight", "TouchRelativeUp", "TouchRelativeDown"};
+		bool any_relative = false;
+		for (u32 i = 0; i < std::size(touch_axes); i++)
+		{
+			const std::vector<std::string> axis(si.GetStringList(ACJV::CONFIG_SECTION, touch_axes[i]));
+			if (axis.empty())
+				continue;
+			any_relative = true;
+			AddBindings(axis, InputAxisEventHandler{[i](InputBindingKey, float value) {
+				ACJV::SetTouchRelativeAxis(i, value);
+			}}, InputBindingInfo::Type::HalfAxis, si, ACJV::CONFIG_SECTION, touch_axes[i], is_profile);
+		}
+		ACJV::SetTouchRelativeActive(any_relative);
+
+		const std::string color_str(si.GetStringValue(ACJV::CONFIG_SECTION, "TouchCursorColor", "#ffffff"));
+		const u32 color = color_str.empty() ? 0xFFFFFFu :
+			static_cast<u32>(std::strtoul(color_str.c_str() + (color_str[0] == '#' ? 1 : 0), nullptr, 16));
+		ACJV::SetTouchCursor(si.GetStringValue(ACJV::CONFIG_SECTION, "TouchCursorPath", ""),
+			si.GetFloatValue(ACJV::CONFIG_SECTION, "TouchCursorScale", 1.0f), color);
+	}
 }
 
 void InputManager::AddPadBindings(SettingsInterface& si, u32 pad_index, bool is_profile)
@@ -1220,6 +1253,15 @@ bool InputManager::IsAxisHandler(const InputEventHandler& handler)
 
 bool InputManager::InvokeEvents(InputBindingKey key, float value, GenericInputBinding generic_key)
 {
+	if (key.source_type == InputSourceType::Pointer && key.source_subtype == InputSubclass::PointerButton &&
+		key.source_index < MAX_POINTER_DEVICES && key.data < 32)
+	{
+		if (value > 0.0f)
+			s_pointer_button_state[key.source_index] |= (1u << key.data);
+		else
+			s_pointer_button_state[key.source_index] &= ~(1u << key.data);
+	}
+
 	if (DoEventHook(key, value))
 		return true;
 
@@ -1487,6 +1529,13 @@ std::pair<float, float> InputManager::GetPointerAbsolutePosition(u32 index)
 {
 	return std::make_pair(s_host_pointer_positions[index][static_cast<u8>(InputPointerAxis::X)],
 		s_host_pointer_positions[index][static_cast<u8>(InputPointerAxis::Y)]);
+}
+
+bool InputManager::IsPointerButtonDown(u32 index, u32 button_index)
+{
+	if (index >= MAX_POINTER_DEVICES || button_index >= 32)
+		return false;
+	return (s_pointer_button_state[index] & (1u << button_index)) != 0;
 }
 
 void InputManager::UpdatePointerAbsolutePosition(u32 index, float x, float y)

--- a/pcsx2/Input/InputManager.h
+++ b/pcsx2/Input/InputManager.h
@@ -298,6 +298,9 @@ namespace InputManager
 	/// Reads absolute pointer position.
 	std::pair<float, float> GetPointerAbsolutePosition(u32 index);
 
+	/// Reads current pointer button state (latched from button events).
+	bool IsPointerButtonDown(u32 index, u32 button_index);
+
 	/// Updates absolute pointer position. Can call from UI thread, use when the host only reports absolute coordinates.
 	void UpdatePointerAbsolutePosition(u32 index, float x, float y);
 


### PR DESCRIPTION
Add initial support for JVS Touch Panel controls. Similar to Light gun UI.

With a crosshair (image for the touch pointer) and the tap (touch) press button. Controller and mouse are working fine.

Data was reverse engineered, so no hack whatsoever.

And I took the time to redo a bit the light gun page (less bloated code).