### PR TITLE
add togleable JVS packet hexdump

### DIFF
--- a/pcsx2-qt/MainWindow.cpp
+++ b/pcsx2-qt/MainWindow.cpp
@@ -407,6 +407,7 @@ void MainWindow::connectSignals()
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableIOPConsoleLogging, "Logging", "EnableIOPConsole", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_ACATA_Read_Logging, "Arcade",  "ATAVerboseReads", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_SRAM_Access_Logging, "Arcade", "SRAMVerboseReads", false);
+	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_ACJV_Access_Logging, "Arcade", "ACJVVerbose", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_RAM_Access_Logging, "Arcade",  "RAMVerboseReads", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnable_UART_Access_Logging, "Arcade",  "UARTVerbose", false);
 	SettingWidgetBinder::BindWidgetToBoolSetting(nullptr, m_ui.actionEnableLogWindow, "Logging", "EnableLogWindow", false);

--- a/pcsx2-qt/MainWindow.ui
+++ b/pcsx2-qt/MainWindow.ui
@@ -151,6 +151,7 @@
     <addaction name="actionEnableCDVDVerboseReads"/>
     <addaction name="actionEnable_ACATA_Read_Logging"/>
     <addaction name="actionEnable_SRAM_Access_Logging"/>
+    <addaction name="actionEnable_ACJV_Access_Logging"/>
     <addaction name="actionEnable_RAM_Access_Logging"/>
     <addaction name="actionEnable_UART_Access_Logging"/>
    </widget>
@@ -1109,6 +1110,14 @@
    </property>
    <property name="text">
     <string>Enable Arcade UART RX/TX Logging</string>
+   </property>
+  </action>
+  <action name="actionEnable_ACJV_Access_Logging">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Log the contents of the input and output buffer of the JVS Controller</string>
    </property>
   </action>
  </widget>

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -1362,6 +1362,7 @@ struct Pcsx2Config
 		bool RAMVerboseReads{false};
 		bool ATAVerboseReads{false};
 		bool UARTVerbose{false};
+		bool ACJVVerbose{false};
 		
 		void LoadSave(SettingsWrapper& wrap);
 

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -1350,6 +1350,18 @@ void do_acjv_packet() {
 			rd16[0x17] = 0x5210;
 		}
 	}
+	Console.WriteLn(Color_Green, "JVS PACKET IN (wr16):");
+    for (int i = 0; i < 0x300; i+=16) {
+        Console.WriteLn("%02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X",
+        wrbuf[i], wrbuf[i+1], wrbuf[i+2], wrbuf[i+3], wrbuf[i+4], wrbuf[i+5], wrbuf[i+6], wrbuf[i+7], wrbuf[i+8], wrbuf[i+9], wrbuf[i+10],
+              wrbuf[i+11], wrbuf[i+12], wrbuf[i+13], wrbuf[i+14], wrbuf[i+15]);
+    }
+	Console.WriteLn(Color_Green, "JVS PACKET OUT (rd16):");
+    for (int i = 0; i < 0x300; i+=16) {
+        Console.WriteLn("%02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X",
+        rdbuf[i], rdbuf[i+1], rdbuf[i+2], rdbuf[i+3], rdbuf[i+4], rdbuf[i+5], rdbuf[i+6], rdbuf[i+7], rdbuf[i+8], rdbuf[i+9], rdbuf[i+10],
+              rdbuf[i+11], rdbuf[i+12], rdbuf[i+13], rdbuf[i+14], rdbuf[i+15]);
+    }
 }
 
 // Free-run the FCA-1 input frame for Ridge Racer V in the rdbuf (do_acjv_packet never runs for it).

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -4931,6 +4931,7 @@ void FullscreenUI::DrawAdvancedSettingsPage()
 			bsi, FSUI_ICONSTR(ICON_FA_COMPACT_DISC, "CDVD Verbose Reads"), FSUI_CSTR("Logs disc reads from games."), "EmuCore", "CdvdVerboseReads", false);
 		DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_MICROCHIP, "Arcade ATA Verbose Reads"), FSUI_CSTR("Logs Arcade ATA reads from games."), "Arcade", "ATAVerboseReads", false);
 		DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_MICROCHIP, "Arcade SRAM Verbose Reads"), FSUI_CSTR("Logs Arcade SRAM reads/writes from games."), "Arcade", "SRAMVerboseReads", false);
+		DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_MICROCHIP, "Arcade JVS Verbose Reads"), FSUI_CSTR("Logs the contents of the input and output buffer for the JVS controller"), "Arcade", "ACJVVerbose", false);
 		DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_MICROCHIP, "Arcade RAM Verbose Reads"), FSUI_CSTR("Logs Arcade RAM transfers from games."), "Arcade", "RAMVerboseReads", false);
 		DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_MICROCHIP, "Arcade UART Verbose Reads"), FSUI_CSTR("Logs TX/RX from the arcade UART"), "Arcade", "UARTVerbose", false);
 	}

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -560,6 +560,7 @@ void VMManager::SetDefaultLoggingSettings(SettingsInterface& si)
 	
 	si.SetBoolValue("Arcade", "ATAVerboseReads", false);
 	si.SetBoolValue("Arcade", "SRAMVerboseReads", false);
+	si.SetBoolValue("Arcade", "ACJVVerbose", false);
 	si.SetBoolValue("Arcade", "RAMVerboseReads", false);
 	si.SetBoolValue("Arcade", "UARTVerbose", false);
 


### PR DESCRIPTION
allows hexdump of the custom jvs packet wrapper used by namco on this system (double 0x300 byte buffer for input and output respectively)