### PR TITLE
ACATA: initial support to .ISO (CD/DVD) image

### DIFF
--- a/pcsx2/DEV9/ACATA.h
+++ b/pcsx2/DEV9/ACATA.h
@@ -86,6 +86,9 @@ namespace ACATA
         extern FILE* IMAGE;
         extern s64 IMAGESIZE;
         extern u32 sectorsize; //512 for hdd and 2048 for Disc (?) check it
+        extern u32 unitbytes;   //bytes per sector unit in a raw disc image file (0 = plain 2048-byte units)
+        extern u32 unitdataoff; //offset of the 2048-byte payload inside a unit
+        extern std::string open_error; //user-facing reason when IO_OpenImage rejects the image
         extern u32 nsector;
         extern s64 LBA;
 

--- a/pcsx2/DEV9/ACATAPI.cpp
+++ b/pcsx2/DEV9/ACATAPI.cpp
@@ -28,6 +28,28 @@ static u32 atapi_dma_len = 0;
 static u8 mode_page_01[12] = {};
 static bool mode_page_01_set = false;
 
+// One READ_10 fetch, whatever the backing image: CHD, plain cooked file or raw-frame file.
+static bool atapi_read_sectors(u32 lba, u32 nsec, u8* dst) {
+    const u32 secsize = ACATAPI::CONSTANTS::DVD_SECTORSIZE;
+    if (ACATA::TH::isCHD) {
+        u32 scale = secsize / CHD.GetSectorSize();
+        return CHD.ReadSectors((u64)lba * scale, nsec * scale, dst);
+    }
+    if (ACATA::TH::unitbytes == 0) {
+        s64 offset = (s64)lba * secsize;
+        size_t expected = (size_t)nsec * secsize;
+        FileSystem::FSeek64(ACATA::TH::IMAGE, offset, SEEK_SET);
+        return fread(dst, 1, expected, ACATA::TH::IMAGE) == expected;
+    }
+    for (u32 i = 0; i < nsec; i++) {
+        s64 offset = (s64)(lba + i) * ACATA::TH::unitbytes + ACATA::TH::unitdataoff;
+        FileSystem::FSeek64(ACATA::TH::IMAGE, offset, SEEK_SET);
+        if (fread(dst + (size_t)i * secsize, 1, secsize, ACATA::TH::IMAGE) != secsize)
+            return false;
+    }
+    return true;
+}
+
 void ACATAPI::Reset() { mode_page_01_set = false; }
 
 static void atapi_pio_write_setup(u32 len) {
@@ -262,17 +284,7 @@ void ACATAPI::handle_cmd(atapi_packet_t P) {
         ACATA_LOG("ATAPI READ_10 lba:%08X sectors:%02X dma:%d", transf_lba, nsec, ACATA_ISDMA);
         if (ACATA_ISDMA) {
             u32 total = nsec * ACATAPI::CONSTANTS::DVD_SECTORSIZE;
-            bool ok = false;
-            if (total <= sizeof(atapi_dma_buf)) {
-                if (ACATA::TH::isCHD) {
-                    u32 scale = ACATAPI::CONSTANTS::DVD_SECTORSIZE / CHD.GetSectorSize();
-                    ok = CHD.ReadSectors((u64)transf_lba * scale, nsec * scale, atapi_dma_buf);
-                } else {
-                    s64 offset = (s64)transf_lba * ACATAPI::CONSTANTS::DVD_SECTORSIZE;
-                    FileSystem::FSeek64(ACATA::TH::IMAGE, offset, SEEK_SET);
-                    ok = (fread(atapi_dma_buf, 1, total, ACATA::TH::IMAGE) == total);
-                }
-            }
+            bool ok = (total <= sizeof(atapi_dma_buf)) && atapi_read_sectors(transf_lba, nsec, atapi_dma_buf);
             if (ok) {
                 atapi_dma_len = total;
                 atapi_complete_nodata();
@@ -291,15 +303,7 @@ void ACATAPI::handle_cmd(atapi_packet_t P) {
                 atapi_complete_error();
                 break;
             }
-            bool ok = false;
-            if (ACATA::TH::isCHD) {
-                u32 scale = ACATAPI::CONSTANTS::DVD_SECTORSIZE / CHD.GetSectorSize();
-                ok = CHD.ReadSectors((u64)transf_lba * scale, nsec * scale, atapi_pio_buf);
-            } else {
-                s64 offset = (s64)transf_lba * ACATAPI::CONSTANTS::DVD_SECTORSIZE;
-                FileSystem::FSeek64(ACATA::TH::IMAGE, offset, SEEK_SET);
-                ok = (fread(atapi_pio_buf, 1, total, ACATA::TH::IMAGE) == total);
-            }
+            bool ok = atapi_read_sectors(transf_lba, nsec, atapi_pio_buf);
             if (ok) {
                 atapi_pio_setup(total);
             } else {

--- a/pcsx2/DEV9/ACATA_IO.cpp
+++ b/pcsx2/DEV9/ACATA_IO.cpp
@@ -10,6 +10,8 @@
 #include "ACATA.h"
 #include "ACATA_IO_CHD.h"
 
+#include <cstring>
+
 #if __POSIX__
 #define INVALID_HANDLE_VALUE -1
 #include <unistd.h>
@@ -17,6 +19,7 @@
 #endif
 
 std::mutex ACATA::TH::ioMutex;
+std::string ACATA::TH::open_error;
 bool ACATA::TH::b_isIdle,
     ACATA::TH::ioWrite,
     ACATA::TH::ioRead,
@@ -25,6 +28,8 @@ std::condition_variable ACATA::TH::Idle_cv, ACATA::TH::ioReady;
 FILE* ACATA::TH::IMAGE;
 s64 ACATA::TH::IMAGESIZE;
 u32 ACATA::TH::sectorsize = ACATAPI::CONSTANTS::DVD_SECTORSIZE; //TODO: remove hardcode before testing HDD/CD games !
+u32 ACATA::TH::unitbytes;
+u32 ACATA::TH::unitdataoff;
 u32 ACATA::TH::nsector;
 s64 ACATA::TH::LBA;
 
@@ -87,8 +92,65 @@ void ACATA::TH::IO_Write(u32* addr, u32 size) {
 	} else Console.ErrorFmt("{}: skipping write due to CHD media", __FUNCTION__);
 }
 
+static bool probe_at(FILE* f, s64 pos, u8* dst, u32 len) {
+	if (FileSystem::FSeek64(f, pos, SEEK_SET) != 0)
+		return false;
+	return std::fread(dst, 1, len, f) == len;
+}
+
+static bool pvd_at(FILE* f, s64 pos) { //ISO9660 primary volume descriptor magic
+	u8 b[6];
+	return probe_at(f, pos, b, 6) && std::memcmp(b, "\x01" "CD001", 6) == 0;
+}
+
+static const u8 CD_SYNC[12] = {0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00};
+
+static void apply_disc_layout(u32 stride, u32 dataoff) { //IMAGESIZE becomes logical bytes, like the CHD branch
+	ACATA::TH::unitbytes = stride;
+	ACATA::TH::unitdataoff = dataoff;
+	ACATA::TH::IMAGESIZE = (ACATA::TH::IMAGESIZE / stride) * ACATAPI::CONSTANTS::DVD_SECTORSIZE;
+	Console.WriteLnFmt("ACATA: disc image has {}-byte sector units, payload at +{}", stride, dataoff);
+}
+
+// Find where the 2048-byte payload sits in a CD/DVD image; false = corrupted dump.
+static bool DetectDiscImageLayout() {
+	FILE* f = ACATA::TH::IMAGE;
+	u8 hdr[16];
+	if (!probe_at(f, 0, hdr, 16))
+		return true;
+	if (std::memcmp(hdr, CD_SYNC, 12) == 0) { //raw CD frames; MODE2 has an 8-byte subheader before the payload
+		for (u32 stride : {2352u, 2448u}) {
+			u8 next_sync[12];
+			if (probe_at(f, stride, next_sync, 12) && std::memcmp(next_sync, CD_SYNC, 12) == 0) {
+				apply_disc_layout(stride, (hdr[15] == 2) ? 24 : 16);
+				return true;
+			}
+		}
+	}
+	if (pvd_at(f, 16 * 2048)) //plain cooked 2048 iso: the default path already fits
+		return true;
+	if ((ACATA::TH::IMAGESIZE % 2336) == 0 && pvd_at(f, 16 * 2336 + 8)) { //2336 Mode2 CD dump: subheader kept
+		apply_disc_layout(2336, 8);
+		return true;
+	}
+	if ((ACATA::TH::IMAGESIZE % 2064) == 0 && pvd_at(f, 16 * 2064 + 12)) { //raw DVD sectors: 12-byte ID/IED/CPR header
+		apply_disc_layout(2064, 12);
+		return true;
+	}
+	if (pvd_at(f, 16 * 2048 + 8)) {
+		ACATA::TH::open_error = "This disc image is a corrupted dump (truncated sectors). A clean dump of this disc is required.";
+		Console.Error("ACATA: this disc image is a corrupted dump (truncated sectors), a clean dump of this disc is required.");
+		return false;
+	}
+	Console.Warning("ACATA: unknown disc image layout, assuming plain 2048-byte sectors");
+	return true;
+}
+
 int ACATA::TH::IO_OpenImage() {
+	open_error.clear();
 	isCHD = ChdImage::IsChdFileName(ACATA::imgpath);
+	unitbytes = 0;
+	unitdataoff = 0;
 	if (isCHD) {
 		if (CHD.Open(ACATA::imgpath)) {
 			u32 secsize = CHD.GetSectorSize();
@@ -114,6 +176,11 @@ int ACATA::TH::IO_OpenImage() {
 		else {
 			Console.ErrorFmt("{}> fail to get filesize: {}", __FUNCTION__, t);
 			return EINVAL;
+		}
+		if ((ACATA::MediaType == ACMEDIATYPE::ACCD || ACATA::MediaType == ACMEDIATYPE::ACDVD) && !DetectDiscImageLayout()) {
+			std::fclose(ACATA::TH::IMAGE);
+			ACATA::TH::IMAGE = nullptr;
+			return EIO;
 		}
 		Console.WriteLn("%s: image opened ok", __FUNCTION__);
 	}

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1450,7 +1450,8 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				ACATA::SetEnv(basedir, s_imgname, s_acmedia);
 				int R;
 				if ((R = ACATA::TH::IO_OpenImage())!=0) {
-					Error::SetString(error, std::string("cannot open arcade media image"));
+					Error::SetString(error, ACATA::TH::open_error.empty() ?
+						std::string("cannot open arcade media image") : ACATA::TH::open_error);
 					return false;
 				}
 				if (s_acmedia == "CD" && !ACATA::imgpath.empty()) {


### PR DESCRIPTION
Add initial support for .ISO (CD/DVD) images with any sector layout, with a clear error on corrupted/truncated dumps instead of a silent boot loop.

**YOU NEED A COMPLETE, UNTRUNCATED .ISO**

Bad rips that drop bytes from each sector will be rejected.

Tested on Netchuu (ver. B), Wangan Midnight, RRV, Tekken 4, Smart Court.