### PR TITLE
JVS: make Vampire Night manual reload per-player

### DIFF
--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -697,8 +697,8 @@ static constexpr float GUN_CAM_VISIBLE_X = 230.0f / 320.0f;
 static constexpr float GUN_CAM_VISIBLE_Y = 140.0f / 224.0f;
 static u16 s_gunRawX[JVS_PLAYER_COUNT] = {0xFFFF, 0xFFFF};
 static u16 s_gunRawY[JVS_PLAYER_COUNT] = {0xFFFF, 0xFFFF};
-static bool s_gunForceOff = false;
-void ACJV::SetGunForceOffscreen(bool held) { s_gunForceOff = held; }
+static bool s_gunForceOff[JVS_PLAYER_COUNT] = {};
+void ACJV::SetGunForceOffscreen(u32 player, bool held) { if (player < JVS_PLAYER_COUNT) s_gunForceOff[player] = held; }
 static float s_gunContour = 0.01f;
 void ACJV::SetGunOffscreenContour(float fraction) { s_gunContour = std::clamp(fraction, 0.0f, 0.05f); }
 
@@ -728,7 +728,7 @@ static void UpdateLightgunFromMouse()
 			// aiming beside the screen, so the native reload (invalid position -> reloadExe) stays reachable.
 			const float contour = s_gunContour;
 			const bool in_aim_area = (dx >= contour && dx <= 1.0f - contour && dy >= contour && dy <= 1.0f - contour);
-			const bool lost = s_gunForceOff || !in_aim_area || (fx < 0.0f || fx > 1.0f || fy < 0.0f || fy > 1.0f);
+			const bool lost = s_gunForceOff[p] || !in_aim_area || (fx < 0.0f || fx > 1.0f || fy < 0.0f || fy > 1.0f);
 			s_gunRawX[p] = lost ? 0xFFFF : static_cast<u16>(std::clamp(fx * 65535.0f, 1.0f, 65534.0f));
 			s_gunRawY[p] = lost ? 0xFFFF : static_cast<u16>(std::clamp(fy * 65535.0f, 1.0f, 65534.0f));
 			if (s_gunRawX[p] == 0x7FFF) s_gunRawX[p] = 0x7FFE; //0x7FFF is skipped by the game's adjust sampler

--- a/pcsx2/DEV9/ACJV.h
+++ b/pcsx2/DEV9/ACJV.h
@@ -182,7 +182,7 @@ namespace ACJV {
     void SetGunAimSource(u32 player, bool joystick);        // lightgun aim source: false = shared mouse, true = player's stick
     void SetGunPointerIndex(u32 player, u32 index);         // host pointer slot for the player's mouse aim (per-device with Raw Input)
     void SetGunRelativeAim(u32 player, float dx, float dy); // player's stick-driven screen position from the GunCon2 (display coords)
-    void SetGunForceOffscreen(bool held);                   // force the camera-lost report (the pedal bind = manual reload on Vampire Night)
+    void SetGunForceOffscreen(u32 player, bool held);       // force that player's camera-lost report (the pedal bind = manual reload on Vampire Night)
     void SetGunOffscreenContour(float fraction);            // width of the aim-beside-the-screen band at the window edge (0..0.05)
     void SetGameId(const std::string& gameid);
     const std::string& GetGameId();

--- a/pcsx2/USB/usb-lightgun/guncon2.cpp
+++ b/pcsx2/USB/usb-lightgun/guncon2.cpp
@@ -663,7 +663,7 @@ namespace usb_lightgun
 				// switch, so there the bind forces the camera-lost report = a manual reload.
 				case BID_A:
 					if (ACJV::GetGunMapping().board == GunBoardModel::CameraVN)
-						ACJV::SetGunForceOffscreen(pressed);
+						ACJV::SetGunForceOffscreen(player, pressed);
 					else
 						ACJV::SetButtonState(player, ACJV::GetGunMapping().pedal, pressed);
 					break;


### PR DESCRIPTION
Follow-up to #126, which wired the Vampire Night manual reload to the foot pedal bind.

SetGunForceOffscreen kept a single global flag, so whichever player pressed their pedal forced the camera-lost report for both guns. P1 could reload P2 and the other way round. It's keyed on the player index now, the same way the rest of the per-player gun state already is.

Tested on a 2 player cabinet with two Sinden guns on Vampire Night: each pedal only reloads its own side now, and the regular offscreen reload still works.
