### PR TITLE
update acgame config parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ CMakeSettings.json
 /ci-artifacts/
 /out/
 /.cache/
+/bin/utils/system2x6_games

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -222,7 +222,7 @@ NM00031:
     nativeScaling: 2 # Fixes misaligned bloom.
 NM00032:
   name: Time Crisis 4
-  region: System256
+  region: System SUPER256
   bootprog: TC4LOAD
   media: HDD
   input: lightgun

--- a/bin/utils/arcade_game_template.py
+++ b/bin/utils/arcade_game_template.py
@@ -88,7 +88,7 @@ platform={platform}
 
 [data]
 subdir={gameid}
-elf=proverb.elf
+elf=boot.elf
 dongle={gameid}.ps2
 mediasrc={gameid}.chd
 media={media}

--- a/pcsx2/Docs/gamedb-schema.json
+++ b/pcsx2/Docs/gamedb-schema.json
@@ -23,7 +23,7 @@
         "region": {
           "type": "string",
           "description": "The region code for the game, for example NTSC-U",
-          "pattern": "^(?:NTSC-(?:B|C|E|HK|J|K|M|T|U).*|PAL-?(?:A|B|E|F|G|I|M|N|P|R|S|U)?.*|Other|System246|System256)$"
+          "pattern": "^(?:NTSC-(?:B|C|E|HK|J|K|M|T|U).*|PAL-?(?:A|B|E|F|G|I|M|N|P|R|S|U)?.*|Other|System246|System256|System SUPER256)$"
         },
         "bootprog": {
           "type": "string",

--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -86,6 +86,11 @@ const char* GameDatabaseSchema::GameEntry::compatAsString() const
 void GameDatabase::parseAndInsert(const std::string_view serial, const ryml::NodeRef& node)
 {
 	GameDatabaseSchema::GameEntry gameEntry;
+
+	if (node.has_child("bootprog")) node["bootprog"] >> gameEntry.arcade.bootprog;
+	if (node.has_child("media")) node["media"] >> gameEntry.arcade.media;
+	if (node.has_child("input")) node["input"] >> gameEntry.arcade.input;
+
 	if (node.has_child("name"))
 	{
 		node["name"] >> gameEntry.name;

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -109,6 +109,11 @@ namespace GameDatabaseSchema
 		std::unordered_map<u32, std::string> patches;
 		std::vector<Patch::DynamicPatch> dynaPatches;
 
+		struct _arcade {
+			std::string bootprog;
+			std::string media;
+			std::string input;
+		}arcade;
 		// Returns the list of memory card serials as a `/` delimited string
 		std::string memcardFiltersAsString() const;
 		const std::string* findPatch(u32 crc) const;

--- a/pcsx2/GameList.cpp
+++ b/pcsx2/GameList.cpp
@@ -148,6 +148,7 @@ const char* GameList::RegionToString(Region region, bool translate)
 		TRANSLATE_NOOP("GameList", "PAL-UK"),
 		TRANSLATE_NOOP("GameList", "System246"),
 		TRANSLATE_NOOP("GameList", "System256"),
+		TRANSLATE_NOOP("GameList", "System SUPER256"),
 	};
 
 	const char* name = names.at(static_cast<int>(region));
@@ -192,6 +193,7 @@ const char* GameList::RegionToFlagFilename(Region region)
 		"gb",  // PAL-UK
 		"246B", // SYSTEM246
 		"256", // SYSTEM256
+		"256", // SYSTEM SUPER256 // TODOx6: make me an independent icon
 	};
 
 	return flag_names.at(static_cast<int>(region));
@@ -329,13 +331,29 @@ bool GameList::GetAcConfListEntry(const std::string& filename, GameList::Entry* 
 			
 		entry->path = filename;
 		entry->serial.clear();
-		entry->region = INI.GetStringValue("game", "platform") == "256" ? Region::SYSTEM256 : Region::SYSTEM246;
+		std::string_view s = INI.GetStringValue("game", "platform");
+		entry->region = Region::Other;
+		if (s == "246") entry->region = Region::SYSTEM246;
+		else if (s == "256") entry->region = Region::SYSTEM256;
+		else if (s == "super256") entry->region = Region::SYSTEMS256;
 		entry->type = EntryType::ARCADE;
 		entry->compatibility_rating = CompatibilityRating::Unknown;
 		entry->crc = 0x00000000;
 		entry->total_size = 0;
 		entry->title = INI.GetStringValue("game", "name");
 		entry->serial = INI.GetStringValue("game", "gameid");
+		if (!entry->serial.empty()) {
+			if (const GameDatabaseSchema::GameEntry* db_entry = GameDatabase::findGame(entry->serial)) {
+				if (entry->title.empty())
+					entry->title = db_entry->name;
+				if (entry->region == Region::Other) {
+					s = db_entry->region;
+					if (s == "System246") entry->region = Region::SYSTEM246;
+					else if (s == "System256") entry->region = Region::SYSTEM256;
+					else if (s == "System SUPER256") entry->region = Region::SYSTEMS256;
+				}
+			}
+		}
 
 	return true;
 }
@@ -442,6 +460,12 @@ GameList::Region GameList::ParseDatabaseRegion(const std::string_view db_region)
 		return Region::PAL_S;
 	else if (db_region.starts_with("PAL-UK"))
 		return Region::PAL_UK;
+	else if (db_region.starts_with("System246"))
+		return Region::SYSTEM246;
+	else if (db_region.starts_with("System256"))
+		return Region::SYSTEM256;
+	else if (db_region.starts_with("System Super256"))
+		return Region::SYSTEMS256;
 	else
 		return Region::Other;
 	// clang-format on

--- a/pcsx2/GameList.h
+++ b/pcsx2/GameList.h
@@ -68,6 +68,7 @@ namespace GameList
 		PAL_UK,
 		SYSTEM246,
 		SYSTEM256,
+		SYSTEMS256,
 		Count
 	};
 

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -198,7 +198,6 @@ static u32 s_frame_advance_count = 0;
 static bool s_fast_boot_requested = false;
 static bool s_gs_open_on_initialize = false;
 static bool s_thread_affinities_set = false;
