### PR TITLE
Input: RawInput multi-mouse source (Windows)

### DIFF
--- a/pcsx2-qt/DisplayWidget.cpp
+++ b/pcsx2-qt/DisplayWidget.cpp
@@ -68,8 +68,8 @@ std::optional<WindowInfo> DisplaySurface::getWindowInfo()
 void DisplaySurface::updateRelativeMode(bool enabled)
 {
 #ifdef _WIN32
-	// prefer ClipCursor() over warping movement when we're using raw input
-	bool clip_cursor = enabled && false /*InputManager::IsUsingRawInput()*/;
+	// clip the system cursor to the window while RawInput drives the guns
+	bool clip_cursor = enabled && InputManager::IsUsingRawInput();
 	if (m_relative_mouse_enabled == enabled && m_clip_mouse_enabled == clip_cursor)
 		return;
 
@@ -304,12 +304,16 @@ bool DisplaySurface::event(QEvent* event)
 
 			if (!m_relative_mouse_enabled)
 			{
-				const qreal dpr = devicePixelRatio();
-				const QPoint mouse_pos = mouse_event->pos();
+				// with RawInput active, per-device positions come from WM_INPUT, so don't overwrite them
+				if (!InputManager::IsUsingRawInput())
+				{
+					const qreal dpr = devicePixelRatio();
+					const QPoint mouse_pos = mouse_event->pos();
 
-				const float scaled_x = static_cast<float>(static_cast<qreal>(mouse_pos.x()) * dpr);
-				const float scaled_y = static_cast<float>(static_cast<qreal>(mouse_pos.y()) * dpr);
-				InputManager::UpdatePointerAbsolutePosition(0, scaled_x, scaled_y);
+					const float scaled_x = static_cast<float>(static_cast<qreal>(mouse_pos.x()) * dpr);
+					const float scaled_y = static_cast<float>(static_cast<qreal>(mouse_pos.y()) * dpr);
+					InputManager::UpdatePointerAbsolutePosition(0, scaled_x, scaled_y);
+				}
 			}
 			else
 			{
@@ -350,11 +354,15 @@ bool DisplaySurface::event(QEvent* event)
 		{
 			if (const u32 button_mask = static_cast<u32>(static_cast<const QMouseEvent*>(event)->button()))
 			{
-				Host::RunOnCPUThread([button_index = std::countr_zero(button_mask),
-										 pressed = (event->type() != QEvent::MouseButtonRelease)]() {
-					InputManager::InvokeEvents(
-						InputManager::MakePointerButtonKey(0, button_index), static_cast<float>(pressed));
-				});
+				// with RawInput active, per-device buttons come from WM_INPUT, so don't duplicate them
+				if (!InputManager::IsUsingRawInput())
+				{
+					Host::RunOnCPUThread([button_index = std::countr_zero(button_mask),
+											 pressed = (event->type() != QEvent::MouseButtonRelease)]() {
+						InputManager::InvokeEvents(
+							InputManager::MakePointerButtonKey(0, button_index), static_cast<float>(pressed));
+					});
+				}
 			}
 
 			// don't toggle fullscreen when we're bound.. that wouldn't end well.

--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -61,6 +61,8 @@
 
 #ifdef _WIN32
 #include "common/RedtapeWindows.h"
+#include "pcsx2/Input/InputSource.h"
+#include "pcsx2/Input/RawInputSource.h"
 #include <Dbt.h>
 #endif
 
@@ -2496,6 +2498,18 @@ bool MainWindow::nativeEvent(const QByteArray& eventType, void* message, qintptr
 				if (GetRawInputData((HRAWINPUT)msg->lParam, RID_INPUT, lpb.data(), &dwSize, sizeof(RAWINPUTHEADER)) == dwSize)
 				{
 					const RAWINPUT* raw = reinterpret_cast<const RAWINPUT*>(lpb.data());
+
+					// dispatch to RawInputSource for per-device tracking
+					InputSource* raw_source = InputManager::GetInputSourceInterface(InputSourceType::RawInput);
+					if (raw_source && raw_source->IsInitialized())
+					{
+						HWND render_hwnd = m_display_surface ?
+							reinterpret_cast<HWND>(m_display_surface->winId()) : static_cast<HWND>(nullptr);
+						pxAssertMsg(dynamic_cast<RawInputSource*>(raw_source), "Expected RawInputSource");
+						static_cast<RawInputSource*>(raw_source)->ProcessRawInput(raw, render_hwnd);
+					}
+
+					// system-cursor lock/clamp, always active
 					if (raw->header.dwType == RIM_TYPEMOUSE)
 					{
 						const RAWMOUSE& mouse = raw->data.mouse;

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.cpp
@@ -52,6 +52,7 @@ ControllerGlobalSettingsWidget::ControllerGlobalSettingsWidget(QWidget* parent, 
 #ifdef _WIN32
 	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(sif, m_ui.enableXInputSource, "InputSources", "XInput", false);
 	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(sif, m_ui.enableDInputSource, "InputSources", "DInput", false);
+	ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(sif, m_ui.enableRawInputSource, "InputSources", "RawInput", false);
 #else
 	m_ui.mainLayout->removeWidget(m_ui.xinputGroup);
 	m_ui.xinputGroup->deleteLater();
@@ -59,6 +60,9 @@ ControllerGlobalSettingsWidget::ControllerGlobalSettingsWidget(QWidget* parent, 
 	m_ui.mainLayout->removeWidget(m_ui.dinputGroup);
 	m_ui.dinputGroup->deleteLater();
 	m_ui.dinputGroup = nullptr;
+	m_ui.mainLayout->removeWidget(m_ui.rawinputGroup);
+	m_ui.rawinputGroup->deleteLater();
+	m_ui.rawinputGroup = nullptr;
 #endif
 
 	if (dialog->isEditingProfile())
@@ -84,6 +88,11 @@ ControllerGlobalSettingsWidget::ControllerGlobalSettingsWidget(QWidget* parent, 
 }
 
 ControllerGlobalSettingsWidget::~ControllerGlobalSettingsWidget() = default;
+
+void ControllerGlobalSettingsWidget::clearDeviceList()
+{
+	m_ui.deviceList->clear();
+}
 
 void ControllerGlobalSettingsWidget::addDeviceToList(const QString& identifier, const QString& name)
 {

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.h
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.h
@@ -25,6 +25,7 @@ public:
 	ControllerGlobalSettingsWidget(QWidget* parent, ControllerSettingsWindow* dialog);
 	~ControllerGlobalSettingsWidget();
 
+	void clearDeviceList();
 	void addDeviceToList(const QString& identifier, const QString& name);
 	void removeDeviceFromList(const QString& identifier);
 

--- a/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
+++ b/pcsx2-qt/Settings/ControllerGlobalSettingsWidget.ui
@@ -72,6 +72,35 @@
      </layout>
     </widget>
    </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="rawinputGroup">
+     <property name="title">
+      <string>Raw Input Source</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_rawinput">
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label_rawinput">
+        <property name="text">
+         <string>The Raw Input source enables per-device tracking for absolute positioning devices (e.g.: light guns). When enabled, each device is tracked independently, allowing multi-player support with separate input per port.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextBrowserInteraction</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="enableRawInputSource">
+        <property name="text">
+         <string>Enable Raw Input Source</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="3" column="0">
     <widget class="QGroupBox" name="dinputGroup">
      <property name="title">
@@ -312,6 +341,7 @@
   <tabstop>enableSDLMFIDriver</tabstop>
   <tabstop>enableXInputSource</tabstop>
   <tabstop>enableDInputSource</tabstop>
+  <tabstop>enableRawInputSource</tabstop>
   <tabstop>enableMouseMapping</tabstop>
   <tabstop>mouseSettings</tabstop>
   <tabstop>multitapPort1</tabstop>

--- a/pcsx2-qt/Settings/ControllerSettingsWindow.cpp
+++ b/pcsx2-qt/Settings/ControllerSettingsWindow.cpp
@@ -278,6 +278,7 @@ void ControllerSettingsWindow::onRestoreDefaultsClicked()
 void ControllerSettingsWindow::onInputDevicesEnumerated(const QList<QPair<QString, QString>>& devices)
 {
 	m_device_list = devices;
+	m_global_settings->clearDeviceList(); // full enumeration replaces the list, it doesn't stack on it
 	for (const QPair<QString, QString>& device : devices)
 		m_global_settings->addDeviceToList(device.first, device.second);
 }

--- a/pcsx2-qt/Settings/InputBindingDialog.cpp
+++ b/pcsx2-qt/Settings/InputBindingDialog.cpp
@@ -85,8 +85,12 @@ bool InputBindingDialog::eventFilter(QObject* watched, QEvent* event)
 	else if (event_type == QEvent::MouseButtonPress || event_type == QEvent::MouseButtonDblClick)
 	{
 		// double clicks get triggered if we click bind, then click again quickly.
-		if (const u32 button_mask = static_cast<u32>(static_cast<const QMouseEvent*>(event)->button()))
-			m_new_bindings.push_back(InputManager::MakePointerButtonKey(0, std::countr_zero(button_mask)));
+		// with RawInput active, buttons arrive as per-device RawMouse events instead
+		if (!InputManager::IsUsingRawInput())
+		{
+			if (const u32 button_mask = static_cast<u32>(static_cast<const QMouseEvent*>(event)->button()))
+				m_new_bindings.push_back(InputManager::MakePointerButtonKey(0, std::countr_zero(button_mask)));
+		}
 		return true;
 	}
 	else if (event_type == QEvent::Wheel)

--- a/pcsx2-qt/Settings/InputBindingWidget.cpp
+++ b/pcsx2-qt/Settings/InputBindingWidget.cpp
@@ -123,8 +123,12 @@ bool InputBindingWidget::eventFilter(QObject* watched, QEvent* event)
 	else if (event_type == QEvent::MouseButtonPress || event_type == QEvent::MouseButtonDblClick)
 	{
 		// double clicks get triggered if we click bind, then click again quickly.
-		if (const u32 button_mask = static_cast<u32>(static_cast<const QMouseEvent*>(event)->button()))
-			m_new_bindings.push_back(InputManager::MakePointerButtonKey(0, std::countr_zero(button_mask)));
+		// with RawInput active, buttons arrive as per-device RawMouse events instead
+		if (!InputManager::IsUsingRawInput())
+		{
+			if (const u32 button_mask = static_cast<u32>(static_cast<const QMouseEvent*>(event)->button()))
+				m_new_bindings.push_back(InputManager::MakePointerButtonKey(0, std::countr_zero(button_mask)));
+		}
 		return true;
 	}
 	else if (event_type == QEvent::Wheel)

--- a/pcsx2-qt/Settings/JVSControlsWidget.cpp
+++ b/pcsx2-qt/Settings/JVSControlsWidget.cpp
@@ -653,18 +653,30 @@ static void populateAimCombo(QComboBox* combo, ControllerSettingsWindow* dialog,
 {
 	combo->blockSignals(true);
 	combo->clear();
-	for (u32 j = 0; j < InputManager::MAX_POINTER_DEVICES; j++)
+	// with RawInput, one entry per mouse; otherwise the single merged system pointer
+	const auto raw_mice = InputManager::EnumerateRawPointerDevices();
+	if (raw_mice.empty())
 	{
-		const QString name = (InputManager::MAX_POINTER_DEVICES == 1)
-			? JVSControlsWidget::tr("Mouse (system)") : QString::fromStdString(InputManager::GetPointerDeviceName(j));
-		combo->addItem(name, QString::fromStdString(InputManager::GetPointerDeviceName(j)));
+		combo->addItem(JVSControlsWidget::tr("Mouse (system)"), QString::fromStdString(InputManager::GetPointerDeviceName(0)));
+	}
+	else
+	{
+		for (const auto& [vidpid, display_name] : raw_mice)
+		{
+			const std::optional<u32> idx = InputManager::GetPointerIndexForRawDevice(vidpid);
+			if (idx.has_value())
+				combo->addItem(QString::fromStdString(display_name), QString::fromStdString(InputManager::GetPointerDeviceName(idx.value())));
+		}
 	}
 	for (const QPair<QString, QString>& dev : dialog->getDeviceList())
 	{
 		// Skip the "Mouse"/"Keyboard" pseudo-devices: no aim stick, and the mouse is already the pointer above.
 		if (dev.first == QLatin1String("Mouse") || dev.first == QLatin1String("Keyboard"))
 			continue;
-		combo->addItem(dev.second, dev.first);
+		// Raw mice are already listed above with their pointer slot.
+		if (dev.first.startsWith(QLatin1String("RawMouse-")))
+			continue;
+		combo->addItem(JVSControlsWidget::tr("%1 (Stick)").arg(dev.second), dev.first);
 	}
 	const int idx = combo->findData(current);
 	combo->setCurrentIndex((idx >= 0) ? idx : 0);
@@ -749,6 +761,16 @@ void JVSControlsWidget::buildLightgunPage()
 	};
 	makeAimCombo(1, "USB1");
 	makeAimCombo(2, "USB2");
+	QPushButton* refreshBtn = new QPushButton(tr("Refresh"), aimGroup);
+	connect(refreshBtn, &QPushButton::clicked, this, []() {
+		g_emu_thread->reloadInputDevices();
+		g_emu_thread->enumerateInputDevices(); // queued after the re-scan; onInputDevicesEnumerated repopulates the combos
+	});
+	ag->addWidget(refreshBtn, 1, 3);
+#ifdef _WIN32
+	m_rawInputStatus = new QLabel(aimGroup);
+	ag->addWidget(m_rawInputStatus, 2, 0, 1, 4);
+#endif
 	refreshAimDevices();
 	ag->setColumnStretch(0, 1);
 	QHBoxLayout* top = new QHBoxLayout();
@@ -925,6 +947,12 @@ void JVSControlsWidget::refreshAimDevices()
 	{
 		populateAimCombo(m_touchAimCombo, m_dialog, QString::fromStdString(m_dialog->getStringValue(
 			ACJV::CONFIG_SECTION, "TouchPointer", InputManager::GetPointerDeviceName(0).c_str())));
+	}
+	if (m_rawInputStatus)
+	{
+		m_rawInputStatus->setText(InputManager::IsUsingRawInput()
+			? QStringLiteral("%1 <b><span style='color:#2ecc71;'>ON</span></b>").arg(tr("Raw Input:"))
+			: QStringLiteral("%1 <b>OFF</b>").arg(tr("Raw Input:")));
 	}
 }
 

--- a/pcsx2-qt/Settings/JVSControlsWidget.h
+++ b/pcsx2-qt/Settings/JVSControlsWidget.h
@@ -14,6 +14,7 @@ class ControllerSettingsWindow;
 class QShowEvent;
 class QComboBox;
 class QVBoxLayout;
+class QLabel;
 struct InputBindingInfo;
 
 class JVSControlsWidget final : public QWidget
@@ -48,4 +49,5 @@ private:
 	std::string m_autoPickedGameId;
 	QComboBox* m_aimCombos[2] = {}; // [0] = USB1/P1, [1] = USB2/P2
 	QComboBox* m_touchAimCombo = nullptr;
+	QLabel* m_rawInputStatus = nullptr;
 };

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -899,10 +899,12 @@ if(WIN32)
 	list(APPEND pcsx2InputSources
 		Input/DInputSource.cpp
 		Input/XInputSource.cpp
+		Input/RawInputSource.cpp
 	)
 	list(APPEND pcsx2InputHeaders
 		Input/DInputSource.h
 		Input/XInputSource.h
+		Input/RawInputSource.h
 	)
 endif()
 

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -670,9 +670,15 @@ const GunMapping& ACJV::GetGunMapping()
 // Per-player lightgun aim source: shared mouse by default, or the player's own controller stick when its
 // Aim Device is set to the pad (GunCon2 has_relative_binds pushes that stick's screen pos here).
 static bool s_gunAimJoystick[JVS_PLAYER_COUNT] = {};
+static u32 s_gunPointerIndex[JVS_PLAYER_COUNT] = {};
 static float s_gunRelativeDX[JVS_PLAYER_COUNT] = {-1.0f, -1.0f};
 static float s_gunRelativeDY[JVS_PLAYER_COUNT] = {-1.0f, -1.0f};
 void ACJV::SetGunAimSource(u32 player, bool joystick) { if (player < JVS_PLAYER_COUNT) s_gunAimJoystick[player] = joystick; }
+void ACJV::SetGunPointerIndex(u32 player, u32 index)
+{
+	if (player < JVS_PLAYER_COUNT && index < InputManager::MAX_POINTER_DEVICES)
+		s_gunPointerIndex[player] = index;
+}
 void ACJV::SetGunRelativeAim(u32 player, float dx, float dy)
 {
 	if (player < JVS_PLAYER_COUNT) { s_gunRelativeDX[player] = dx; s_gunRelativeDY[player] = dy; }
@@ -694,21 +700,20 @@ void ACJV::SetGunOffscreenContour(float fraction) { s_gunContour = std::clamp(fr
 
 static void UpdateLightgunFromMouse()
 {
-	float mdx, mdy;
-	const auto& [mx, my] = InputManager::GetPointerAbsolutePosition(0);
-	GSTranslateWindowToDisplayCoordinates(mx, my, &mdx, &mdy);
-
 	constexpr float edge_margin = 0.01f;
 	const auto& gm = ACJV::GetGunMapping();
 	const bool camera = (gm.board == GunBoardModel::CameraVN);
 	const bool side_switch = (gm.board == GunBoardModel::SideSwitchTC4);
 	const bool two_tier = (gm.board == GunBoardModel::TwoTierTC3);
 	const bool unclamped = camera || side_switch || two_tier;
-	float udx = -1.0f, udy = -1.0f;
-	if (unclamped)
-		GSTranslateWindowToDisplayCoordinatesUnclamped(mx, my, &udx, &udy);
+	const bool raw_input = InputManager::IsUsingRawInput();
 	for (u32 p = 0; p < JVS_PLAYER_COUNT; p++)
 	{
+		float mdx = -1.0f, mdy = -1.0f, udx = -1.0f, udy = -1.0f;
+		const auto& [mx, my] = InputManager::GetPointerAbsolutePosition(raw_input ? s_gunPointerIndex[p] : 0);
+		GSTranslateWindowToDisplayCoordinates(mx, my, &mdx, &mdy);
+		if (unclamped)
+			GSTranslateWindowToDisplayCoordinatesUnclamped(mx, my, &udx, &udy);
 		const float dx = s_gunAimJoystick[p] ? s_gunRelativeDX[p] : (unclamped ? udx : mdx);
 		const float dy = s_gunAimJoystick[p] ? s_gunRelativeDY[p] : (unclamped ? udy : mdy);
 		if (camera)

--- a/pcsx2/DEV9/ACJV.h
+++ b/pcsx2/DEV9/ACJV.h
@@ -179,6 +179,7 @@ namespace ACJV {
     JVS_MODE ResolveModeFromGameId(const std::string& gameid); // device mode from the gameid alone; jvsmode= is an optional override
     void SetScreenPos(u16 x, u16 y);
     void SetGunAimSource(u32 player, bool joystick);        // lightgun aim source: false = shared mouse, true = player's stick
+    void SetGunPointerIndex(u32 player, u32 index);         // host pointer slot for the player's mouse aim (per-device with Raw Input)
     void SetGunRelativeAim(u32 player, float dx, float dy); // player's stick-driven screen position from the GunCon2 (display coords)
     void SetGunForceOffscreen(bool held);                   // force the camera-lost report (the pedal bind = manual reload on Vampire Night)
     void SetGunOffscreenContour(float fraction);            // width of the aim-beside-the-screen band at the window edge (0..0.05)

--- a/pcsx2/Input/InputManager.cpp
+++ b/pcsx2/Input/InputManager.cpp
@@ -5,6 +5,9 @@
 #include "ImGui/ImGuiManager.h"
 #include "Input/InputManager.h"
 #include "Input/InputSource.h"
+#ifdef _WIN32
+#include "Input/RawInputSource.h"
+#endif
 #include "SIO/Pad/Pad.h"
 #include "SIO/Sio.h"
 #include "USB/USB.h"
@@ -702,6 +705,7 @@ static std::array<const char*, static_cast<u32>(InputSourceType::Count)> s_input
 #ifdef _WIN32
 	"DInput",
 	"XInput",
+	"RawInput",
 #endif
 }};
 
@@ -729,6 +733,9 @@ bool InputManager::GetInputSourceDefaultEnabled(InputSourceType type)
 			return false;
 
 		case InputSourceType::XInput:
+			return false;
+
+		case InputSourceType::RawInput:
 			return false;
 #endif
 
@@ -1255,6 +1262,11 @@ bool InputManager::IsAxisHandler(const InputEventHandler& handler)
 
 bool InputManager::InvokeEvents(InputBindingKey key, float value, GenericInputBinding generic_key)
 {
+	// When RawInput is active, suppress all Pointer button events.
+	// These are duplicates of the per-device RawMouse events from the lightgun.
+	if (key.source_type == InputSourceType::Pointer && key.source_subtype == InputSubclass::PointerButton && IsUsingRawInput())
+		return false;
+
 	if (key.source_type == InputSourceType::Pointer && key.source_subtype == InputSubclass::PointerButton &&
 		key.source_index < MAX_POINTER_DEVICES && key.data < 32)
 	{
@@ -1525,6 +1537,41 @@ void InputManager::GenerateRelativeMouseEvents()
 			}
 		}
 	}
+}
+
+#ifdef _WIN32
+static RawInputSource* GetActiveRawInputSource()
+{
+	InputSource* source = InputManager::GetInputSourceInterface(InputSourceType::RawInput);
+	return (source && source->IsInitialized()) ? static_cast<RawInputSource*>(source) : nullptr;
+}
+#endif
+
+bool InputManager::IsUsingRawInput()
+{
+#ifdef _WIN32
+	return GetActiveRawInputSource() != nullptr;
+#else
+	return false;
+#endif
+}
+
+std::optional<u32> InputManager::GetPointerIndexForRawDevice(const std::string_view device_path)
+{
+#ifdef _WIN32
+	if (RawInputSource* source = GetActiveRawInputSource())
+		return source->GetPointerIndexForDevicePath(device_path);
+#endif
+	return std::nullopt;
+}
+
+std::vector<std::pair<std::string, std::string>> InputManager::EnumerateRawPointerDevices()
+{
+#ifdef _WIN32
+	if (RawInputSource* source = GetActiveRawInputSource())
+		return source->GetRawMouseDeviceList();
+#endif
+	return {};
 }
 
 std::pair<float, float> InputManager::GetPointerAbsolutePosition(u32 index)
@@ -1992,6 +2039,7 @@ void InputManager::UpdateInputSourceState(SettingsInterface& si, std::unique_loc
 #ifdef _WIN32
 #include "Input/DInputSource.h"
 #include "Input/XInputSource.h"
+#include "Input/RawInputSource.h"
 #endif
 
 void InputManager::ReloadSources(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock)
@@ -2000,5 +2048,6 @@ void InputManager::ReloadSources(SettingsInterface& si, std::unique_lock<std::mu
 #ifdef _WIN32
 	UpdateInputSourceState<DInputSource>(si, settings_lock, InputSourceType::DInput);
 	UpdateInputSourceState<XInputSource>(si, settings_lock, InputSourceType::XInput);
+	UpdateInputSourceState<RawInputSource>(si, settings_lock, InputSourceType::RawInput);
 #endif
 }

--- a/pcsx2/Input/InputManager.h
+++ b/pcsx2/Input/InputManager.h
@@ -27,6 +27,7 @@ enum class InputSourceType : u32
 #ifdef _WIN32
 	DInput,
 	XInput,
+	RawInput,
 #endif
 	Count,
 };
@@ -166,12 +167,12 @@ namespace InputManager
 	static constexpr double VIBRATION_UPDATE_INTERVAL_SECONDS = 0.5; // 500ms
 
 	/// Maximum number of host mouse devices.
-	static constexpr u32 MAX_POINTER_DEVICES = 1;
+	static constexpr u32 MAX_POINTER_DEVICES = 8;
 	static constexpr u32 MAX_POINTER_BUTTONS = 3;
 
-	/// Maximum number of software cursors. We allocate an extra two for USB devices with
-	/// positioning data from the controller instead of a mouse.
-	static constexpr u32 MAX_SOFTWARE_CURSORS = MAX_POINTER_BUTTONS + 2;
+	/// Maximum number of software cursors: one per pointer device, plus the relative-aim
+	/// slots (GunCon2 uses MAX_POINTER_DEVICES + port).
+	static constexpr u32 MAX_SOFTWARE_CURSORS = MAX_POINTER_DEVICES * 2;
 
 	/// Returns a pointer to the external input source class, if present.
 	InputSource* GetInputSourceInterface(InputSourceType type);
@@ -294,6 +295,15 @@ namespace InputManager
 	/// Zeros all vibration intensities. Call when pausing.
 	/// The pad vibration state will internally remain, so that when emulation is unpaused, the effect resumes.
 	void PauseVibration();
+
+	/// Returns true if the RawInput source is active (Windows multi-mouse).
+	bool IsUsingRawInput();
+
+	/// Returns the pointer index assigned to a raw device, or nullopt.
+	std::optional<u32> GetPointerIndexForRawDevice(const std::string_view device_path);
+
+	/// Returns raw pointer devices as (identity, display_name) pairs.
+	std::vector<std::pair<std::string, std::string>> EnumerateRawPointerDevices();
 
 	/// Reads absolute pointer position.
 	std::pair<float, float> GetPointerAbsolutePosition(u32 index);

--- a/pcsx2/Input/RawInputSource.cpp
+++ b/pcsx2/Input/RawInputSource.cpp
@@ -1,0 +1,596 @@
+// SPDX-FileCopyrightText: 2026 Tovarichtch
+// SPDX-License-Identifier: GPL-3.0+
+
+#ifdef _WIN32
+
+#include "Input/RawInputSource.h"
+#include "Input/InputManager.h"
+#include "common/Assertions.h"
+#include "common/Console.h"
+#include "common/StringUtil.h"
+
+#include "Host.h"
+
+#include "fmt/format.h"
+
+#include <algorithm>
+
+#include <hidsdi.h>
+
+RawInputSource::RawInputSource() = default;
+
+RawInputSource::~RawInputSource() = default;
+
+std::string RawInputSource::GetDeviceIdentifier(u32 index)
+{
+	return fmt::format("RawMouse-{}", index);
+}
+
+bool RawInputSource::Initialize(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock)
+{
+	settings_lock.unlock();
+	const std::optional<WindowInfo> toplevel_wi(Host::GetTopLevelWindowInfo());
+	settings_lock.lock();
+
+	if (!toplevel_wi.has_value() || toplevel_wi->type != WindowInfo::Type::Win32)
+	{
+		Console.Error("(RawInput) Missing top level window.");
+		return false;
+	}
+
+	m_hwnd = static_cast<HWND>(toplevel_wi->window_handle);
+
+	if (!EnumerateRawMice())
+	{
+		Console.Error("(RawInput) Failed to enumerate raw input devices.");
+		return false;
+	}
+
+	settings_lock.unlock();
+	AssignPointerIndices();
+	settings_lock.lock();
+	RebuildHandleMap();
+
+	m_initialized = true;
+
+	if (m_mice.empty())
+	{
+		Console.Warning("(RawInput) No mice found.");
+		return true;
+	}
+
+	Console.WriteLn("(RawInput) Initialized with %zu mice.", m_mice.size());
+	for (const auto& mouse : m_mice)
+	{
+		Console.WriteLn("  [pointer %u] %s", mouse.pointer_index, mouse.display_name.c_str());
+		Console.WriteLn("    path: %s", mouse.device_path.c_str());
+		InputManager::OnInputDeviceConnected(GetDeviceIdentifier(mouse.pointer_index), mouse.display_name);
+	}
+
+	return true;
+}
+
+void RawInputSource::UpdateSettings(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock)
+{
+}
+
+static std::string GetDisplayNameForDevice(const std::string& device_path, u32 index)
+{
+	std::string product_name;
+	const std::wstring wdevice_path = StringUtil::UTF8StringToWideString(device_path);
+	if (!wdevice_path.empty())
+	{
+		HANDLE hid_handle = CreateFileW(wdevice_path.c_str(), 0,
+			FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr);
+		if (hid_handle != INVALID_HANDLE_VALUE)
+		{
+			wchar_t product_string[256] = {};
+			if (HidD_GetProductString(hid_handle, product_string, sizeof(product_string)) && product_string[0] != L'\0')
+				product_name = StringUtil::WideStringToUTF8String(product_string);
+			CloseHandle(hid_handle);
+		}
+	}
+
+	std::string tag; // static VID:PID tag to tell apart same-named devices
+	const size_t vid_pos = device_path.find("VID_");
+	const size_t pid_pos = device_path.find("PID_");
+	if (vid_pos != std::string::npos && vid_pos + 8 <= device_path.size() &&
+		pid_pos != std::string::npos && pid_pos + 8 <= device_path.size())
+		tag = fmt::format("[{}:{}]", device_path.substr(vid_pos + 4, 4), device_path.substr(pid_pos + 4, 4));
+
+	if (!product_name.empty())
+		return tag.empty() ? fmt::format("{} (Mouse {})", product_name, index) :
+							 fmt::format("{} {} (Mouse {})", product_name, tag, index);
+	if (!tag.empty())
+		return fmt::format("Mouse {} {}", index, tag);
+
+	return fmt::format("Mouse {}", index);
+}
+
+static std::string ExtractVidPid(const std::string& device_path)
+{
+	// Extract "VID_XXXX&PID_XXXX" from a HID device path for port-independent matching.
+	const size_t vid_pos = device_path.find("VID_");
+	const size_t pid_pos = device_path.find("PID_");
+	if (vid_pos == std::string::npos || pid_pos == std::string::npos)
+		return {};
+	const std::string vid = (vid_pos + 8 <= device_path.size()) ? device_path.substr(vid_pos, 8) : "";
+	const std::string pid = (pid_pos + 8 <= device_path.size()) ? device_path.substr(pid_pos, 8) : "";
+	if (vid.empty() || pid.empty())
+		return {};
+	return vid + "&" + pid; // "VID_XXXX&PID_XXXX"
+}
+
+static std::string GetDeviceIdentity(const std::string& device_path)
+{
+	// VID+PID when the path has one (survives port changes); otherwise the full path (I2C/Bluetooth/PS2).
+	const std::string vidpid = ExtractVidPid(device_path);
+	return vidpid.empty() ? device_path : vidpid;
+}
+
+static u32 FindStoredSlot(const std::string& identity)
+{
+	for (u32 slot = 0; slot < InputManager::MAX_POINTER_DEVICES; slot++)
+	{
+		if (Host::GetBaseStringSettingValue("RawInput", fmt::format("Pointer{}Device", slot).c_str(), "") == identity)
+			return slot;
+	}
+	return InputManager::MAX_POINTER_DEVICES;
+}
+
+bool RawInputSource::ReloadDevices()
+{
+	// Re-enumerate raw mice. Match new HANDLEs to existing device_paths
+	// so that pointer_index stays stable mid-session.
+	std::lock_guard<std::mutex> guard(m_mice_mutex);
+
+	UINT device_count = 0;
+	if (GetRawInputDeviceList(nullptr, &device_count, sizeof(RAWINPUTDEVICELIST)) == static_cast<UINT>(-1))
+		return false;
+
+	std::vector<RAWINPUTDEVICELIST> device_list(device_count);
+	if (GetRawInputDeviceList(device_list.data(), &device_count, sizeof(RAWINPUTDEVICELIST)) == static_cast<UINT>(-1))
+		return false;
+
+	// Fresh enumeration keyed by full device path: unique per physical port, so twin devices
+	// sharing a VID+PID and devices without one (I2C touchpads, Bluetooth) can't collide.
+	std::unordered_map<std::string, HANDLE> new_devices;
+	for (UINT i = 0; i < device_count; i++)
+	{
+		if (device_list[i].dwType != RIM_TYPEMOUSE)
+			continue;
+
+		UINT name_size = 0;
+		GetRawInputDeviceInfoW(device_list[i].hDevice, RIDI_DEVICENAME, nullptr, &name_size);
+		if (name_size == 0)
+			continue;
+
+		std::wstring wpath(name_size, L'\0');
+		if (GetRawInputDeviceInfoW(device_list[i].hDevice, RIDI_DEVICENAME, wpath.data(), &name_size) == static_cast<UINT>(-1))
+			continue;
+
+		while (!wpath.empty() && wpath.back() == L'\0')
+			wpath.pop_back();
+
+		std::string path = StringUtil::WideStringToUTF8String(wpath);
+		if (!path.empty())
+			new_devices[std::move(path)] = device_list[i].hDevice;
+	}
+
+	// Update existing mice. Exact path first (same port), then VID+PID on another path
+	// (replugged elsewhere); path goes first so twins can't steal each other's port match.
+	bool changed = false;
+	std::vector<bool> matched(m_mice.size(), false);
+	for (size_t m = 0; m < m_mice.size(); m++)
+	{
+		const auto it = new_devices.find(m_mice[m].device_path);
+		if (it == new_devices.end())
+			continue;
+		m_mice[m].handle = it->second;
+		matched[m] = true;
+		new_devices.erase(it);
+	}
+	for (size_t m = 0; m < m_mice.size(); m++)
+	{
+		if (matched[m])
+			continue;
+		const std::string vidpid = ExtractVidPid(m_mice[m].device_path);
+		if (vidpid.empty())
+			continue;
+		const auto it = std::find_if(new_devices.begin(), new_devices.end(),
+			[&](const auto& d) { return ExtractVidPid(d.first) == vidpid; });
+		if (it == new_devices.end())
+			continue;
+		m_mice[m].handle = it->second;
+		m_mice[m].device_path = it->first;
+		matched[m] = true;
+		new_devices.erase(it);
+		Console.WriteLn("(RawInput) Updated handle for pointer %u (%s).", m_mice[m].pointer_index, m_mice[m].display_name.c_str());
+	}
+	for (size_t m = m_mice.size(); m-- > 0;)
+	{
+		if (matched[m])
+			continue;
+		Console.WriteLn("(RawInput) Device removed: pointer %u (%s).", m_mice[m].pointer_index, m_mice[m].display_name.c_str());
+		const InputBindingKey key = MakeGenericControllerButtonKey(InputSourceType::RawInput, m_mice[m].pointer_index, 0);
+		InputManager::OnInputDeviceDisconnected(key, GetDeviceIdentifier(m_mice[m].pointer_index));
+		m_mice.erase(m_mice.begin() + m);
+		changed = true;
+	}
+
+	// Any remaining entries are newly connected devices.
+	for (const auto& [path, handle] : new_devices)
+	{
+		if (m_mice.size() >= InputManager::MAX_POINTER_DEVICES)
+			break;
+
+		// Saved slot if free (restores assignment after full disconnect/reconnect), else first free.
+		const u32 preferred_slot = FindStoredSlot(GetDeviceIdentity(path));
+		u32 taken_mask = 0;
+		for (const auto& m : m_mice)
+			if (m.pointer_index < InputManager::MAX_POINTER_DEVICES)
+				taken_mask |= (1u << m.pointer_index);
+
+		u32 assigned_slot;
+		if (preferred_slot < InputManager::MAX_POINTER_DEVICES && !(taken_mask & (1u << preferred_slot)))
+		{
+			assigned_slot = preferred_slot;
+		}
+		else
+		{
+			assigned_slot = static_cast<u32>(std::countr_zero(~taken_mask));
+			if (assigned_slot >= InputManager::MAX_POINTER_DEVICES)
+				break;
+		}
+
+		RawMouseDevice dev;
+		dev.handle = handle;
+		dev.device_path = path;
+		dev.display_name = GetDisplayNameForDevice(path, assigned_slot);
+		dev.pointer_index = assigned_slot;
+		dev.button_state = 0;
+
+		Console.WriteLn("(RawInput) New device: pointer %u (%s).", dev.pointer_index, dev.display_name.c_str());
+		InputManager::OnInputDeviceConnected(GetDeviceIdentifier(dev.pointer_index), dev.display_name);
+		m_mice.push_back(std::move(dev));
+		changed = true;
+	}
+
+	RebuildHandleMap();
+	return changed;
+}
+
+void RawInputSource::Shutdown()
+{
+	std::lock_guard<std::mutex> guard(m_mice_mutex);
+	for (const auto& mouse : m_mice)
+	{
+		const InputBindingKey key = MakeGenericControllerButtonKey(InputSourceType::RawInput, mouse.pointer_index, 0);
+		InputManager::OnInputDeviceDisconnected(key, GetDeviceIdentifier(mouse.pointer_index));
+	}
+
+	m_mice.clear();
+	m_handle_to_mouse_index.clear();
+	m_hwnd = nullptr;
+	m_initialized = false;
+}
+
+bool RawInputSource::IsInitialized()
+{
+	return m_initialized;
+}
+
+void RawInputSource::PollEvents()
+{
+	// Events arrive via MainWindow::nativeEvent -> ProcessRawInput.
+}
+
+std::vector<std::pair<std::string, std::string>> RawInputSource::EnumerateDevices()
+{
+	std::vector<std::pair<std::string, std::string>> devices;
+	for (const auto& mouse : m_mice)
+		devices.emplace_back(GetDeviceIdentifier(mouse.pointer_index), mouse.display_name);
+	return devices;
+}
+
+std::vector<InputBindingKey> RawInputSource::EnumerateMotors()
+{
+	return {};
+}
+
+bool RawInputSource::GetGenericBindingMapping(const std::string_view device, InputManager::GenericInputBindingMapping* mapping)
+{
+	return false;
+}
+
+InputLayout RawInputSource::GetControllerLayout(u32 index)
+{
+	return InputLayout::Unknown;
+}
+
+void RawInputSource::UpdateMotorState(InputBindingKey key, float intensity)
+{
+}
+
+void RawInputSource::UpdateMotorState(InputBindingKey large_key, InputBindingKey small_key, float large_intensity, float small_intensity)
+{
+}
+
+std::optional<InputBindingKey> RawInputSource::ParseKeyString(const std::string_view device, const std::string_view binding)
+{
+	if (!device.starts_with("RawMouse-") || binding.empty())
+		return std::nullopt;
+
+	const std::optional<s32> device_index = StringUtil::FromChars<s32>(device.substr(9));
+	if (!device_index.has_value() || device_index.value() < 0)
+		return std::nullopt;
+
+	InputBindingKey key = {};
+	key.source_type = InputSourceType::RawInput;
+	key.source_index = static_cast<u32>(device_index.value());
+
+	for (u32 i = 0; i < NUM_BUTTONS; i++)
+	{
+		if (binding == s_button_names[i])
+		{
+			key.source_subtype = InputSubclass::ControllerButton;
+			key.data = i;
+			return key;
+		}
+	}
+
+	if (binding.starts_with("Button"))
+	{
+		const std::optional<u32> button_index = StringUtil::FromChars<u32>(binding.substr(6));
+		if (!button_index.has_value())
+			return std::nullopt;
+
+		key.source_subtype = InputSubclass::ControllerButton;
+		key.data = button_index.value();
+		return key;
+	}
+
+	return std::nullopt;
+}
+
+TinyString RawInputSource::ConvertKeyToString(InputBindingKey key, bool display, bool migration)
+{
+	TinyString ret;
+
+	if (key.source_type == InputSourceType::RawInput)
+	{
+		if (key.source_subtype == InputSubclass::ControllerButton)
+		{
+			if (display)
+			{
+				if (key.data < NUM_BUTTONS)
+					ret.format("RawMouse-{} {}", u32{key.source_index}, s_button_display_names[key.data]);
+				else
+					ret.format("RawMouse-{} Button {}", u32{key.source_index}, key.data + 1);
+			}
+			else
+			{
+				if (key.data < NUM_BUTTONS)
+					ret.format("RawMouse-{}/{}", u32{key.source_index}, s_button_names[key.data]);
+				else
+					ret.format("RawMouse-{}/Button{}", u32{key.source_index}, key.data);
+			}
+		}
+	}
+
+	return ret;
+}
+
+TinyString RawInputSource::ConvertKeyToIcon(InputBindingKey key)
+{
+	return {};
+}
+
+bool RawInputSource::EnumerateRawMice()
+{
+	std::lock_guard<std::mutex> guard(m_mice_mutex);
+	UINT device_count = 0;
+	if (GetRawInputDeviceList(nullptr, &device_count, sizeof(RAWINPUTDEVICELIST)) == static_cast<UINT>(-1))
+	{
+		Console.Error("(RawInput) GetRawInputDeviceList(count) failed: %08X", GetLastError());
+		return false;
+	}
+
+	if (device_count == 0)
+		return true;
+
+	std::vector<RAWINPUTDEVICELIST> device_list(device_count);
+	if (GetRawInputDeviceList(device_list.data(), &device_count, sizeof(RAWINPUTDEVICELIST)) == static_cast<UINT>(-1))
+	{
+		Console.Error("(RawInput) GetRawInputDeviceList(enum) failed: %08X", GetLastError());
+		return false;
+	}
+
+	for (UINT i = 0; i < device_count; i++)
+	{
+		if (device_list[i].dwType != RIM_TYPEMOUSE)
+			continue;
+
+		const HANDLE handle = device_list[i].hDevice;
+
+		UINT name_size = 0;
+		GetRawInputDeviceInfoW(handle, RIDI_DEVICENAME, nullptr, &name_size);
+
+		std::wstring wdevice_path;
+		std::string device_path;
+		if (name_size > 0)
+		{
+			wdevice_path.resize(name_size, L'\0');
+			if (GetRawInputDeviceInfoW(handle, RIDI_DEVICENAME, wdevice_path.data(), &name_size) != static_cast<UINT>(-1))
+			{
+				while (!wdevice_path.empty() && wdevice_path.back() == L'\0')
+					wdevice_path.pop_back();
+				device_path = StringUtil::WideStringToUTF8String(wdevice_path);
+			}
+		}
+
+		if (device_path.empty())
+			continue;
+
+		if (m_mice.size() >= InputManager::MAX_POINTER_DEVICES)
+			break;
+
+		RawMouseDevice dev;
+		dev.handle = handle;
+		dev.device_path = std::move(device_path);
+		dev.pointer_index = 0; // assigned later by AssignPointerIndices
+		dev.button_state = 0;
+
+		m_mice.push_back(std::move(dev));
+	}
+
+	return true;
+}
+
+void RawInputSource::AssignPointerIndices()
+{
+	// Runs from Initialize() on the CPU thread, before any event flows; settings access is safe.
+	if (m_mice.empty())
+		return;
+
+	bool slot_taken[InputManager::MAX_POINTER_DEVICES] = {};
+	std::vector<bool> assigned(m_mice.size(), false);
+	for (size_t m = 0; m < m_mice.size(); m++)
+	{
+		const u32 slot = FindStoredSlot(GetDeviceIdentity(m_mice[m].device_path));
+		if (slot >= InputManager::MAX_POINTER_DEVICES || slot_taken[slot])
+			continue;
+		m_mice[m].pointer_index = slot;
+		slot_taken[slot] = true;
+		assigned[m] = true;
+	}
+
+	u32 next_free = 0;
+	for (size_t m = 0; m < m_mice.size(); m++)
+	{
+		if (assigned[m])
+			continue;
+		while (next_free < InputManager::MAX_POINTER_DEVICES && slot_taken[next_free])
+			next_free++;
+		if (next_free >= InputManager::MAX_POINTER_DEVICES)
+			break;
+		m_mice[m].pointer_index = next_free;
+		slot_taken[next_free] = true;
+	}
+
+	// Save the final assignment so ReloadDevices can restore it after disconnect/reconnect.
+	for (auto& mouse : m_mice)
+	{
+		mouse.display_name = GetDisplayNameForDevice(mouse.device_path, mouse.pointer_index);
+		Host::SetBaseStringSettingValue("RawInput",
+			fmt::format("Pointer{}Device", mouse.pointer_index).c_str(), GetDeviceIdentity(mouse.device_path).c_str());
+	}
+	Host::CommitBaseSettingChanges();
+}
+
+void RawInputSource::RebuildHandleMap()
+{
+	m_handle_to_mouse_index.clear();
+	for (u32 i = 0; i < static_cast<u32>(m_mice.size()); i++)
+		m_handle_to_mouse_index[m_mice[i].handle] = i;
+}
+
+std::optional<u32> RawInputSource::GetPointerIndexForDevicePath(const std::string_view device_path) const
+{
+	std::lock_guard<std::mutex> guard(m_mice_mutex);
+	for (const auto& mouse : m_mice)
+	{
+		if (mouse.device_path == device_path)
+			return mouse.pointer_index;
+		// Also match by VID+PID (stored by GetRawMouseDeviceList).
+		const std::string vidpid = ExtractVidPid(mouse.device_path);
+		if (!vidpid.empty() && vidpid == device_path)
+			return mouse.pointer_index;
+	}
+	return std::nullopt;
+}
+
+std::vector<std::pair<std::string, std::string>> RawInputSource::GetRawMouseDeviceList() const
+{
+	std::lock_guard<std::mutex> guard(m_mice_mutex);
+	std::vector<std::pair<std::string, std::string>> result;
+	for (const auto& mouse : m_mice)
+		result.emplace_back(GetDeviceIdentity(mouse.device_path), mouse.display_name);
+	return result;
+}
+
+void RawInputSource::ProcessRawInput(const RAWINPUT* raw, HWND render_hwnd)
+{
+	if (!m_initialized || raw->header.dwType != RIM_TYPEMOUSE)
+		return;
+
+	std::lock_guard<std::mutex> guard(m_mice_mutex);
+	const auto it = m_handle_to_mouse_index.find(raw->header.hDevice);
+	if (it == m_handle_to_mouse_index.end())
+		return;
+
+	const u32 mouse_idx = it->second;
+	pxAssert(mouse_idx < m_mice.size());
+	RawMouseDevice& mouse = m_mice[mouse_idx];
+	const RAWMOUSE& rm = raw->data.mouse;
+	const u32 pointer_index = mouse.pointer_index;
+
+	const HWND coord_hwnd = render_hwnd ? render_hwnd : m_hwnd;
+
+	// Position: absolute devices only (lightguns); relative mice keep the Qt pointer path.
+	if (rm.usFlags & MOUSE_MOVE_ABSOLUTE)
+	{
+		const bool is_virtual_desktop = (rm.usFlags & MOUSE_VIRTUAL_DESKTOP) != 0;
+		const int screen_w = GetSystemMetrics(is_virtual_desktop ? SM_CXVIRTUALSCREEN : SM_CXSCREEN);
+		const int screen_h = GetSystemMetrics(is_virtual_desktop ? SM_CYVIRTUALSCREEN : SM_CYSCREEN);
+
+		if (screen_w > 0 && screen_h > 0)
+		{
+			POINT pt;
+			pt.x = static_cast<LONG>(static_cast<float>(rm.lLastX) / 65535.0f * static_cast<float>(screen_w));
+			pt.y = static_cast<LONG>(static_cast<float>(rm.lLastY) / 65535.0f * static_cast<float>(screen_h));
+
+			if (is_virtual_desktop)
+			{
+				pt.x += GetSystemMetrics(SM_XVIRTUALSCREEN);
+				pt.y += GetSystemMetrics(SM_YVIRTUALSCREEN);
+			}
+
+			if (ScreenToClient(coord_hwnd, &pt))
+			{
+				InputManager::UpdatePointerAbsolutePosition(
+					pointer_index,
+					static_cast<float>(pt.x),
+					static_cast<float>(pt.y));
+			}
+		}
+	}
+	static constexpr struct
+	{
+		USHORT down_flag;
+		USHORT up_flag;
+		u32 button_index;
+	} button_map[] = {
+		{RI_MOUSE_LEFT_BUTTON_DOWN, RI_MOUSE_LEFT_BUTTON_UP, 0},
+		{RI_MOUSE_RIGHT_BUTTON_DOWN, RI_MOUSE_RIGHT_BUTTON_UP, 1},
+		{RI_MOUSE_MIDDLE_BUTTON_DOWN, RI_MOUSE_MIDDLE_BUTTON_UP, 2},
+	};
+
+	for (const auto& bm : button_map)
+	{
+		if (rm.usButtonFlags & bm.down_flag)
+		{
+			mouse.button_state |= (1u << bm.button_index);
+			const InputBindingKey key = MakeGenericControllerButtonKey(InputSourceType::RawInput, pointer_index, bm.button_index);
+			Host::RunOnCPUThread([key]() { InputManager::InvokeEvents(key, 1.0f, GenericInputBinding::Unknown); });
+		}
+		else if (rm.usButtonFlags & bm.up_flag)
+		{
+			mouse.button_state &= ~(1u << bm.button_index);
+			const InputBindingKey key = MakeGenericControllerButtonKey(InputSourceType::RawInput, pointer_index, bm.button_index);
+			Host::RunOnCPUThread([key]() { InputManager::InvokeEvents(key, 0.0f, GenericInputBinding::Unknown); });
+		}
+	}
+}
+
+#endif // _WIN32

--- a/pcsx2/Input/RawInputSource.h
+++ b/pcsx2/Input/RawInputSource.h
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 Tovarichtch
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+#include <mutex>
+
+#ifdef _WIN32
+
+#include "common/RedtapeWindows.h"
+#include "Input/InputSource.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+struct tagRAWINPUT;
+typedef struct tagRAWINPUT RAWINPUT;
+
+class RawInputSource final : public InputSource
+{
+public:
+	enum : u32
+	{
+		NUM_BUTTONS = 3,
+	};
+
+	RawInputSource();
+	~RawInputSource() override;
+
+	bool Initialize(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock) override;
+	void UpdateSettings(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock) override;
+	bool ReloadDevices() override;
+	void Shutdown() override;
+	bool IsInitialized() override;
+
+	void PollEvents() override;
+	std::vector<std::pair<std::string, std::string>> EnumerateDevices() override;
+	std::vector<InputBindingKey> EnumerateMotors() override;
+	bool GetGenericBindingMapping(const std::string_view device, InputManager::GenericInputBindingMapping* mapping) override;
+	InputLayout GetControllerLayout(u32 index) override;
+	void UpdateMotorState(InputBindingKey key, float intensity) override;
+	void UpdateMotorState(InputBindingKey large_key, InputBindingKey small_key, float large_intensity, float small_intensity) override;
+
+	std::optional<InputBindingKey> ParseKeyString(const std::string_view device, const std::string_view binding) override;
+	TinyString ConvertKeyToString(InputBindingKey key, bool display = false, bool migration = false) override;
+	TinyString ConvertKeyToIcon(InputBindingKey key) override;
+
+	/// Called from MainWindow::nativeEvent to dispatch WM_INPUT messages.
+	void ProcessRawInput(const RAWINPUT* raw, HWND render_hwnd);
+
+	/// Pointer index for a device path or VID+PID identity, if known.
+	std::optional<u32> GetPointerIndexForDevicePath(const std::string_view device_path) const;
+
+	/// All mice as (identity, display_name) for UI dropdowns.
+	std::vector<std::pair<std::string, std::string>> GetRawMouseDeviceList() const;
+
+private:
+	struct RawMouseDevice
+	{
+		HANDLE handle = nullptr;
+		std::string device_path;
+		std::string display_name;
+		u32 pointer_index = 0;
+		u32 button_state = 0;
+	};
+
+	bool EnumerateRawMice();
+
+	/// Saved-identity slots first, then first-free; persists the result.
+	void AssignPointerIndices();
+
+	void RebuildHandleMap();
+
+	static std::string GetDeviceIdentifier(u32 index);
+
+	HWND m_hwnd = nullptr;
+	bool m_initialized = false;
+	std::vector<RawMouseDevice> m_mice;
+	mutable std::mutex m_mice_mutex; // Protects m_mice and m_handle_to_mouse_index
+	std::unordered_map<HANDLE, u32> m_handle_to_mouse_index;
+
+	static constexpr const char* s_button_names[] = {"LeftButton", "RightButton", "MiddleButton"};
+	static constexpr const char* s_button_display_names[] = {"Left Button", "Right Button", "Middle Button"};
+};
+
+#endif // _WIN32

--- a/pcsx2/USB/usb-lightgun/guncon2.cpp
+++ b/pcsx2/USB/usb-lightgun/guncon2.cpp
@@ -130,6 +130,7 @@ namespace usb_lightgun
 		// Configuration
 		//////////////////////////////////////////////////////////////////////////
 		bool has_relative_binds = false;
+		u32 pointer_index = 0; // host pointer slot for mouse aim (per-device with Raw Input)
 		bool custom_config = false;
 		u32 screen_width = 640;
 		u32 screen_height = 240;
@@ -166,6 +167,7 @@ namespace usb_lightgun
 
 		// 0..1, not -1..1.
 		std::pair<float, float> GetAbsolutePositionFromRelativeAxes() const;
+		u32 EffectivePointerIndex() const;
 		u32 GetSoftwarePointerIndex() const;
 		void UpdateSoftwarePointerPosition();
 	};
@@ -274,7 +276,7 @@ namespace usb_lightgun
 					// TODO: use CalculatePosition() result instead of raw mouse, so Relative Aiming (joystick) works for S246
 					if (ACJV::enabled)
 					{
-						const auto& [mx, my] = InputManager::GetPointerAbsolutePosition(0);
+						const auto& [mx, my] = InputManager::GetPointerAbsolutePosition(us->EffectivePointerIndex());
 						float dx, dy;
 						GSTranslateWindowToDisplayCoordinates(mx, my, &dx, &dy);
 						bool on_screen = (dx >= 0.0f && dy >= 0.0f);
@@ -387,7 +389,7 @@ namespace usb_lightgun
 	{
 		float pointer_x, pointer_y;
 		const auto& [window_x, window_y] =
-			(has_relative_binds) ? GetAbsolutePositionFromRelativeAxes() : InputManager::GetPointerAbsolutePosition(0);
+			(has_relative_binds) ? GetAbsolutePositionFromRelativeAxes() : InputManager::GetPointerAbsolutePosition(EffectivePointerIndex());
 		GSTranslateWindowToDisplayCoordinates(window_x, window_y, &pointer_x, &pointer_y);
 
 		s16 pos_x, pos_y;
@@ -439,9 +441,14 @@ namespace usb_lightgun
 			screen_rel_x * ImGuiManager::GetWindowWidth(), screen_rel_y * ImGuiManager::GetWindowHeight());
 	}
 
+	u32 GunCon2State::EffectivePointerIndex() const
+	{
+		return InputManager::IsUsingRawInput() ? pointer_index : 0;
+	}
+
 	u32 GunCon2State::GetSoftwarePointerIndex() const
 	{
-		return has_relative_binds ? (InputManager::MAX_POINTER_DEVICES + port) : 0;
+		return has_relative_binds ? (InputManager::MAX_POINTER_DEVICES + port) : EffectivePointerIndex();
 	}
 
 	void GunCon2State::UpdateSoftwarePointerPosition()
@@ -507,6 +514,17 @@ namespace usb_lightgun
 		ACJV::SetGunRelativeAim(s->port, dx, dy);
 	}
 
+	static u32 PointerIndexFromBinding(const std::string& binding)
+	{
+		if (StringUtil::StartsWithNoCase(binding, "Pointer-"))
+		{
+			const std::optional<u32> idx = StringUtil::FromChars<u32>(std::string_view(binding).substr(8));
+			if (idx.has_value() && idx.value() < InputManager::MAX_POINTER_DEVICES)
+				return idx.value();
+		}
+		return 0;
+	}
+
 	void GunCon2Device::UpdateSettings(USBDevice* dev, SettingsInterface& si) const
 	{
 		GunCon2State* s = USB_CONTAINER_OF(dev, GunCon2State, dev);
@@ -551,6 +569,8 @@ namespace usb_lightgun
 		ACJV::SetGunAimSource(s->port, joystick_aim);
 		if (joystick_aim)
 			ForwardRelativeAimToJVS(s);
+		s->pointer_index = PointerIndexFromBinding(pointer_binding);
+		ACJV::SetGunPointerIndex(s->port, s->pointer_index);
 
 		const s32 new_pointer_index = s->GetSoftwarePointerIndex();
 
@@ -563,12 +583,15 @@ namespace usb_lightgun
 		if (cursor_changed)
 		{
 			const u32 other_port = s->port ^ 1u;
+			const std::string other_binding = USB::GetConfigString(si, other_port, TypeName(), "Pointer");
 			const bool other_aims_mouse = USB::GetConfigDevice(si, other_port) == TypeName() &&
-				StringUtil::StartsWithNoCase(USB::GetConfigString(si, other_port, TypeName(), "Pointer"), "Pointer-") &&
+				StringUtil::StartsWithNoCase(other_binding, "Pointer-") &&
 				!USB::GetConfigString(si, other_port, TypeName(), "cursor_path").empty();
+			const s32 other_slot = static_cast<s32>(InputManager::IsUsingRawInput() ? PointerIndexFromBinding(other_binding) : 0u);
 			if (prev_pointer_index != new_pointer_index &&
-				(prev_pointer_index >= static_cast<s32>(InputManager::MAX_POINTER_DEVICES) || !other_aims_mouse))
-				ImGuiManager::ClearSoftwareCursor(prev_pointer_index); // shared slot 0: keep only while the other gun aims with it
+				(prev_pointer_index >= static_cast<s32>(InputManager::MAX_POINTER_DEVICES) ||
+					!(other_aims_mouse && other_slot == prev_pointer_index)))
+				ImGuiManager::ClearSoftwareCursor(prev_pointer_index); // keep the slot only while the other gun still aims with it
 
 			const bool had_software_cursor = !s->cursor_path.empty();
 

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -285,6 +285,7 @@
     </ClCompile>
     <ClCompile Include="Host.cpp" />
     <ClCompile Include="Input\DInputSource.cpp" />
+    <ClCompile Include="Input\RawInputSource.cpp" />
     <ClCompile Include="Input\InputManager.cpp" />
     <ClCompile Include="Input\InputSource.cpp" />
     <ClCompile Include="Input\SDLInputSource.cpp" />
@@ -731,6 +732,7 @@
     </ClInclude>
     <ClInclude Include="Host.h" />
     <ClInclude Include="Input\DInputSource.h" />
+    <ClInclude Include="Input\RawInputSource.h" />
     <ClInclude Include="Input\InputManager.h" />
     <ClInclude Include="Input\InputSource.h" />
     <ClInclude Include="Input\SDLInputSource.h" />

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -1349,6 +1349,9 @@
     <ClCompile Include="Input\XInputSource.cpp">
       <Filter>Misc\Input</Filter>
     </ClCompile>
+    <ClCompile Include="Input\RawInputSource.cpp">
+      <Filter>Misc\Input</Filter>
+    </ClCompile>
     <ClCompile Include="Host.cpp">
       <Filter>System</Filter>
     </ClCompile>
@@ -2311,6 +2314,9 @@
       <Filter>Misc\Input</Filter>
     </ClInclude>
     <ClInclude Include="Input\XInputSource.h">
+      <Filter>Misc\Input</Filter>
+    </ClInclude>
+    <ClInclude Include="Input\RawInputSource.h">
       <Filter>Misc\Input</Filter>
     </ClInclude>
     <ClInclude Include="Host.h">


### PR DESCRIPTION
Initial support for RawInput (currently for multi-mouse, Windows).

Based on my own work for GunCon2 multi-gun support: https://github.com/Tovarichtch/pcsx2/tree/combined

Each pointing device (e.g.: light guns and mice) is tracked as its own pointer instead of being merged into the single system cursor. This makes two-player light gun play possible in Vampire Night.

**Note:** with `Raw Input` enabled, existing `Pointer-0` button bindings must be rebound on the specific `RawMouse` device.

Main features:
  - New `Raw Input` opt-in source in Controller Settings -> Global Settings (Windows only).
  - Per-player aim device selection in JVS tab -> Lightgun page, with a `Refresh` button and a `Raw Input` `ON/OFF` indicator
  - Device names carry a static [VID:PID] tag to tell apart identical devices (e.g.: same light gun name)
  - Pointer slots persist across replug, port changes and restarts. Hotplug possible
  - Buttons are per-device (`RawMouse-N` bindings), so each trigger is its own input; merged `Pointer` events are suppressed while the source is active to avoid double reads
  - Fixes the `Detected Devices` list stacking duplicate entries on every re-enumeration (upstream bug)

Todo:
- Only for Light Gun at this time, will extend eventually for all tabs.
- Add `evdev` support for linux and Batocera easy support
- Sleep