### PR TITLE
JVS: DIPSwitches status correction

### DIFF
--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -1316,7 +1316,7 @@ void do_acjv_packet() {
 		rd16[1]      = JvFirmwareVersion();
 		rd16[0x14]   = RootPacketID; // Xored with value at 0x10 in send packet, needs to be the same
 		rd16[0x21]   = wr16[0x0D];
-		rd16[0x30]  = s_dip_switch_state; // here the game polls the dip switch values?
+		rdbuf[0x30]  = s_dip_switch_state; // here the game polls the dip switch values?
 		static u8 s_acFrameSeq = 0;
 		rdbuf[0x57] = ++s_acFrameSeq; // game waits on this byte advancing each frame to finalize a coin decrement
 		u16 PacketID = wr16[0x0C];


### PR DESCRIPTION
offset is 0x30 at u8* access, code was doing it at u16* access

### Description of Changes

fixes the location on the JVS packet where dip switch status really goes

### Rationale behind Changes

### Suggested Testing Steps
Most games seem to have a real time indicator of dip switches status on their test menus

### Did you use AI to help find, test, or implement this issue or feature?
NO

### Related GameIDs
ALL OF THEM