-static bool s_acgame_sys246 = false;
 static bool s_acgame_sys256 = false;
 
 static LimiterModeType s_limiter_mode = LimiterModeType::Nominal;
@@ -1367,8 +1366,6 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				std::string subdir = INI.GetStringValue("data", "subdir", s_serial.c_str());
 				if (subdir != "") basedir = Path::AppendDirectory(basedir, subdir);
 				Console.WriteLnFmt(Color_Green, "ACGAME: basedir:'{}'", basedir);
-
-
 				s_acmedia = INI.GetStringValue("data", "media");
 				s_imgname = INI.GetStringValue("data", "mediasrc", fmt::format("{}.chd", s_serial).c_str());
 				ArcadeiLinkID = INI.GetStringValue("data", "256Region", "");
@@ -1380,10 +1377,28 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				s_title = INI.GetStringValue("game", "name");
 
 				ACJV::SetGameId(s_title); // Adapt JVS input to detected GAMEID
-				std::string platform = INI.GetStringValue("game", "platform", "246");
-				s_acgame_sys246 = (platform == "246" || platform == "256" || platform == "super256");
-				s_acgame_sys256 = (platform == "256" || platform == "super256");
-				PS2CLK = (platform == "super256") ? PS2CLK_SS256 : ((platform == "256") ? PS2CLK_S256 : PS2CLK_DEFAULT);
+				std::string platform = INI.GetStringValue("game", "platform", "");
+				if (platform.empty()) {
+					if (const GameDatabaseSchema::GameEntry* db_entry = GameDatabase::findGame(s_serial)) {
+						std::string_view s = db_entry->region;
+						if (s == "System246") {
+							PS2CLK = PS2CLK_DEFAULT;
+							s_acgame_sys256 = false;
+						} else if (s == "System256") {
+							PS2CLK = PS2CLK_S256;
+							s_acgame_sys256 = true;
+						} else if (s == "System SUPER256") {
+							PS2CLK = PS2CLK_SS256;
+							s_acgame_sys256 = true;
+						} else {
+							Error::SetString(error, TRANSLATE_STR("VMManager", "game platform parameter is missing from both acgame and gameDB"));
+							return false;
+						}
+					}
+				} else {
+					s_acgame_sys256 = (platform == "256" || platform == "super256");
+					PS2CLK = (platform == "super256") ? PS2CLK_SS256 : ((platform == "256") ? PS2CLK_S256 : PS2CLK_DEFAULT);
+				}
 				if (PS2CLK != PS2CLK_DEFAULT)
 					Console.WriteLnFmt(Color_Green, "ACGAME: System {} requested — overclock will be applied", platform);
 
@@ -1715,8 +1730,7 @@ VMBootResult VMManager::Initialize(const VMBootParameters& boot_params, Error* e
 	s_cpu_implementation_changed = false;
 	UpdateCPUImplementations();
 	mmap_ResetBlockTracking();
-	if (s_acgame_sys246)
-		EmuConfig.Cpu.ExtraMemory = true;
+	EmuConfig.Cpu.ExtraMemory = true;
 	if (s_acgame_sys256)
 	{
 		s_sys256_mode = true;

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1410,7 +1410,7 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 						}
 					}
 					if (s_title.empty() && !db_entry->name.empty()) {
-						s_acmedia = db_entry->name;
+						s_title = db_entry->name;
 					}
 				}
 

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1353,22 +1353,8 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				return false;
 			} else {
 				Console.WriteLn(Color_Green, "# ARCADE GAME CONFIG FILE DETECTED");
-				std::string basedir = Path::ToNativePath(Path::GetDirectory(filename))+FS_OSPATH_SEPARATOR_CHARACTER;
-				std::string subdir = INI.GetStringValue("data", "subdir");
-				if (subdir != "") basedir = Path::AppendDirectory(basedir, subdir);
-				Console.WriteLnFmt(Color_Green, "ACGAME: basedir:'{}'", basedir);
 				std::string s_acmedia, s_imgname, s_serial;
-				s_acmedia = INI.GetStringValue("data", "media");
-				s_imgname = INI.GetStringValue("data", "mediasrc");
-				ArcadeiLinkID = INI.GetStringValue("data", "256Region", "");
-				if (!ArcadeiLinkID.empty() &&
-					(ArcadeiLinkID != "ASIA4" && ArcadeiLinkID != "ASIA5" && ArcadeiLinkID != "JAPAN")) {
-					Error::SetStringFmt(error, "Invalid SYSTEM256 regional signature override! '{}'", ArcadeiLinkID);
-					return false;
-				} else Console.WriteLnFmt(Color_Green, "system256 Region: changing iLinkID to {}", ArcadeiLinkID);
-				s_title = s_serial = INI.GetStringValue("game", "name");
-				s_arcade_gameid = s_disc_serial = s_serial = INI.GetStringValue("game", "gameid");
-				s_acgame_serial = s_serial;
+				s_acgame_serial = s_arcade_gameid = s_disc_serial = s_serial = INI.GetStringValue("game", "gameid");
 				bool idvalid = (s_serial.length() == 7 && (s_serial[0] == 'N' && s_serial[1] == 'M'));
     			for (int i = 2; idvalid && i < 7; i++)
     			    idvalid = (s_serial[i] >= '0' && s_serial[i] <= '9');
@@ -1377,18 +1363,29 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 					return false;
 				}
 
-				ACJV::SetGameId(s_serial); // Adapt JVS input to detected GAMEID
-				std::string platform = INI.GetStringValue("game", "platform", "");
+				std::string basedir = Path::ToNativePath(Path::GetDirectory(filename))+FS_OSPATH_SEPARATOR_CHARACTER;
+				std::string subdir = INI.GetStringValue("data", "subdir", s_serial.c_str());
+				if (subdir != "") basedir = Path::AppendDirectory(basedir, subdir);
+				Console.WriteLnFmt(Color_Green, "ACGAME: basedir:'{}'", basedir);
+
+
+				s_acmedia = INI.GetStringValue("data", "media");
+				s_imgname = INI.GetStringValue("data", "mediasrc", fmt::format("{}.chd", s_serial).c_str());
+				ArcadeiLinkID = INI.GetStringValue("data", "256Region", "");
+				if (!ArcadeiLinkID.empty() &&
+					(ArcadeiLinkID != "ASIA4" && ArcadeiLinkID != "ASIA5" && ArcadeiLinkID != "JAPAN")) {
+					Error::SetStringFmt(error, "Invalid SYSTEM256 regional signature override! '{}'", ArcadeiLinkID);
+					return false;
+				} else Console.WriteLnFmt(Color_Green, "system256 Region: changing iLinkID to {}", ArcadeiLinkID);
+				s_title = INI.GetStringValue("game", "name");
+
+				ACJV::SetGameId(s_title); // Adapt JVS input to detected GAMEID
+				std::string platform = INI.GetStringValue("game", "platform", "246");
 				s_acgame_sys246 = (platform == "246" || platform == "256" || platform == "super256");
 				s_acgame_sys256 = (platform == "256" || platform == "super256");
-				if (platform == "super256")
-					PS2CLK = PS2CLK_SS256;
-				else if (s_acgame_sys256)
-					PS2CLK = PS2CLK_S256;
-				if (s_acgame_sys256)
-				{
+				PS2CLK = (platform == "super256") ? PS2CLK_SS256 : ((platform == "256") ? PS2CLK_S256 : PS2CLK_DEFAULT);
+				if (PS2CLK != PS2CLK_DEFAULT)
 					Console.WriteLnFmt(Color_Green, "ACGAME: System {} requested — overclock will be applied", platform);
-				}
 
 				// When subdir= is set, basedir points to the subdir (e.g. roms/tekken4/).
 				// Dongle/card files may live elsewhere, so fall back to acgame dir and memcards/.
@@ -1396,27 +1393,23 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				std::string card;
 				// Slot 1 (mc0:) = dongle (boot modules only, no save data).
 				// Always overwrite — DONGLEMAN corrupts this file at runtime.
-				if ((card = INI.GetStringValue("data", "dongle", "")) != "") {
-					std::string src = Path::Combine(basedir, card);
-					if (!FileSystem::FileExists(src.c_str()))
-						src = Path::Combine(acgamedir, card);
-					if (!FileSystem::FileExists(src.c_str()))
-						src = Path::Combine(Path::Combine(acgamedir, "memcards"), card);
-					std::string dst = Path::Combine(EmuFolders::MemoryCards, card);
-					if (FileSystem::FileExists(src.c_str()))
-						FileSystem::CopyFilePath(src.c_str(), dst.c_str(), true);
+				if ((card = INI.GetStringValue("data", "dongle", fmt::format("{}.ps2", s_serial).c_str())) != "") {
+					std::string src = Path::Combine(EmuFolders::MemoryCards, card);
+					if (!FileSystem::FileExists(src.c_str())) {
+						Error::SetStringFmt(error, "requested dongle image does not exist! '{}'", card);
+						Console.ErrorFmt("ACGAME: cannot open a dongle file at location '{}'", src);
+						return false;
+					}
 					Host::SetBaseStringSettingValue("MemoryCards", "Slot1_Filename", card.c_str());
 				}
 				// Slot 2 (mc1:) = save card (e.g. SC2 conquest). Never overwrite existing saves.
 				if ((card = INI.GetStringValue("data", "card", "")) != "") {
-					std::string src = Path::Combine(basedir, card);
-					if (!FileSystem::FileExists(src.c_str()))
-						src = Path::Combine(acgamedir, card);
-					if (!FileSystem::FileExists(src.c_str()))
-						src = Path::Combine(Path::Combine(acgamedir, "memcards"), card);
-					std::string dst = Path::Combine(EmuFolders::MemoryCards, card);
-					if (FileSystem::FileExists(src.c_str()) && !FileSystem::FileExists(dst.c_str()))
-						FileSystem::CopyFilePath(src.c_str(), dst.c_str(), false);
+					std::string src = Path::Combine(EmuFolders::MemoryCards, card);
+					if (!FileSystem::FileExists(src.c_str())) {
+						Error::SetStringFmt(error, "requested memcard image does not exist! '{}'", card);
+						Console.ErrorFmt("ACGAME: cannot open a card file at location '{}'", src);
+						return false;
+					}
 					Host::SetBaseStringSettingValue("MemoryCards", "Slot2_Filename", card.c_str());
 				}
 				/// TODOx6: Decide if we want to lock mc1 access if .ACGAME does not ask for it
@@ -1454,7 +1447,7 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				ACATA::SetEnv(basedir, s_imgname, s_acmedia);
 				int R;
 				if ((R = ACATA::TH::IO_OpenImage())!=0) {
-					Error::SetString(error, std::string("cannot open arcade media image"));
+					Error::SetStringFmt(error, "cannot open arcade media image {}", ACATA::imgpath);
 					return false;
 				}
 				if (s_acmedia == "CD" && !ACATA::imgpath.empty()) {

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -1369,17 +1369,21 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				s_acmedia = INI.GetStringValue("data", "media");
 				s_imgname = INI.GetStringValue("data", "mediasrc", fmt::format("{}.chd", s_serial).c_str());
 				ArcadeiLinkID = INI.GetStringValue("data", "256Region", "");
-				if (!ArcadeiLinkID.empty() &&
-					(ArcadeiLinkID != "ASIA4" && ArcadeiLinkID != "ASIA5" && ArcadeiLinkID != "JAPAN")) {
-					Error::SetStringFmt(error, "Invalid SYSTEM256 regional signature override! '{}'", ArcadeiLinkID);
-					return false;
-				} else Console.WriteLnFmt(Color_Green, "system256 Region: changing iLinkID to {}", ArcadeiLinkID);
+				if (!ArcadeiLinkID.empty()) {
+					if (ArcadeiLinkID != "ASIA4" && ArcadeiLinkID != "ASIA5" && ArcadeiLinkID != "JAPAN") {
+						Error::SetStringFmt(error, "Invalid SYSTEM256 regional signature override! '{}'", ArcadeiLinkID);
+						return false;
+					} else
+						Console.WriteLnFmt(Color_Green, "system256 Region: changing iLinkID to {}", ArcadeiLinkID);
+				}
 				s_title = INI.GetStringValue("game", "name");
 
-				ACJV::SetGameId(s_title); // Adapt JVS input to detected GAMEID
+				ACJV::SetGameId(s_serial); // Adapt JVS input to detected GAMEID
 				std::string platform = INI.GetStringValue("game", "platform", "");
-				if (platform.empty()) {
-					if (const GameDatabaseSchema::GameEntry* db_entry = GameDatabase::findGame(s_serial)) {
+
+				
+				if (const GameDatabaseSchema::GameEntry* db_entry = GameDatabase::findGame(s_serial)) {
+					if (platform.empty()) {
 						std::string_view s = db_entry->region;
 						if (s == "System246") {
 							PS2CLK = PS2CLK_DEFAULT;
@@ -1391,14 +1395,25 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 							PS2CLK = PS2CLK_SS256;
 							s_acgame_sys256 = true;
 						} else {
-							Error::SetString(error, TRANSLATE_STR("VMManager", "game platform parameter is missing from both acgame and gameDB"));
+							Error::SetString(error, TRANSLATE_STR("VMManager", "Cannot resolve platform variant"));
+							return false;
+						}
+					} else {
+						s_acgame_sys256 = (platform == "256" || platform == "super256");
+						PS2CLK = (platform == "super256") ? PS2CLK_SS256 : ((platform == "256") ? PS2CLK_S256 : PS2CLK_DEFAULT);
+					}
+					if (s_acmedia.empty()) {
+						s_acmedia = db_entry->arcade.media;
+						if (s_acmedia.empty()) {
+							Error::SetString(error, TRANSLATE_STR("VMManager", "Cannot resolve media type"));
 							return false;
 						}
 					}
-				} else {
-					s_acgame_sys256 = (platform == "256" || platform == "super256");
-					PS2CLK = (platform == "super256") ? PS2CLK_SS256 : ((platform == "256") ? PS2CLK_S256 : PS2CLK_DEFAULT);
+					if (s_title.empty() && !db_entry->name.empty()) {
+						s_acmedia = db_entry->name;
+					}
 				}
+
 				if (PS2CLK != PS2CLK_DEFAULT)
 					Console.WriteLnFmt(Color_Green, "ACGAME: System {} requested — overclock will be applied", platform);
 
@@ -1433,7 +1448,7 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				// ---> else Host::SetBaseBoolSettingValue("MemoryCards", "Slot2_Enable", false);
 
 				//FileMcd_Reopen(s_serial);
-				s_elf_override = Path::Combine(basedir, INI.GetStringValue("data", "elf"));
+				s_elf_override = Path::Combine(basedir, INI.GetStringValue("data", "elf", "boot.elf"));
 				EmuConfig.CurrentGameArgs = INI.GetStringValue("data", "args");
 				ACSRAM::filepath = Path::Combine(basedir, INI.GetStringValue("data", "sram", "sram.bin"));
 				// JVS device mode: an explicit jvsmode= in the .acgame overrides (force/legacy); otherwise it is


### PR DESCRIPTION
arcade gameID will be used to generate more default values, allowing to resolve absence of more entries on the acgame:
- `subdir`: now will always default to the arcade gameID
- game media: image name will default to `GAMEID.chd`
- `dongle`: image will default to `GAMEID.ps2`
- `platform`: now both the VM overclock support and icon detection for the gamelist will be resolved with gameDB if the acgame does not specify them