### PR TITLE
Low Latency Audio

### DIFF
--- a/3rdparty/cubeb/src/cubeb.c
+++ b/3rdparty/cubeb/src/cubeb.c
@@ -58,6 +58,10 @@ winmm_init(cubeb ** context, char const * context_name);
 #if defined(USE_WASAPI)
 int
 wasapi_init(cubeb ** context, char const * context_name);
+int
+iaudioclient3_init(cubeb ** context, char const * context_name);
+int
+wasapi_exclusive_init(cubeb ** context, char const * context_name);
 #endif
 #if defined(USE_SNDIO)
 int
@@ -175,6 +179,14 @@ cubeb_init(cubeb ** context, char const * context_name,
     } else if (!strcmp(backend_name, "wasapi")) {
 #if defined(USE_WASAPI)
       init_oneshot = wasapi_init;
+#endif
+    } else if (!strcmp(backend_name, "iaudioclient3")) {
+#if defined(USE_WASAPI)
+      init_oneshot = iaudioclient3_init;
+#endif
+    } else if (!strcmp(backend_name, "wasapi-exclusive")) {
+#if defined(USE_WASAPI)
+      init_oneshot = wasapi_exclusive_init;
 #endif
     } else if (!strcmp(backend_name, "winmm")) {
 #if defined(USE_WINMM)
@@ -322,6 +334,8 @@ cubeb_get_backend_names()
 #endif
 #if defined(USE_WASAPI)
     "wasapi",
+    "iaudioclient3",
+    "wasapi-exclusive",
 #endif
 #if defined(USE_WINMM)
     "winmm",

--- a/3rdparty/cubeb/src/cubeb_wasapi.cpp
+++ b/3rdparty/cubeb/src/cubeb_wasapi.cpp
@@ -300,6 +300,8 @@ typedef enum {
 
 struct cubeb {
   cubeb_ops const * ops = &wasapi_ops;
+  bool use_iaudioclient3 = false;
+  bool use_exclusive_mode = false;
   owned_critical_section lock;
   cubeb_strings * device_ids;
   /* Device enumerator to get notifications when the
@@ -474,6 +476,8 @@ struct cubeb_stream {
   float volume = 1.0;
   /* True if the stream is draining. */
   bool draining = false;
+  /* Exclusive event streams must write one complete buffer before Start. */
+  bool output_needs_priming = false;
   /* This needs an active audio input stream to be known, and is updated in the
    * first audio input callback. */
   std::atomic<int64_t> input_latency_hns{LATENCY_NOT_AVAILABLE_YET};
@@ -1003,6 +1007,35 @@ mask_to_channel_layout(WAVEFORMATEX const * fmt)
   return mask;
 }
 
+bool
+waveformatex_is_compatible(WAVEFORMATEX const * lhs,
+                           WAVEFORMATEX const * rhs)
+{
+  if (!lhs || !rhs || lhs->wFormatTag != rhs->wFormatTag ||
+      lhs->nChannels != rhs->nChannels ||
+      lhs->nSamplesPerSec != rhs->nSamplesPerSec ||
+      lhs->wBitsPerSample != rhs->wBitsPerSample ||
+      lhs->nBlockAlign != rhs->nBlockAlign) {
+    return false;
+  }
+
+  if (lhs->wFormatTag != WAVE_FORMAT_EXTENSIBLE) {
+    return true;
+  }
+
+  if (lhs->cbSize < sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX) ||
+      rhs->cbSize < sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)) {
+    return false;
+  }
+
+  auto lhs_ext = reinterpret_cast<WAVEFORMATEXTENSIBLE const *>(lhs);
+  auto rhs_ext = reinterpret_cast<WAVEFORMATEXTENSIBLE const *>(rhs);
+  return lhs_ext->Samples.wValidBitsPerSample ==
+             rhs_ext->Samples.wValidBitsPerSample &&
+         lhs_ext->dwChannelMask == rhs_ext->dwChannelMask &&
+         IsEqualGUID(lhs_ext->SubFormat, rhs_ext->SubFormat);
+}
+
 uint32_t
 get_rate(cubeb_stream * stm)
 {
@@ -1026,6 +1059,59 @@ REFERENCE_TIME
 frames_to_hns(uint32_t rate, uint32_t frames)
 {
   return std::ceil(frames * 10000000.0 / rate);
+}
+
+uint32_t
+frames_to_rate(uint32_t frames, uint32_t source_rate, uint32_t target_rate)
+{
+  XASSERT(source_rate);
+  uint64_t numerator = uint64_t(frames) * target_rate + source_rate - 1;
+  return static_cast<uint32_t>(
+      std::min<uint64_t>(numerator / source_rate,
+                         std::numeric_limits<uint32_t>::max()));
+}
+
+struct shared_mode_engine_periods {
+  uint32_t default_period;
+  uint32_t fundamental_period;
+  uint32_t minimum_period;
+  uint32_t maximum_period;
+};
+
+bool
+shared_mode_engine_periods_are_valid(
+    shared_mode_engine_periods const & periods)
+{
+  return periods.fundamental_period && periods.minimum_period &&
+         periods.maximum_period >= periods.minimum_period;
+}
+
+HRESULT
+get_shared_mode_engine_periods(com_ptr<IAudioClient> & audio_client,
+                               WAVEFORMATEX const * format,
+                               com_ptr<IAudioClient3> & audio_client3,
+                               shared_mode_engine_periods & periods)
+{
+  HRESULT hr =
+      audio_client->QueryInterface<IAudioClient3>(audio_client3.receive());
+  if (FAILED(hr)) {
+    return hr;
+  }
+
+  AudioClientProperties properties = {};
+  properties.cbSize = sizeof(AudioClientProperties);
+#ifndef __MINGW32__
+  properties.eCategory = AudioCategory_GameEffects;
+#endif
+  hr = audio_client3->SetClientProperties(&properties);
+  if (FAILED(hr)) {
+    LOG("Could not set IAudioClient3 game-effects properties: %lx", hr);
+    return hr;
+  }
+
+  return audio_client3->GetSharedModeEnginePeriod(
+      format, &periods.default_period, &periods.fundamental_period,
+      &periods.minimum_period, &periods.maximum_period);
 }
 
 /* This returns the size of a frame in the stream, before the eventual upmix
@@ -1284,6 +1370,36 @@ get_output_buffer(cubeb_stream * stm, void *& buffer, size_t & frame_count)
 
   XASSERT(has_output(stm));
 
+  if (stm->context->use_exclusive_mode) {
+    if (stm->draining) {
+      LOG("WASAPI exclusive draining finished.");
+      wasapi_state_callback(stm, stm->user_ptr, CUBEB_STATE_DRAINED);
+      return false;
+    }
+
+    frame_count = stm->output_buffer_frame_count;
+    BYTE * output_buffer = nullptr;
+    hr = stm->render_client->GetBuffer(frame_count, &output_buffer);
+    if (hr == AUDCLNT_E_DEVICE_INVALIDATED) {
+      LOG("WASAPI exclusive output device invalidated");
+      if (stm->output_device_id ||
+          (stm->output_stream_params.prefs &
+           CUBEB_STREAM_PREF_DISABLE_DEVICE_SWITCHING) ||
+          !trigger_async_reconfigure(stm)) {
+        wasapi_state_callback(stm, stm->user_ptr, CUBEB_STATE_ERROR);
+        return false;
+      }
+      frame_count = 0;
+      return true;
+    }
+    if (FAILED(hr)) {
+      LOG("Cannot get WASAPI exclusive render buffer: %lx", hr);
+      return false;
+    }
+    buffer = output_buffer;
+    return true;
+  }
+
   hr = stm->output_client->GetCurrentPadding(&padding_out);
   if (hr == AUDCLNT_E_DEVICE_INVALIDATED) {
     // Application can recover from this error. More info
@@ -1479,13 +1595,51 @@ refill_callback_output(cubeb_stream * stm)
   }
   XASSERT(size_t(got) == output_frames || stm->draining);
 
-  hr = stm->render_client->ReleaseBuffer(got, 0);
+  size_t frames_to_release = got;
+  if (stm->context->use_exclusive_mode) {
+    if (size_t(got) < output_frames) {
+      size_t frame_size =
+          stm->output_mix_params.channels * stm->bytes_per_sample;
+      memset(static_cast<BYTE *>(output_buffer) + size_t(got) * frame_size, 0,
+             (output_frames - size_t(got)) * frame_size);
+    }
+    frames_to_release = output_frames;
+  }
+
+  hr = stm->render_client->ReleaseBuffer(frames_to_release, 0);
   if (FAILED(hr)) {
     LOG("failed to release buffer: %lx", hr);
     return false;
   }
 
   return size_t(got) == output_frames || stm->draining;
+}
+
+int
+prime_exclusive_output(cubeb_stream * stm)
+{
+  if (!stm->context->use_exclusive_mode || !stm->output_needs_priming) {
+    return CUBEB_OK;
+  }
+
+  BYTE * output_buffer = nullptr;
+  HRESULT hr = stm->render_client->GetBuffer(stm->output_buffer_frame_count,
+                                              &output_buffer);
+  if (FAILED(hr)) {
+    LOG("Could not get WASAPI exclusive priming buffer: %lx", hr);
+    return CUBEB_ERROR;
+  }
+
+  hr = stm->render_client->ReleaseBuffer(stm->output_buffer_frame_count,
+                                         AUDCLNT_BUFFERFLAGS_SILENT);
+  if (FAILED(hr)) {
+    LOG("Could not release WASAPI exclusive priming buffer: %lx", hr);
+    return CUBEB_ERROR;
+  }
+
+  stm->output_needs_priming = false;
+  LOG("Primed WASAPI exclusive output buffer with silence");
+  return CUBEB_OK;
 }
 
 void
@@ -1539,17 +1693,25 @@ static unsigned int __stdcall wasapi_stream_render_loop(LPVOID stream)
       /* stm->active was set by wasapi_stream_start/_stop before signaling,
          and SetEvent provides the necessary memory barrier. */
       if (stm->active && !mmcss_handle) {
-        /* We could consider using "Pro Audio" here for WebAudio and
-           maybe WebRTC. */
+        /* Exclusive output benefits from the higher-priority Pro Audio task;
+           retain the established Audio task for shared streams. */
+        const char * mmcss_task = stm->context->use_exclusive_mode
+                                      ? "Pro Audio"
+                                      : "Audio";
         mmcss_handle =
-            AvSetMmThreadCharacteristicsA("Audio", &mmcss_task_index);
+            AvSetMmThreadCharacteristicsA(mmcss_task, &mmcss_task_index);
+        if (!mmcss_handle && stm->context->use_exclusive_mode) {
+          mmcss_task = "Audio";
+          mmcss_handle =
+              AvSetMmThreadCharacteristicsA(mmcss_task, &mmcss_task_index);
+        }
         if (!mmcss_handle) {
           /* This is not fatal, but we might glitch under heavy load. */
           LOG("Unable to use mmcss to bump the render thread priority: %lx",
               GetLastError());
         } else {
-          LOG("MMCSS render thread promoted (task index %lu)",
-              mmcss_task_index);
+          LOG("MMCSS render thread promoted with %s profile (task index %lu)",
+              mmcss_task, mmcss_task_index);
         }
       } else if (!stm->active && mmcss_handle) {
         AvRevertMmThreadCharacteristics(mmcss_handle);
@@ -1592,6 +1754,12 @@ static unsigned int __stdcall wasapi_stream_render_loop(LPVOID stream)
       LOG("Stream setup successfuly.");
       XASSERT(stm->output_client || stm->input_client);
       if (stm->output_client) {
+        r = prime_exclusive_output(stm);
+        if (r != CUBEB_OK) {
+          is_playing = false;
+          hr = E_FAIL;
+          continue;
+        }
         hr = stm->output_client->Start();
         if (FAILED(hr)) {
           LOG("Error starting output after reconfigure, error: %lx", hr);
@@ -1860,8 +2028,9 @@ stream_set_volume(cubeb_stream * stm, float volume)
 } // namespace
 
 extern "C" {
-int
-wasapi_init(cubeb ** context, char const * context_name)
+static int
+wasapi_init_internal(cubeb ** context, char const * context_name,
+                     bool use_iaudioclient3, bool use_exclusive_mode)
 {
   /* We don't use the device yet, but need to make sure we can initialize one
      so that this backend is not incorrectly enabled on platforms that don't
@@ -1881,6 +2050,8 @@ wasapi_init(cubeb ** context, char const * context_name)
   cubeb * ctx = new cubeb();
 
   ctx->ops = &wasapi_ops;
+  ctx->use_iaudioclient3 = use_iaudioclient3;
+  ctx->use_exclusive_mode = use_exclusive_mode;
   auto_lock lock(ctx->lock);
   if (cubeb_strings_init(&ctx->device_ids) != CUBEB_OK) {
     delete ctx;
@@ -1899,6 +2070,24 @@ wasapi_init(cubeb ** context, char const * context_name)
   *context = ctx;
 
   return CUBEB_OK;
+}
+
+int
+wasapi_init(cubeb ** context, char const * context_name)
+{
+  return wasapi_init_internal(context, context_name, false, false);
+}
+
+int
+iaudioclient3_init(cubeb ** context, char const * context_name)
+{
+  return wasapi_init_internal(context, context_name, true, false);
+}
+
+int
+wasapi_exclusive_init(cubeb ** context, char const * context_name)
+{
+  return wasapi_init_internal(context, context_name, false, true);
 }
 }
 
@@ -1948,7 +2137,10 @@ wasapi_destroy(cubeb * context)
 char const *
 wasapi_get_backend_id(cubeb * context)
 {
-  return "wasapi";
+  if (context->use_iaudioclient3) {
+    return "iaudioclient3";
+  }
+  return context->use_exclusive_mode ? "wasapi-exclusive" : "wasapi";
 }
 
 int
@@ -2007,6 +2199,34 @@ wasapi_get_min_latency(cubeb * ctx, cubeb_stream_params params,
     return CUBEB_ERROR;
   }
 
+  if (ctx->use_iaudioclient3) {
+    WAVEFORMATEX * tmp = nullptr;
+    hr = client->GetMixFormat(&tmp);
+    if (SUCCEEDED(hr)) {
+      com_heap_ptr<WAVEFORMATEX> mix_format(tmp);
+      com_ptr<IAudioClient3> client3;
+      shared_mode_engine_periods periods = {};
+      hr = get_shared_mode_engine_periods(client, mix_format.get(), client3,
+                                          periods);
+      if (SUCCEEDED(hr) && shared_mode_engine_periods_are_valid(periods)) {
+        *latency_frames = frames_to_rate(periods.minimum_period,
+                                         mix_format->nSamplesPerSec,
+                                         params.rate);
+        LOG("IAudioClient3 AudioCategory_GameEffects engine periods in "
+            "mix-rate frames: default=%u, fundamental=%u, minimum=%u, "
+            "maximum=%u",
+            periods.default_period, periods.fundamental_period,
+            periods.minimum_period, periods.maximum_period);
+        LOG("Minimum latency in stream-rate frames: %u", *latency_frames);
+        return CUBEB_OK;
+      }
+    }
+
+    LOG("Could not query IAudioClient3 engine period: %lx; using the shared "
+        "WASAPI default period",
+        hr);
+  }
+
   REFERENCE_TIME minimum_period;
   REFERENCE_TIME default_period;
   hr = client->GetDevicePeriod(&default_period, &minimum_period);
@@ -2018,18 +2238,14 @@ wasapi_get_min_latency(cubeb * ctx, cubeb_stream_params params,
   LOG("default device period: %I64d, minimum device period: %I64d",
       default_period, minimum_period);
 
-  /* If we're on Windows 10, we can use IAudioClient3 to get minimal latency.
-     Otherwise, according to the docs, the best latency we can achieve is by
-     synchronizing the stream and the engine.
-     http://msdn.microsoft.com/en-us/library/windows/desktop/dd370871%28v=vs.85%29.aspx
-   */
-
-  // #ifdef _WIN32_WINNT_WIN10
-#if 0
-     *latency_frames = hns_to_frames(params.rate, minimum_period);
-#else
-  *latency_frames = hns_to_frames(params.rate, default_period);
-#endif
+  if (ctx->use_exclusive_mode) {
+    *latency_frames = hns_to_frames(params.rate, minimum_period);
+  } else {
+    // The minimum period returned by GetDevicePeriod is for exclusive mode.
+    // A regular shared-mode IAudioClient stream synchronizes to the default
+    // engine period instead.
+    *latency_frames = hns_to_frames(params.rate, default_period);
+  }
 
   LOG("Minimum latency in frames: %u", *latency_frames);
 
@@ -2183,118 +2399,172 @@ initialize_iaudioclient2(com_ptr<IAudioClient> & audio_client,
   return CUBEB_OK;
 }
 
-#if 0
 bool
 initialize_iaudioclient3(com_ptr<IAudioClient> & audio_client,
-                         cubeb_stream * stm,
                          const com_heap_ptr<WAVEFORMATEX> & mix_format,
-                         DWORD flags, EDataFlow direction)
+                         DWORD flags, REFERENCE_TIME latency_hns)
 {
   com_ptr<IAudioClient3> audio_client3;
-  audio_client->QueryInterface<IAudioClient3>(audio_client3.receive());
-  if (!audio_client3) {
-    LOG("Could not get IAudioClient3 interface");
-    return false;
-  }
-
-  if (flags & AUDCLNT_STREAMFLAGS_LOOPBACK) {
-    // IAudioClient3 doesn't work with loopback streams, and will return error
-    // 88890021: AUDCLNT_E_INVALID_STREAM_FLAG
-    LOG("Audio stream is loopback, not using IAudioClient3");
-    return false;
-  }
-
-  // Some people have reported glitches with capture streams:
-  // http://blog.nirbheek.in/2018/03/low-latency-audio-on-windows-with.html
-  if (direction == eCapture) {
-    LOG("Audio stream is capture, not using IAudioClient3");
-    return false;
-  }
-
-  // Possibly initialize a shared-mode stream using IAudioClient3. Initializing
-  // a stream this way lets you request lower latencies, but also locks the
-  // global WASAPI engine at that latency.
-  // - If we request a shared-mode stream, streams created with IAudioClient
-  // will
-  //   have their latency adjusted to match. When  the shared-mode stream is
-  //   closed, they'll go back to normal.
-  // - If there's already a shared-mode stream running, then we cannot request
-  //   the engine change to a different latency - we have to match it.
-  // - It's antisocial to lock the WASAPI engine at its default latency. If we
-  //   would do this, then stop and use IAudioClient instead.
-
-  HRESULT hr;
-  uint32_t default_period = 0, fundamental_period = 0, min_period = 0,
-           max_period = 0;
-  hr = audio_client3->GetSharedModeEnginePeriod(
-      mix_format.get(), &default_period, &fundamental_period, &min_period,
-      &max_period);
+  shared_mode_engine_periods periods = {};
+  HRESULT hr = get_shared_mode_engine_periods(
+      audio_client, mix_format.get(), audio_client3, periods);
   if (FAILED(hr)) {
-    LOG("Could not get shared mode engine period: error: %lx", hr);
+    LOG("Could not query IAudioClient3 engine periods: %lx", hr);
     return false;
-  }
-  uint32_t requested_latency = stm->latency;
-  if (requested_latency >= default_period) {
-    LOG("Requested latency %i greater than default latency %i, not using "
-        "IAudioClient3",
-        requested_latency, default_period);
-    return false;
-  }
-  LOG("Got shared mode engine period: default=%i fundamental=%i min=%i max=%i",
-      default_period, fundamental_period, min_period, max_period);
-  // Snap requested latency to a valid value
-  uint32_t old_requested_latency = requested_latency;
-  if (requested_latency < min_period) {
-    requested_latency = min_period;
-  }
-  requested_latency -= (requested_latency - min_period) % fundamental_period;
-  if (requested_latency != old_requested_latency) {
-    LOG("Requested latency %i was adjusted to %i", old_requested_latency,
-        requested_latency);
   }
 
-  hr = audio_client3->InitializeSharedAudioStream(flags, requested_latency,
+  if (!shared_mode_engine_periods_are_valid(periods)) {
+    LOG("IAudioClient3 returned invalid engine periods: fundamental=%u, "
+        "minimum=%u, maximum=%u",
+        periods.fundamental_period, periods.minimum_period,
+        periods.maximum_period);
+    return false;
+  }
+
+  uint32_t requested_period =
+      hns_to_frames(mix_format->nSamplesPerSec, latency_hns);
+  uint32_t adjusted_period =
+      std::max(periods.minimum_period,
+               std::min(requested_period, periods.maximum_period));
+  adjusted_period -= adjusted_period % periods.fundamental_period;
+  if (adjusted_period < periods.minimum_period) {
+    adjusted_period = periods.minimum_period;
+  }
+
+  LOG("IAudioClient3 AudioCategory_GameEffects engine periods in mix-rate "
+      "frames: default=%u, fundamental=%u, minimum=%u, maximum=%u",
+      periods.default_period, periods.fundamental_period,
+      periods.minimum_period, periods.maximum_period);
+  if (adjusted_period != requested_period) {
+    LOG("IAudioClient3 adjusted requested period from %u to %u frames",
+        requested_period, adjusted_period);
+  }
+
+  hr = audio_client3->InitializeSharedAudioStream(flags, adjusted_period,
                                                   mix_format.get(), NULL);
   if (SUCCEEDED(hr)) {
     return true;
-  } else if (hr == AUDCLNT_E_ENGINE_PERIODICITY_LOCKED) {
-    LOG("Got AUDCLNT_E_ENGINE_PERIODICITY_LOCKED, adjusting latency request");
-  } else {
-    LOG("Could not initialize shared stream with IAudioClient3: error: %lx",
-        hr);
+  }
+
+  if (hr != AUDCLNT_E_ENGINE_PERIODICITY_LOCKED) {
+    LOG("Could not initialize IAudioClient3 stream: %lx", hr);
     return false;
   }
 
   uint32_t current_period = 0;
-  WAVEFORMATEX * current_format = nullptr;
-  // We have to pass a valid WAVEFORMATEX** and not nullptr, otherwise
-  // GetCurrentSharedModeEnginePeriod will return E_POINTER
-  hr = audio_client3->GetCurrentSharedModeEnginePeriod(&current_format,
+  WAVEFORMATEX * tmp = nullptr;
+  hr = audio_client3->GetCurrentSharedModeEnginePeriod(&tmp,
                                                        &current_period);
-  CoTaskMemFree(current_format);
-  if (FAILED(hr)) {
-    LOG("Could not get current shared mode engine period: error: %lx", hr);
+  if (FAILED(hr) || !tmp) {
+    LOG("Could not get locked IAudioClient3 engine period: %lx", hr);
     return false;
   }
+  com_heap_ptr<WAVEFORMATEX> current_format(tmp);
 
-  if (current_period >= default_period) {
-    LOG("Current shared mode engine period %i too high, not using IAudioClient",
-        current_period);
+  if (!waveformatex_is_compatible(current_format.get(), mix_format.get())) {
+    LOG("Locked IAudioClient3 engine format differs from the requested mix "
+        "format; using IAudioClient");
     return false;
   }
 
   hr = audio_client3->InitializeSharedAudioStream(flags, current_period,
                                                   mix_format.get(), NULL);
   if (SUCCEEDED(hr)) {
-    LOG("Current shared mode engine period is %i instead of requested %i",
-        current_period, requested_latency);
+    LOG("Using locked IAudioClient3 engine period %u instead of requested %u",
+        current_period, adjusted_period);
     return true;
   }
 
-  LOG("Could not initialize shared stream with IAudioClient3: error: %lx", hr);
+  LOG("Could not initialize locked-period IAudioClient3 stream: %lx", hr);
   return false;
 }
-#endif
+
+HRESULT
+initialize_exclusive_stream(com_ptr<IAudioClient> & audio_client,
+                            com_ptr<IMMDevice> const & device,
+                            const com_heap_ptr<WAVEFORMATEX> & format,
+                            DWORD flags, REFERENCE_TIME requested_latency_hns)
+{
+  WAVEFORMATEX legacy_format = {};
+  WAVEFORMATEX const * selected_format = format.get();
+  HRESULT hr = audio_client->IsFormatSupported(AUDCLNT_SHAREMODE_EXCLUSIVE,
+                                                selected_format, nullptr);
+  if (hr == AUDCLNT_E_UNSUPPORTED_FORMAT &&
+      format->wFormatTag == WAVE_FORMAT_EXTENSIBLE &&
+      format->nChannels <= 2) {
+    WAVEFORMATEXTENSIBLE const * extensible =
+        reinterpret_cast<WAVEFORMATEXTENSIBLE const *>(format.get());
+    WORD legacy_tag = 0;
+    if (IsEqualGUID(extensible->SubFormat, KSDATAFORMAT_SUBTYPE_PCM)) {
+      legacy_tag = WAVE_FORMAT_PCM;
+    } else if (IsEqualGUID(extensible->SubFormat,
+                           KSDATAFORMAT_SUBTYPE_IEEE_FLOAT)) {
+      legacy_tag = WAVE_FORMAT_IEEE_FLOAT;
+    }
+
+    if (legacy_tag) {
+      legacy_format = *format;
+      legacy_format.wFormatTag = legacy_tag;
+      legacy_format.cbSize = 0;
+      hr = audio_client->IsFormatSupported(AUDCLNT_SHAREMODE_EXCLUSIVE,
+                                            &legacy_format, nullptr);
+      if (hr == S_OK) {
+        selected_format = &legacy_format;
+        LOG("Using legacy WAVEFORMATEX for WASAPI exclusive stream");
+      }
+    }
+  }
+  if (hr != S_OK) {
+    LOG("WASAPI exclusive format is not supported: %lx", hr);
+    return FAILED(hr) ? hr : AUDCLNT_E_UNSUPPORTED_FORMAT;
+  }
+
+  REFERENCE_TIME default_period = 0;
+  REFERENCE_TIME minimum_period = 0;
+  hr = audio_client->GetDevicePeriod(&default_period, &minimum_period);
+  if (FAILED(hr)) {
+    LOG("Could not query WASAPI exclusive device period: %lx", hr);
+    return hr;
+  }
+
+  REFERENCE_TIME period_hns = std::max(requested_latency_hns, minimum_period);
+  LOG("WASAPI exclusive periods: default=%I64d hns, minimum=%I64d hns, "
+      "requested=%I64d hns, using=%I64d hns",
+      default_period, minimum_period, requested_latency_hns, period_hns);
+
+  hr = audio_client->Initialize(AUDCLNT_SHAREMODE_EXCLUSIVE, flags, period_hns,
+                                period_hns, selected_format, NULL);
+  if (hr != AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED) {
+    return hr;
+  }
+
+  UINT32 aligned_frames = 0;
+  hr = audio_client->GetBufferSize(&aligned_frames);
+  if (FAILED(hr)) {
+    LOG("Could not get aligned WASAPI exclusive buffer size: %lx", hr);
+    return hr;
+  }
+
+  period_hns = static_cast<REFERENCE_TIME>(
+      (uint64_t(aligned_frames) * 10000000 +
+       selected_format->nSamplesPerSec / 2) /
+      selected_format->nSamplesPerSec);
+  LOG("WASAPI exclusive aligned period is %u frames (%I64d hns)",
+      aligned_frames, period_hns);
+
+  // IAudioClient must be released and activated again after the alignment
+  // probe. This path needs proper testing across older USB audio drivers.
+  audio_client = nullptr;
+  hr = device->Activate(__uuidof(IAudioClient), CLSCTX_INPROC_SERVER, NULL,
+                        audio_client.receive_vpp());
+  if (FAILED(hr)) {
+    LOG("Could not reactivate aligned WASAPI exclusive client: %lx", hr);
+    return hr;
+  }
+
+  return audio_client->Initialize(AUDCLNT_SHAREMODE_EXCLUSIVE, flags,
+                                  period_hns, period_hns, selected_format, NULL);
+}
 
 #define DIRECTION_NAME (direction == eCapture ? "capture" : "render")
 
@@ -2512,16 +2782,37 @@ setup_wasapi_stream_one_side(cubeb_stream * stm,
     }
   }
 
-#if 0 // See https://bugzilla.mozilla.org/show_bug.cgi?id=1590902
-  if (initialize_iaudioclient3(audio_client, stm, mix_format, flags, direction)) {
-    LOG("Initialized with IAudioClient3");
-  } else {
-#endif
-  hr = audio_client->Initialize(AUDCLNT_SHAREMODE_SHARED, flags, latency_hns, 0,
-                                mix_format.get(), NULL);
-#if 0
+  bool initialized = false;
+  if (stm->context->use_exclusive_mode) {
+    if (direction != eRender || is_loopback) {
+      LOG("WASAPI exclusive backend only supports output streams");
+      return CUBEB_ERROR_NOT_SUPPORTED;
+    }
+    hr = initialize_exclusive_stream(audio_client, device, mix_format, flags,
+                                     latency_hns);
+    if (FAILED(hr)) {
+      LOG("Unable to initialize WASAPI exclusive render client: %lx", hr);
+      return CUBEB_ERROR;
+    }
+    initialized = true;
+    LOG("Initialized WASAPI exclusive stream");
+  } else if (stm->context->use_iaudioclient3 && direction == eRender &&
+             !is_loopback) {
+    // Keep this opt-in and output-only: capture was implicated in the Cubeb
+    // regressions that disabled IAudioClient3 and needs proper testing.
+    initialized =
+        initialize_iaudioclient3(audio_client, mix_format, flags, latency_hns);
   }
-#endif
+
+  if (initialized) {
+    if (stm->context->use_iaudioclient3) {
+      LOG("Initialized with IAudioClient3");
+    }
+    hr = S_OK;
+  } else {
+    hr = audio_client->Initialize(AUDCLNT_SHAREMODE_SHARED, flags, latency_hns,
+                                  0, mix_format.get(), NULL);
+  }
   if (FAILED(hr)) {
     LOG("Unable to initialize audio client for %s: %lx.", DIRECTION_NAME, hr);
     return CUBEB_ERROR;
@@ -2854,6 +3145,9 @@ setup_wasapi_stream(cubeb_stream * stm)
         frames_to_bytes_before_mix(stm, stm->output_buffer_frame_count));
   }
 
+  stm->output_needs_priming =
+      stm->context->use_exclusive_mode && has_output(stm);
+
   return CUBEB_OK;
 }
 
@@ -2880,6 +3174,11 @@ wasapi_stream_init(cubeb * context, cubeb_stream ** stream,
   int rv;
 
   XASSERT(context && stream && (input_stream_params || output_stream_params));
+
+  if (context->use_exclusive_mode && input_stream_params) {
+    LOG("WASAPI exclusive backend does not support input streams");
+    return CUBEB_ERROR_NOT_SUPPORTED;
+  }
 
   if (output_stream_params && input_stream_params &&
       output_stream_params->format != input_stream_params->format) {
@@ -3049,6 +3348,7 @@ close_wasapi_stream(cubeb_stream * stm)
   stm->render_client = nullptr;
   stm->output_client = nullptr;
   stm->output_device = nullptr;
+  stm->output_needs_priming = false;
 
   stm->capture_client = nullptr;
   stm->input_client = nullptr;
@@ -3134,6 +3434,13 @@ stream_start_one_side(cubeb_stream * stm, StreamDirection dir)
   XASSERT((dir == OUTPUT && stm->output_client) ||
           (dir == INPUT && stm->input_client));
 
+  if (dir == OUTPUT) {
+    int rv = prime_exclusive_output(stm);
+    if (rv != CUBEB_OK) {
+      return rv;
+    }
+  }
+
   HRESULT hr =
       dir == OUTPUT ? stm->output_client->Start() : stm->input_client->Start();
   if (hr == AUDCLNT_E_DEVICE_INVALIDATED) {
@@ -3151,6 +3458,13 @@ stream_start_one_side(cubeb_stream * stm, StreamDirection dir)
     if (r != CUBEB_OK) {
       LOG("reconfigure failed");
       return r;
+    }
+
+    if (dir == OUTPUT) {
+      r = prime_exclusive_output(stm);
+      if (r != CUBEB_OK) {
+        return r;
+      }
     }
 
     HRESULT hr2 = dir == OUTPUT ? stm->output_client->Start()
@@ -3584,6 +3898,29 @@ wasapi_create_device(cubeb * ctx, cubeb_device_info & ret,
       SUCCEEDED(client->GetDevicePeriod(&def_period, &min_period))) {
     ret.latency_lo = hns_to_frames(ret.default_rate, min_period);
     ret.latency_hi = hns_to_frames(ret.default_rate, def_period);
+
+    if (ctx->use_iaudioclient3 && flow == eRender) {
+      // If IAudioClient3 is unavailable this backend falls back to ordinary
+      // shared WASAPI, whose guaranteed period is the default period.
+      ret.latency_lo = ret.latency_hi;
+
+      WAVEFORMATEX * tmp = nullptr;
+      if (SUCCEEDED(client->GetMixFormat(&tmp))) {
+        com_heap_ptr<WAVEFORMATEX> mix_format(tmp);
+        com_ptr<IAudioClient3> client3;
+        shared_mode_engine_periods periods = {};
+        if (SUCCEEDED(get_shared_mode_engine_periods(
+                client, mix_format.get(), client3, periods)) &&
+            shared_mode_engine_periods_are_valid(periods)) {
+          uint32_t target_rate =
+              ret.default_rate ? ret.default_rate : mix_format->nSamplesPerSec;
+          ret.latency_lo = frames_to_rate(
+              periods.minimum_period, mix_format->nSamplesPerSec, target_rate);
+          ret.latency_hi = frames_to_rate(
+              periods.maximum_period, mix_format->nSamplesPerSec, target_rate);
+        }
+      }
+    }
   } else {
     ret.latency_lo = 0;
     ret.latency_hi = 0;

--- a/pcsx2-qt/CMakeLists.txt
+++ b/pcsx2-qt/CMakeLists.txt
@@ -60,6 +60,8 @@ target_sources(pcsx2-qt PRIVATE
 	Settings/AdvancedSettingsWidget.h
 	Settings/AdvancedSettingsWidget.ui
 	Settings/AudioExpansionSettingsDialog.ui
+	Settings/AudioLatencySlider.cpp
+	Settings/AudioLatencySlider.h
 	Settings/AudioSettingsWidget.cpp
 	Settings/AudioSettingsWidget.h
 	Settings/AudioSettingsWidget.ui

--- a/pcsx2-qt/Settings/AudioLatencySlider.cpp
+++ b/pcsx2-qt/Settings/AudioLatencySlider.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "AudioLatencySlider.h"
+
+#include <QtGui/QPainter>
+#include <QtWidgets/QStyle>
+#include <QtWidgets/QStyleOptionSlider>
+#include <algorithm>
+
+AudioLatencySlider::AudioLatencySlider(QWidget* parent)
+	: QSlider(parent)
+{
+}
+
+void AudioLatencySlider::setMinimumLatencyMarker(int latency_ms)
+{
+	if (m_minimum_latency_ms == latency_ms)
+		return;
+
+	m_minimum_latency_ms = latency_ms;
+	update();
+}
+
+void AudioLatencySlider::paintEvent(QPaintEvent* event)
+{
+	QSlider::paintEvent(event);
+	if (m_minimum_latency_ms < minimum() || m_minimum_latency_ms > maximum())
+		return;
+
+	QStyleOptionSlider option;
+	initStyleOption(&option);
+	option.sliderPosition = m_minimum_latency_ms;
+	option.sliderValue = m_minimum_latency_ms;
+
+	const QRect handle_rect = style()->subControlRect(QStyle::CC_Slider, &option, QStyle::SC_SliderHandle, this);
+	const QRect groove_rect = style()->subControlRect(QStyle::CC_Slider, &option, QStyle::SC_SliderGroove, this);
+	const int marker_top = std::max(0, groove_rect.top() - 5);
+	const int marker_bottom = std::min(height(), groove_rect.bottom() + 6);
+
+	QPainter painter(this);
+	painter.fillRect(handle_rect.center().x() - 1, marker_top, 3, marker_bottom - marker_top,
+		palette().color(QPalette::Highlight));
+}

--- a/pcsx2-qt/Settings/AudioLatencySlider.h
+++ b/pcsx2-qt/Settings/AudioLatencySlider.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include <QtWidgets/QSlider>
+
+class AudioLatencySlider final : public QSlider
+{
+public:
+	explicit AudioLatencySlider(QWidget* parent = nullptr);
+
+	void setMinimumLatencyMarker(int latency_ms);
+
+protected:
+	void paintEvent(QPaintEvent* event) override;
+
+private:
+	int m_minimum_latency_ms = 0;
+};

--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -54,7 +54,6 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* settings_dialog, QWidge
 		AudioStreamParameters::DEFAULT_BUFFER_MS);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.outputLatencyMS, "SPU2/Output", "OutputLatencyMS",
 		AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS);
-	SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.outputLatencyMinimal, "SPU2/Output", "OutputLatencyMinimal", false);
 	connect(m_ui.audioBackend, &QComboBox::currentIndexChanged, this, &AudioSettingsWidget::updateDriverNames);
 	connect(m_ui.expansionMode, &QComboBox::currentIndexChanged, this, &AudioSettingsWidget::onExpansionModeChanged);
 	connect(m_ui.expansionSettings, &QToolButton::clicked, this, &AudioSettingsWidget::onExpansionSettingsClicked);
@@ -66,8 +65,6 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* settings_dialog, QWidge
 
 	connect(m_ui.bufferMS, &QSlider::valueChanged, this, &AudioSettingsWidget::updateLatencyLabel);
 	connect(m_ui.outputLatencyMS, &QSlider::valueChanged, this, &AudioSettingsWidget::updateLatencyLabel);
-	connect(m_ui.outputLatencyMinimal, &QCheckBox::checkStateChanged, this, &AudioSettingsWidget::onMinimalOutputLatencyChanged);
-	onMinimalOutputLatencyChanged();
 	updateLatencyLabel();
 
 	// for per-game, just use the normal path, since it needs to re-read/apply
@@ -101,8 +98,7 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* settings_dialog, QWidge
 		   "average latency, as audio will be stretched/shrunk to keep the buffer size within check."));
 	dialog()->registerWidgetHelp(
 		m_ui.outputLatencyMS, tr("Output Latency"), tr("%1 ms").arg(AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS),
-		tr("Determines the latency from the buffer to the host audio output. This can be set lower than the target latency "
-		   "to reduce audio delay."));
+		tr("Requests the host output latency. The backend may adjust or reject subminimum values."));
 	dialog()->registerWidgetHelp(m_ui.standardVolume, tr("Standard Volume"), "100%",
 		tr("Controls the volume of the audio played on the host at normal speed."));
 	dialog()->registerWidgetHelp(m_ui.fastForwardVolume, tr("Fast Forward Volume"), "100%",
@@ -210,7 +206,6 @@ void AudioSettingsWidget::updateDeviceNames()
 
 	QObject::disconnect(m_ui.outputDevice, &QComboBox::currentIndexChanged, nullptr, nullptr);
 	m_ui.outputDevice->clear();
-	m_output_device_latency = 0;
 
 	if (devices.empty())
 	{
@@ -227,7 +222,6 @@ void AudioSettingsWidget::updateDeviceNames()
 			m_ui.outputDevice->addItem(QString::fromStdString(di.display_name), QString::fromStdString(di.name));
 			if (di.name == current_device)
 			{
-				m_output_device_latency = di.minimum_latency_frames;
 				is_known_device = true;
 			}
 		}
@@ -247,46 +241,28 @@ void AudioSettingsWidget::updateDeviceNames()
 
 void AudioSettingsWidget::updateLatencyLabel()
 {
-	const u32 expand_buffer_ms = AudioStream::GetMSForBufferSize(SPU2::SAMPLE_RATE, getEffectiveExpansionBlockSize());
+	const u32 expand_buffer_ms = AudioStream::GetMSForFrames(SPU2::SAMPLE_RATE, getEffectiveExpansionBlockSize());
 	const u32 config_buffer_ms = dialog()->getEffectiveIntValue("SPU2/Output", "BufferMS", AudioStreamParameters::DEFAULT_BUFFER_MS);
 	const u32 config_output_latency_ms = dialog()->getEffectiveIntValue("SPU2/Output", "OutputLatencyMS", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS);
-	const bool minimal_output = dialog()->getEffectiveBoolValue("SPU2/Output", "OutputLatencyMinimal", false);
 
 	//: Preserve the %1 variable, adapt the latter ms (and/or any possible spaces in between) to your language's ruleset.
-	m_ui.outputLatencyLabel->setText(minimal_output ? tr("N/A") : tr("%1 ms").arg(config_output_latency_ms));
+	m_ui.outputLatencyLabel->setText(tr("%1 ms").arg(config_output_latency_ms));
 	m_ui.bufferMSLabel->setText(tr("%1 ms").arg(config_buffer_ms));
 
-	const u32 output_latency_ms = minimal_output ? AudioStream::GetMSForBufferSize(SPU2::SAMPLE_RATE, m_output_device_latency) : config_output_latency_ms;
-	if (output_latency_ms > 0)
+	if (expand_buffer_ms > 0)
 	{
-		if (expand_buffer_ms > 0)
-		{
-			m_ui.bufferingLabel->setText(tr("Maximum Latency: %1 ms (%2 ms buffer + %3 ms expand + %4 ms output)")
-					.arg(config_buffer_ms + expand_buffer_ms + output_latency_ms)
-					.arg(config_buffer_ms)
-					.arg(expand_buffer_ms)
-					.arg(output_latency_ms));
-		}
-		else
-		{
-			m_ui.bufferingLabel->setText(tr("Maximum Latency: %1 ms (%2 ms buffer + %3 ms output)")
-					.arg(config_buffer_ms + output_latency_ms)
-					.arg(config_buffer_ms)
-					.arg(output_latency_ms));
-		}
+		m_ui.bufferingLabel->setText(tr("Maximum Latency: %1 ms (%2 ms buffer + %3 ms expand + %4 ms output)")
+				.arg(config_buffer_ms + expand_buffer_ms + config_output_latency_ms)
+				.arg(config_buffer_ms)
+				.arg(expand_buffer_ms)
+				.arg(config_output_latency_ms));
 	}
 	else
 	{
-		if (expand_buffer_ms > 0)
-		{
-			m_ui.bufferingLabel->setText(tr("Maximum Latency: %1 ms (%2 ms expand, minimum output latency unknown)")
-					.arg(expand_buffer_ms + config_buffer_ms)
-					.arg(expand_buffer_ms));
-		}
-		else
-		{
-			m_ui.bufferingLabel->setText(tr("Maximum Latency: %1 ms (minimum output latency unknown)").arg(config_buffer_ms));
-		}
+		m_ui.bufferingLabel->setText(tr("Maximum Latency: %1 ms (%2 ms buffer + %3 ms output)")
+				.arg(config_buffer_ms + config_output_latency_ms)
+				.arg(config_buffer_ms)
+				.arg(config_output_latency_ms));
 	}
 }
 
@@ -294,13 +270,6 @@ void AudioSettingsWidget::updateVolumeLabel()
 {
 	m_ui.standardVolumeLabel->setText(tr("%1%").arg(m_ui.standardVolume->value()));
 	m_ui.fastForwardVolumeLabel->setText(tr("%1%").arg(m_ui.fastForwardVolume->value()));
-}
-
-void AudioSettingsWidget::onMinimalOutputLatencyChanged()
-{
-	const bool minimal = dialog()->getEffectiveBoolValue("SPU2/Output", "OutputLatencyMinimal", false);
-	m_ui.outputLatencyMS->setEnabled(!minimal);
-	updateLatencyLabel();
 }
 
 void AudioSettingsWidget::onStandardVolumeChanged(const int new_value)

--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -52,6 +52,8 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* settings_dialog, QWidge
 		Pcsx2Config::SPU2Options::DEFAULT_SYNC_MODE);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.bufferMS, "SPU2/Output", "BufferMS",
 		AudioStreamParameters::DEFAULT_BUFFER_MS);
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.lowLatencyBufferMS, "SPU2/Output", "LowLatencyBufferMS",
+		AudioStreamParameters::DEFAULT_LOW_LATENCY_BUFFER_MS);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.outputLatencyMS, "SPU2/Output", "OutputLatencyMS",
 		AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS);
 	connect(m_ui.audioBackend, &QComboBox::currentIndexChanged, this, &AudioSettingsWidget::updateDriverNames);
@@ -64,6 +66,7 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* settings_dialog, QWidge
 	updateDriverNames();
 
 	connect(m_ui.bufferMS, &QSlider::valueChanged, this, &AudioSettingsWidget::updateLatencyLabel);
+	connect(m_ui.lowLatencyBufferMS, &QSlider::valueChanged, this, &AudioSettingsWidget::updateLatencyLabel);
 	connect(m_ui.outputLatencyMS, &QSlider::valueChanged, this, &AudioSettingsWidget::updateLatencyLabel);
 	updateLatencyLabel();
 
@@ -96,6 +99,9 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* settings_dialog, QWidge
 		m_ui.bufferMS, tr("Buffer Size"), tr("%1 ms").arg(AudioStreamParameters::DEFAULT_BUFFER_MS),
 		tr("Determines the buffer size which the time stretcher will try to keep filled. It effectively selects the "
 		   "average latency, as audio will be stretched/shrunk to keep the buffer size within check."));
+	dialog()->registerWidgetHelp(m_ui.lowLatencyBufferMS, tr("Low-Latency Buffer"),
+		tr("%1 ms").arg(AudioStreamParameters::DEFAULT_LOW_LATENCY_BUFFER_MS),
+		tr("Larger buffers reduce underrun in exchange for latency."));
 	dialog()->registerWidgetHelp(
 		m_ui.outputLatencyMS, tr("Output Latency"), tr("%1 ms").arg(AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS),
 		tr("Requests the host output latency. The backend may adjust or reject subminimum values."));
@@ -144,6 +150,15 @@ u32 AudioSettingsWidget::getEffectiveExpansionBlockSize() const
 	return std::has_single_bit(config_block_size) ? config_block_size : std::bit_ceil(config_block_size);
 }
 
+bool AudioSettingsWidget::isLowLatencyMode() const
+{
+	const std::string sync_mode_name = dialog()->getEffectiveStringValue("SPU2/Output", "SyncMode",
+		Pcsx2Config::SPU2Options::GetSyncModeName(Pcsx2Config::SPU2Options::DEFAULT_SYNC_MODE));
+	return Pcsx2Config::SPU2Options::ParseSyncMode(sync_mode_name.c_str())
+	           .value_or(Pcsx2Config::SPU2Options::DEFAULT_SYNC_MODE) ==
+	       Pcsx2Config::SPU2Options::SPU2SyncMode::LowLatency;
+}
+
 void AudioSettingsWidget::onExpansionModeChanged()
 {
 	const AudioExpansionMode expansion_mode = getEffectiveExpansionMode();
@@ -159,7 +174,14 @@ void AudioSettingsWidget::onSyncModeChanged()
 						Pcsx2Config::SPU2Options::GetSyncModeName(Pcsx2Config::SPU2Options::DEFAULT_SYNC_MODE))
 				.c_str())
 			.value_or(Pcsx2Config::SPU2Options::DEFAULT_SYNC_MODE);
-	m_ui.stretchSettings->setEnabled(sync_mode == Pcsx2Config::SPU2Options::SPU2SyncMode::TimeStretch);
+	const bool low_latency = (sync_mode == Pcsx2Config::SPU2Options::SPU2SyncMode::LowLatency);
+	m_ui.stretchSettings->setEnabled(
+		sync_mode == Pcsx2Config::SPU2Options::SPU2SyncMode::TimeStretch || low_latency);
+	m_ui.label_2->setText(low_latency ? tr("TimeStretch Fallback Buffer:") : tr("Buffer Size:"));
+	m_ui.lowLatencyBufferLabel->setVisible(low_latency);
+	m_ui.lowLatencyBufferMS->setVisible(low_latency);
+	m_ui.lowLatencyBufferMSLabel->setVisible(low_latency);
+	updateLatencyLabel();
 }
 
 AudioBackend AudioSettingsWidget::getEffectiveBackend() const
@@ -243,25 +265,29 @@ void AudioSettingsWidget::updateLatencyLabel()
 {
 	const u32 expand_buffer_ms = AudioStream::GetMSForFrames(SPU2::SAMPLE_RATE, getEffectiveExpansionBlockSize());
 	const u32 config_buffer_ms = dialog()->getEffectiveIntValue("SPU2/Output", "BufferMS", AudioStreamParameters::DEFAULT_BUFFER_MS);
+	const u32 config_low_latency_buffer_ms = dialog()->getEffectiveIntValue(
+		"SPU2/Output", "LowLatencyBufferMS", AudioStreamParameters::DEFAULT_LOW_LATENCY_BUFFER_MS);
 	const u32 config_output_latency_ms = dialog()->getEffectiveIntValue("SPU2/Output", "OutputLatencyMS", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS);
+	const u32 selected_buffer_ms = isLowLatencyMode() ? config_low_latency_buffer_ms : config_buffer_ms;
 
 	//: Preserve the %1 variable, adapt the latter ms (and/or any possible spaces in between) to your language's ruleset.
 	m_ui.outputLatencyLabel->setText(tr("%1 ms").arg(config_output_latency_ms));
 	m_ui.bufferMSLabel->setText(tr("%1 ms").arg(config_buffer_ms));
+	m_ui.lowLatencyBufferMSLabel->setText(tr("%1 ms").arg(config_low_latency_buffer_ms));
 
 	if (expand_buffer_ms > 0)
 	{
 		m_ui.bufferingLabel->setText(tr("Maximum Latency: %1 ms (%2 ms buffer + %3 ms expand + %4 ms output)")
-				.arg(config_buffer_ms + expand_buffer_ms + config_output_latency_ms)
-				.arg(config_buffer_ms)
+				.arg(selected_buffer_ms + expand_buffer_ms + config_output_latency_ms)
+				.arg(selected_buffer_ms)
 				.arg(expand_buffer_ms)
 				.arg(config_output_latency_ms));
 	}
 	else
 	{
 		m_ui.bufferingLabel->setText(tr("Maximum Latency: %1 ms (%2 ms buffer + %3 ms output)")
-				.arg(config_buffer_ms + config_output_latency_ms)
-				.arg(config_buffer_ms)
+				.arg(selected_buffer_ms + config_output_latency_ms)
+				.arg(selected_buffer_ms)
 				.arg(config_output_latency_ms));
 	}
 }

--- a/pcsx2-qt/Settings/AudioSettingsWidget.cpp
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.cpp
@@ -18,6 +18,8 @@
 #include <algorithm>
 #include <bit>
 
+static constexpr int MINIMUM_LATENCY_FRAMES_ROLE = Qt::UserRole + 1;
+
 AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* settings_dialog, QWidget* parent)
 	: SettingsWidget(settings_dialog, parent)
 {
@@ -54,7 +56,7 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* settings_dialog, QWidge
 		AudioStreamParameters::DEFAULT_BUFFER_MS);
 	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.lowLatencyBufferMS, "SPU2/Output", "LowLatencyBufferMS",
 		AudioStreamParameters::DEFAULT_LOW_LATENCY_BUFFER_MS);
-	SettingWidgetBinder::BindWidgetToIntSetting(sif, m_ui.outputLatencyMS, "SPU2/Output", "OutputLatencyMS",
+	SettingWidgetBinder::BindWidgetToIntSetting(sif, static_cast<QSlider*>(m_ui.outputLatencyMS), "SPU2/Output", "OutputLatencyMS",
 		AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS);
 	connect(m_ui.audioBackend, &QComboBox::currentIndexChanged, this, &AudioSettingsWidget::updateDriverNames);
 	connect(m_ui.expansionMode, &QComboBox::currentIndexChanged, this, &AudioSettingsWidget::onExpansionModeChanged);
@@ -104,7 +106,7 @@ AudioSettingsWidget::AudioSettingsWidget(SettingsWindow* settings_dialog, QWidge
 		tr("Larger buffers reduce underrun in exchange for latency."));
 	dialog()->registerWidgetHelp(
 		m_ui.outputLatencyMS, tr("Output Latency"), tr("%1 ms").arg(AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS),
-		tr("Requests the host output latency. The backend may adjust or reject subminimum values."));
+		tr("Requests the host output latency. The marker shows the minimum reported by the selected backend and device."));
 	dialog()->registerWidgetHelp(m_ui.standardVolume, tr("Standard Volume"), "100%",
 		tr("Controls the volume of the audio played on the host at normal speed."));
 	dialog()->registerWidgetHelp(m_ui.fastForwardVolume, tr("Fast Forward Volume"), "100%",
@@ -157,6 +159,14 @@ bool AudioSettingsWidget::isLowLatencyMode() const
 	return Pcsx2Config::SPU2Options::ParseSyncMode(sync_mode_name.c_str())
 	           .value_or(Pcsx2Config::SPU2Options::DEFAULT_SYNC_MODE) ==
 	       Pcsx2Config::SPU2Options::SPU2SyncMode::LowLatency;
+}
+
+u32 AudioSettingsWidget::getMinimumOutputLatencyMS() const
+{
+	if (m_minimum_output_latency_frames == 0)
+		return 0;
+
+	return AudioStream::GetMSForFramesCeil(SPU2::SAMPLE_RATE, m_minimum_output_latency_frames);
 }
 
 void AudioSettingsWidget::onExpansionModeChanged()
@@ -228,6 +238,7 @@ void AudioSettingsWidget::updateDeviceNames()
 
 	QObject::disconnect(m_ui.outputDevice, &QComboBox::currentIndexChanged, nullptr, nullptr);
 	m_ui.outputDevice->clear();
+	m_minimum_output_latency_frames = 0;
 
 	if (devices.empty())
 	{
@@ -242,8 +253,11 @@ void AudioSettingsWidget::updateDeviceNames()
 		for (const AudioStream::DeviceInfo& di : devices)
 		{
 			m_ui.outputDevice->addItem(QString::fromStdString(di.display_name), QString::fromStdString(di.name));
+			m_ui.outputDevice->setItemData(
+				m_ui.outputDevice->count() - 1, di.minimum_latency_frames, MINIMUM_LATENCY_FRAMES_ROLE);
 			if (di.name == current_device)
 			{
+				m_minimum_output_latency_frames = di.minimum_latency_frames;
 				is_known_device = true;
 			}
 		}
@@ -256,8 +270,15 @@ void AudioSettingsWidget::updateDeviceNames()
 
 		SettingWidgetBinder::BindWidgetToStringSetting(dialog()->getSettingsInterface(), m_ui.outputDevice, "SPU2/Output",
 			"DeviceName", std::move(devices.front().name));
+		connect(m_ui.outputDevice, &QComboBox::currentIndexChanged, this, &AudioSettingsWidget::onOutputDeviceChanged);
 	}
 
+	updateLatencyLabel();
+}
+
+void AudioSettingsWidget::onOutputDeviceChanged(int index)
+{
+	m_minimum_output_latency_frames = m_ui.outputDevice->itemData(index, MINIMUM_LATENCY_FRAMES_ROLE).toUInt();
 	updateLatencyLabel();
 }
 
@@ -269,11 +290,32 @@ void AudioSettingsWidget::updateLatencyLabel()
 		"SPU2/Output", "LowLatencyBufferMS", AudioStreamParameters::DEFAULT_LOW_LATENCY_BUFFER_MS);
 	const u32 config_output_latency_ms = dialog()->getEffectiveIntValue("SPU2/Output", "OutputLatencyMS", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS);
 	const u32 selected_buffer_ms = isLowLatencyMode() ? config_low_latency_buffer_ms : config_buffer_ms;
+	const u32 minimum_output_latency_ms = getMinimumOutputLatencyMS();
 
 	//: Preserve the %1 variable, adapt the latter ms (and/or any possible spaces in between) to your language's ruleset.
 	m_ui.outputLatencyLabel->setText(tr("%1 ms").arg(config_output_latency_ms));
 	m_ui.bufferMSLabel->setText(tr("%1 ms").arg(config_buffer_ms));
 	m_ui.lowLatencyBufferMSLabel->setText(tr("%1 ms").arg(config_low_latency_buffer_ms));
+	if (minimum_output_latency_ms > 0)
+	{
+		if (config_output_latency_ms < minimum_output_latency_ms)
+		{
+			m_ui.outputLatencyStatusLabel->setText(
+				tr("Reported minimum: %1 ms. Requested latency: %2 ms. If audio is poor, increase the requested latency.")
+					.arg(minimum_output_latency_ms)
+					.arg(config_output_latency_ms));
+		}
+		else
+		{
+			m_ui.outputLatencyStatusLabel->setText(tr("Backend minimum: %1 ms").arg(minimum_output_latency_ms));
+		}
+		m_ui.outputLatencyStatusLabel->show();
+	}
+	else
+	{
+		m_ui.outputLatencyStatusLabel->hide();
+	}
+	m_ui.outputLatencyMS->setMinimumLatencyMarker(static_cast<int>(minimum_output_latency_ms));
 
 	if (expand_buffer_ms > 0)
 	{

--- a/pcsx2-qt/Settings/AudioSettingsWidget.h
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.h
@@ -26,7 +26,6 @@ private Q_SLOTS:
 	void updateDeviceNames();
 	void updateLatencyLabel();
 	void updateVolumeLabel();
-	void onMinimalOutputLatencyChanged();
 	void onStandardVolumeChanged(const int new_value);
 	void onFastForwardVolumeChanged(const int new_value);
 	void onOutputMutedChanged(const int new_state);
@@ -41,5 +40,4 @@ private:
 	void resetVolume(const bool fast_forward);
 
 	Ui::AudioSettingsWidget m_ui;
-	u32 m_output_device_latency = 0;
 };

--- a/pcsx2-qt/Settings/AudioSettingsWidget.h
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.h
@@ -37,6 +37,7 @@ private:
 	AudioBackend getEffectiveBackend() const;
 	AudioExpansionMode getEffectiveExpansionMode() const;
 	u32 getEffectiveExpansionBlockSize() const;
+	bool isLowLatencyMode() const;
 	void resetVolume(const bool fast_forward);
 
 	Ui::AudioSettingsWidget m_ui;

--- a/pcsx2-qt/Settings/AudioSettingsWidget.h
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.h
@@ -24,6 +24,7 @@ private Q_SLOTS:
 
 	void updateDriverNames();
 	void updateDeviceNames();
+	void onOutputDeviceChanged(int index);
 	void updateLatencyLabel();
 	void updateVolumeLabel();
 	void onStandardVolumeChanged(const int new_value);
@@ -37,8 +38,10 @@ private:
 	AudioBackend getEffectiveBackend() const;
 	AudioExpansionMode getEffectiveExpansionMode() const;
 	u32 getEffectiveExpansionBlockSize() const;
+	u32 getMinimumOutputLatencyMS() const;
 	bool isLowLatencyMode() const;
 	void resetVolume(const bool fast_forward);
 
 	Ui::AudioSettingsWidget m_ui;
+	u32 m_minimum_output_latency_frames = 0;
 };

--- a/pcsx2-qt/Settings/AudioSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.ui
@@ -125,7 +125,7 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="0" colspan="2">
+      <item row="8" column="0" colspan="2">
        <widget class="QLabel" name="bufferingLabel">
         <property name="text">
          <string>Maximum latency: 0 frames (0.00ms)</string>
@@ -148,7 +148,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
+      <item row="7" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
          <widget class="QSlider" name="outputLatencyMS">
@@ -181,7 +181,7 @@
       <item row="0" column="1">
        <widget class="QComboBox" name="audioBackend"/>
       </item>
-      <item row="6" column="0">
+      <item row="7" column="0">
        <widget class="QLabel" name="label_5">
         <property name="text">
          <string>Output Latency:</string>
@@ -223,6 +223,55 @@
          <cstring>syncMode</cstring>
         </property>
        </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="lowLatencyBufferLabel">
+        <property name="text">
+         <string>Low-Latency Buffer:</string>
+        </property>
+        <property name="buddy">
+         <cstring>lowLatencyBufferMS</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <layout class="QHBoxLayout" name="lowLatencyBufferLayout" stretch="1,0">
+        <item>
+         <widget class="QSlider" name="lowLatencyBufferMS">
+          <property name="minimum">
+           <number>10</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="singleStep">
+           <number>1</number>
+          </property>
+          <property name="pageStep">
+           <number>5</number>
+          </property>
+          <property name="value">
+           <number>20</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
+          </property>
+          <property name="tickPosition">
+           <enum>QSlider::TickPosition::TicksBothSides</enum>
+          </property>
+          <property name="tickInterval">
+           <number>10</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="lowLatencyBufferMSLabel">
+          <property name="text">
+           <string>20 ms</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -385,6 +434,7 @@
   <tabstop>syncMode</tabstop>
   <tabstop>stretchSettings</tabstop>
   <tabstop>bufferMS</tabstop>
+  <tabstop>lowLatencyBufferMS</tabstop>
   <tabstop>outputLatencyMS</tabstop>
   <tabstop>standardVolume</tabstop>
   <tabstop>resetStandardVolume</tabstop>

--- a/pcsx2-qt/Settings/AudioSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.ui
@@ -153,7 +153,7 @@
         <item>
          <widget class="QSlider" name="outputLatencyMS">
           <property name="minimum">
-           <number>15</number>
+           <number>1</number>
           </property>
           <property name="maximum">
            <number>200</number>
@@ -173,13 +173,6 @@
          <widget class="QLabel" name="outputLatencyLabel">
           <property name="text">
            <string>0 ms</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="outputLatencyMinimal">
-          <property name="text">
-           <string>Minimal</string>
           </property>
          </widget>
         </item>
@@ -393,7 +386,6 @@
   <tabstop>stretchSettings</tabstop>
   <tabstop>bufferMS</tabstop>
   <tabstop>outputLatencyMS</tabstop>
-  <tabstop>outputLatencyMinimal</tabstop>
   <tabstop>standardVolume</tabstop>
   <tabstop>resetStandardVolume</tabstop>
   <tabstop>fastForwardVolume</tabstop>

--- a/pcsx2-qt/Settings/AudioSettingsWidget.ui
+++ b/pcsx2-qt/Settings/AudioSettingsWidget.ui
@@ -125,7 +125,7 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="0" colspan="2">
+      <item row="9" column="0" colspan="2">
        <widget class="QLabel" name="bufferingLabel">
         <property name="text">
          <string>Maximum latency: 0 frames (0.00ms)</string>
@@ -151,7 +151,7 @@
       <item row="7" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
-         <widget class="QSlider" name="outputLatencyMS">
+         <widget class="AudioLatencySlider" name="outputLatencyMS">
           <property name="minimum">
            <number>1</number>
           </property>
@@ -177,6 +177,19 @@
          </widget>
         </item>
        </layout>
+      </item>
+      <item row="8" column="0" colspan="2">
+       <widget class="QLabel" name="outputLatencyStatusLabel">
+        <property name="text">
+         <string>Backend minimum: 0 ms</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
       </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="audioBackend"/>
@@ -442,6 +455,13 @@
   <tabstop>resetFastForwardVolume</tabstop>
   <tabstop>muted</tabstop>
  </tabstops>
+ <customwidgets>
+  <customwidget>
+   <class>AudioLatencySlider</class>
+   <extends>QSlider</extends>
+   <header>Settings/AudioLatencySlider.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/pcsx2-qt/pcsx2-qt.vcxproj
+++ b/pcsx2-qt/pcsx2-qt.vcxproj
@@ -159,6 +159,7 @@
     <ClCompile Include="Settings\InputBindingWidget.cpp" />
     <ClCompile Include="Settings\JVSControlsWidget.cpp" />
     <ClCompile Include="Settings\ControllerSettingsWindow.cpp" />
+    <ClCompile Include="Settings\AudioLatencySlider.cpp" />
     <ClCompile Include="Settings\AudioSettingsWidget.cpp" />
     <ClCompile Include="Settings\MemoryCardConvertDialog.cpp" />
     <ClCompile Include="Settings\MemoryCardSettingsWidget.cpp" />
@@ -270,6 +271,7 @@
     <QtMoc Include="Settings\ControllerBindingWidget.h" />
     <QtMoc Include="Settings\ControllerGlobalSettingsWidget.h" />
     <ClInclude Include="Settings\MemoryCardConvertWorker.h" />
+    <ClInclude Include="Settings\AudioLatencySlider.h" />
     <QtMoc Include="Settings\OsdFontPickerDialog.h" />
     <ClInclude Include="SettingWidgetBinder.h" />
     <QtMoc Include="QtHost.h" />

--- a/pcsx2-qt/pcsx2-qt.vcxproj.filters
+++ b/pcsx2-qt/pcsx2-qt.vcxproj.filters
@@ -119,6 +119,9 @@
     <ClCompile Include="Settings\MemoryCardSettingsWidget.cpp">
       <Filter>Settings</Filter>
     </ClCompile>
+    <ClCompile Include="Settings\AudioLatencySlider.cpp">
+      <Filter>Settings</Filter>
+    </ClCompile>
     <ClCompile Include="Settings\AudioSettingsWidget.cpp">
       <Filter>Settings</Filter>
     </ClCompile>
@@ -303,6 +306,9 @@
       <Filter>Settings</Filter>
     </ClInclude>
     <ClInclude Include="Settings\MemoryCardConvertWorker.h">
+      <Filter>Settings</Filter>
+    </ClInclude>
+    <ClInclude Include="Settings\AudioLatencySlider.h">
       <Filter>Settings</Filter>
     </ClInclude>
     <ClInclude Include="Settings\OsdFontPickerDialog.h">

--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -839,11 +839,15 @@ set(pcsx2DebugToolsHeaders
 	DebugTools/BiosDebugData.h)
 
 set(pcsx2HostSources
+	Host/AudioRateController.cpp
+	Host/AudioRateResampler.cpp
 	Host/AudioStream.cpp
 	Host/CubebAudioStream.cpp
 	Host/SDLAudioStream.cpp)
 
 set(pcsx2HostHeaders
+	Host/AudioRateController.h
+	Host/AudioRateResampler.h
 	Host/AudioStream.h
 	Host/AudioStreamTypes.h)
 

--- a/pcsx2/Config.h
+++ b/pcsx2/Config.h
@@ -978,12 +978,7 @@ struct Pcsx2Config
 
 	struct SPU2Options
 	{
-		enum class SPU2SyncMode : u8
-		{
-			Disabled,
-			TimeStretch,
-			Count
-		};
+		using SPU2SyncMode = AudioSynchronizationMode;
 
 		static constexpr s32 MAX_VOLUME = 200;
 		static constexpr AudioBackend DEFAULT_BACKEND = AudioBackend::Cubeb;
@@ -1025,8 +1020,6 @@ struct Pcsx2Config
 		SPU2Options();
 
 		void LoadSave(SettingsWrapper& wrap);
-
-		bool IsTimeStretchEnabled() const { return (SyncMode == SPU2SyncMode::TimeStretch); }
 
 		bool operator==(const SPU2Options& right) const;
 		bool operator!=(const SPU2Options& right) const;

--- a/pcsx2/Host/AudioRateController.cpp
+++ b/pcsx2/Host/AudioRateController.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "Host/AudioRateController.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+	constexpr float CORRECTION_LIMIT = 0.01f;
+	constexpr float FILTER_TIME_CONSTANT_SECONDS = 0.025f;
+	constexpr float PROPORTIONAL_GAIN = 0.012f;
+	constexpr float INTEGRAL_GAIN_PER_SECOND = 0.040f;
+	constexpr float CORRECTION_SLEW_PER_SECOND = 0.040f;
+	constexpr float INTEGRAL_DECAY_SECONDS = 0.75f;
+	constexpr float SATURATION_RELEASE_MARGIN = 0.0005f;
+} // namespace
+
+AudioRateController::AudioRateController(u32 sample_rate, u32 target_frames)
+	: m_sample_rate(std::max(sample_rate, 1u))
+	, m_target_frames(std::max(target_frames, 1u))
+{
+	Reset();
+}
+
+void AudioRateController::Reset()
+{
+	m_filtered_buffered_frames = static_cast<float>(m_target_frames);
+	m_integral = 0.0f;
+	m_correction = 1.0f;
+	m_saturation_direction = 0;
+}
+
+float AudioRateController::Update(
+	u32 buffered_frames, u32 callback_frames, u32 input_frames, float nominal_rate, bool discontinuity)
+{
+	const float target_frames = static_cast<float>(m_target_frames);
+	const float dt = static_cast<float>(std::max(input_frames, 1u)) / static_cast<float>(m_sample_rate);
+	if (discontinuity)
+	{
+		m_filtered_buffered_frames = static_cast<float>(buffered_frames);
+		m_integral = 0.0f;
+		m_saturation_direction = 0;
+	}
+
+	const float filter_alpha = 1.0f - std::exp(-dt / FILTER_TIME_CONSTANT_SECONDS);
+	m_filtered_buffered_frames +=
+		(static_cast<float>(buffered_frames) - m_filtered_buffered_frames) * filter_alpha;
+
+	float error_frames = m_filtered_buffered_frames - target_frames;
+	const float deadband_frames = std::max(static_cast<float>(m_sample_rate) * 0.001f,
+		static_cast<float>(callback_frames) * 0.20f);
+	if (std::abs(error_frames) <= deadband_frames)
+	{
+		error_frames = 0.0f;
+		m_integral *= std::exp(-dt / INTEGRAL_DECAY_SECONDS);
+	}
+	else
+	{
+		const float normalized_error = error_frames / target_frames;
+		const float proposed_integral = m_integral + normalized_error * INTEGRAL_GAIN_PER_SECOND * dt;
+		const float proposed_delta = PROPORTIONAL_GAIN * normalized_error + proposed_integral;
+		// Stop integrating while the error would push farther beyond a correction limit.
+		if (std::abs(proposed_delta) <= CORRECTION_LIMIT ||
+			(proposed_delta > CORRECTION_LIMIT && normalized_error < 0.0f) ||
+			(proposed_delta < -CORRECTION_LIMIT && normalized_error > 0.0f))
+		{
+			m_integral = proposed_integral;
+		}
+	}
+
+	const float normalized_error = error_frames / target_frames;
+	const float unclamped_correction = 1.0f + PROPORTIONAL_GAIN * normalized_error + m_integral;
+	const float lower_limit = 1.0f - CORRECTION_LIMIT;
+	const float upper_limit = 1.0f + CORRECTION_LIMIT;
+	if ((m_saturation_direction < 0 && unclamped_correction >= (lower_limit + SATURATION_RELEASE_MARGIN)) ||
+		(m_saturation_direction > 0 && unclamped_correction <= (upper_limit - SATURATION_RELEASE_MARGIN)))
+	{
+		m_saturation_direction = 0;
+	}
+	if (m_saturation_direction == 0)
+	{
+		if (unclamped_correction <= lower_limit)
+			m_saturation_direction = -1;
+		else if (unclamped_correction >= upper_limit)
+			m_saturation_direction = 1;
+	}
+
+	// Apply hysteresis at the correction limits to prevent callback jitter from repeatedly entering and leaving saturation.
+	const float requested_correction = (m_saturation_direction < 0) ? lower_limit :
+	                                   (m_saturation_direction > 0) ? upper_limit :
+	                                                                  unclamped_correction;
+	const float max_slew = CORRECTION_SLEW_PER_SECOND * dt;
+	m_correction += std::clamp(requested_correction - m_correction, -max_slew, max_slew);
+	m_correction = std::clamp(m_correction, lower_limit, upper_limit);
+
+	return std::max(nominal_rate, 0.0f) * m_correction;
+}

--- a/pcsx2/Host/AudioRateController.h
+++ b/pcsx2/Host/AudioRateController.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include "common/Pcsx2Defs.h"
+
+class AudioRateController
+{
+public:
+	AudioRateController(u32 sample_rate, u32 target_frames);
+
+	void Reset();
+	float Update(u32 buffered_frames, u32 callback_frames, u32 input_frames, float nominal_rate, bool discontinuity);
+
+private:
+	u32 m_sample_rate;
+	u32 m_target_frames = 1;
+	float m_filtered_buffered_frames = 0.0f;
+	float m_integral = 0.0f;
+	float m_correction = 1.0f;
+	s8 m_saturation_direction = 0;
+};

--- a/pcsx2/Host/AudioRateResampler.cpp
+++ b/pcsx2/Host/AudioRateResampler.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#include "Host/AudioRateResampler.h"
+
+#include "../../3rdparty/soundtouch/source/SoundTouch/RateTransposer.h"
+
+#include <cmath>
+#include <vector>
+
+AudioRateResampler::AudioRateResampler(u32 channels)
+{
+	m_transposer = std::make_unique<soundtouch::RateTransposer>();
+	m_transposer->setChannels(static_cast<int>(channels));
+	m_transposer->enableAAFilter(false);
+	m_transposer->setRate(1.0);
+
+	// Preallocate SoundTouch's internal FIFOs before entering the real-time path.
+	static constexpr u32 PREWARM_FRAMES = 4096;
+	std::vector<float> silence(PREWARM_FRAMES * channels, 0.0f);
+	for (const double rate : {0.94, 1.07})
+	{
+		m_transposer->setRate(rate);
+		m_transposer->putSamples(silence.data(), PREWARM_FRAMES);
+		m_transposer->receiveSamples(m_transposer->numSamples());
+		m_transposer->clear();
+	}
+
+	m_transposer->setRate(1.0);
+	m_transposer->clear();
+}
+
+AudioRateResampler::~AudioRateResampler() = default;
+
+void AudioRateResampler::Reset()
+{
+	m_transposer->clear();
+}
+
+void AudioRateResampler::SetRate(float rate)
+{
+	if (!std::isfinite(rate) || rate <= 0.0f)
+		return;
+
+	m_transposer->setRate(static_cast<double>(rate));
+}
+
+void AudioRateResampler::PutFrames(const float* frames, u32 num_frames)
+{
+	m_transposer->putSamples(frames, num_frames);
+}
+
+u32 AudioRateResampler::ReceiveFrames(float* frames, u32 max_frames)
+{
+	return m_transposer->receiveSamples(frames, max_frames);
+}
+
+u32 AudioRateResampler::GetAvailableFrames() const
+{
+	return m_transposer->numSamples();
+}

--- a/pcsx2/Host/AudioRateResampler.h
+++ b/pcsx2/Host/AudioRateResampler.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2002-2026 PCSX2 Dev Team
+// SPDX-License-Identifier: GPL-3.0+
+
+#pragma once
+
+#include "common/Pcsx2Defs.h"
+
+#include <memory>
+
+namespace soundtouch
+{
+	class RateTransposer;
+}
+
+class AudioRateResampler
+{
+public:
+	explicit AudioRateResampler(u32 channels);
+	~AudioRateResampler();
+
+	AudioRateResampler(const AudioRateResampler&) = delete;
+	AudioRateResampler& operator=(const AudioRateResampler&) = delete;
+
+	void Reset();
+	void SetRate(float rate);
+	void PutFrames(const float* frames, u32 num_frames);
+	u32 ReceiveFrames(float* frames, u32 max_frames);
+
+	u32 GetAvailableFrames() const;
+
+private:
+	std::unique_ptr<soundtouch::RateTransposer> m_transposer;
+};

--- a/pcsx2/Host/AudioStream.cpp
+++ b/pcsx2/Host/AudioStream.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "Host/AudioStream.h"
+#include "Host/AudioRateController.h"
+#include "Host/AudioRateResampler.h"
 #include "FreeSurroundDecoder.h"
 #include "Host.h"
 #include "GS/GSVector.h"
@@ -67,7 +69,7 @@ std::unique_ptr<AudioStream> AudioStream::CreateNullStream(u32 sample_rate, u32 
 	params.buffer_ms = static_cast<u16>(buffer_ms);
 
 	std::unique_ptr<AudioStream> stream(new AudioStream(sample_rate, params));
-	stream->BaseInitialize(&StereoSampleReaderImpl, false);
+	stream->BaseInitialize(&StereoSampleReaderImpl, AudioSynchronizationMode::Disabled);
 	stream->SetOutputVolume(0);
 	return stream;
 }
@@ -105,19 +107,19 @@ std::vector<AudioStream::DeviceInfo> AudioStream::GetOutputDevices(AudioBackend 
 }
 
 std::unique_ptr<AudioStream> AudioStream::CreateStream(AudioBackend backend, u32 sample_rate, const AudioStreamParameters& parameters,
-	const char* driver_name, const char* device_name, bool stretch_enabled, Error* error)
+	const char* driver_name, const char* device_name, AudioSynchronizationMode sync_mode, Error* error)
 {
-	INFO_LOG("Creating {} audio stream, sample rate = {}, expansion = {}, buffer = {}, latency = {}, stretching {}, driver = {}, device = {}",
-		GetBackendName(backend), sample_rate, GetExpansionModeName(parameters.expansion_mode), parameters.buffer_ms, parameters.output_latency_ms,
-		stretch_enabled ? "enabled" : "disabled", driver_name, device_name);
+	INFO_LOG("Creating {} audio stream, sample rate = {}, expansion = {}, buffer = {}, low latency buffer = {}, latency = {}, sync mode {}, driver = {}, device = {}",
+		GetBackendName(backend), sample_rate, GetExpansionModeName(parameters.expansion_mode), parameters.buffer_ms,
+		parameters.low_latency_buffer_ms, parameters.output_latency_ms, static_cast<u32>(sync_mode), driver_name, device_name);
 
 	switch (backend)
 	{
 		case AudioBackend::Cubeb:
-			return CreateCubebAudioStream(sample_rate, parameters, driver_name, device_name, stretch_enabled, error);
+			return CreateCubebAudioStream(sample_rate, parameters, driver_name, device_name, sync_mode, error);
 
 		case AudioBackend::SDL:
-			return CreateSDLAudioStream(sample_rate, parameters, stretch_enabled, error);
+			return CreateSDLAudioStream(sample_rate, parameters, sync_mode, error);
 
 		case AudioBackend::Null:
 			return CreateNullStream(sample_rate, parameters.buffer_ms);
@@ -234,6 +236,7 @@ u32 AudioStream::GetBufferedFramesRelaxed() const
 
 void AudioStream::ReadFrames(SampleType* samples, u32 num_frames)
 {
+	m_callback_frames.store(num_frames, std::memory_order_relaxed);
 	const u32 available_frames = GetBufferedFramesRelaxed();
 	u32 frames_to_read = num_frames;
 	u32 silence_frames = 0;
@@ -260,6 +263,7 @@ void AudioStream::ReadFrames(SampleType* samples, u32 num_frames)
 		silence_frames = frames_to_read - available_frames;
 		frames_to_read = available_frames;
 		m_filling = true;
+		m_discontinuity_count.fetch_add(1, std::memory_order_relaxed);
 
 		if (IsStretchEnabled())
 			StretchUnderrun();
@@ -355,6 +359,7 @@ void AudioStream::InternalWriteFrames(const SampleType* data, u32 num_frames)
 		}
 		else
 		{
+			m_discontinuity_count.fetch_add(1, std::memory_order_relaxed);
 			LOG_UNDERRUN("Buffer overrun, chunk dropped");
 			return;
 		}
@@ -386,34 +391,72 @@ void AudioStream::InternalWriteFrames(const SampleType* data, u32 num_frames)
 	m_wpos.store(wpos, std::memory_order_release);
 }
 
-void AudioStream::BaseInitialize(SampleReader sample_reader, bool stretch_enabled)
+void AudioStream::BaseInitialize(SampleReader sample_reader, AudioSynchronizationMode sync_mode)
 {
-	m_stretch_enabled = stretch_enabled;
+	m_sync_mode = sync_mode;
+	switch (sync_mode)
+	{
+		case AudioSynchronizationMode::Disabled:
+			m_processing_mode = ProcessingMode::None;
+			break;
+
+		case AudioSynchronizationMode::TimeStretch:
+			m_processing_mode = ProcessingMode::TimeStretch;
+			break;
+
+		case AudioSynchronizationMode::LowLatency:
+			m_processing_mode = ProcessingMode::Resample;
+			break;
+
+		case AudioSynchronizationMode::Count:
+			break;
+	}
 	m_paused = false;
 	m_sample_reader = sample_reader;
 
 	AllocateBuffer();
 	ExpandAllocate();
-	StretchAllocate();
+	ProcessorAllocate();
+	if (m_processing_mode == ProcessingMode::Resample)
+		PrimeLowLatencyBuffer();
 }
 
 void AudioStream::AllocateBuffer()
 {
 	// use a larger buffer when time stretching, since we need more input
-	const u32 multiplier = IsStretchEnabled() ? 16 : 1;
-	m_buffer_size = GetAlignedBufferSize(((m_parameters.buffer_ms * multiplier) * m_sample_rate) / 1000);
-	m_target_buffer_size = GetAlignedBufferSize((m_sample_rate * m_parameters.buffer_ms) / 1000u);
+	u32 target_ms;
+	u32 multiplier;
+	switch (m_processing_mode)
+	{
+		case ProcessingMode::None:
+			target_ms = m_parameters.buffer_ms;
+			multiplier = 1;
+			break;
+
+		case ProcessingMode::Resample:
+			target_ms = m_parameters.low_latency_buffer_ms;
+			multiplier = 4;
+			break;
+
+		case ProcessingMode::TimeStretch:
+			target_ms = m_parameters.buffer_ms;
+			multiplier = 16;
+			break;
+	}
+	m_target_buffer_size = std::max(GetAlignedBufferSize((m_sample_rate * target_ms) / 1000u), CHUNK_SIZE);
+	m_buffer_size = GetAlignedBufferSize(((target_ms * multiplier) * m_sample_rate) / 1000u);
+	if (m_processing_mode == ProcessingMode::Resample)
+		m_buffer_size = std::max(m_buffer_size, m_target_buffer_size + CHUNK_SIZE);
 
 	m_buffer = std::make_unique<float[]>(m_buffer_size * m_internal_channels);
-	m_staging_buffer = std::make_unique<float[]>(CHUNK_SIZE * m_internal_channels);
+	m_staging_buffer = std::make_unique<float[]>(CHUNK_SIZE * 2 * m_internal_channels);
 
 	if (IsExpansionEnabled())
 		m_expand_buffer = std::make_unique<float[]>(m_parameters.expand_block_size * NUM_INPUT_CHANNELS);
 
-	DEV_LOG(
-		"Allocated buffer of {} frames for buffer of {} ms [expansion {} (block size {}), stretch {}, target size {}].",
-		m_buffer_size, m_parameters.buffer_ms, GetExpansionModeName(m_parameters.expansion_mode),
-		m_parameters.expand_block_size, m_stretch_enabled ? "enabled" : "disabled", m_target_buffer_size);
+	DEV_LOG("Allocated audio buffer: {} frames, {} ms, expansion {}, block size {}, mode {}, target {}.",
+		m_buffer_size, target_ms, GetExpansionModeName(m_parameters.expansion_mode), m_parameters.expand_block_size,
+		static_cast<u32>(m_processing_mode), m_target_buffer_size);
 }
 
 void AudioStream::DestroyBuffer()
@@ -435,6 +478,12 @@ void AudioStream::EmptyBuffer()
 		m_expand_buffer_pos = 0;
 	}
 
+	if (m_processing_mode == ProcessingMode::Resample)
+	{
+		ResetLowLatencyState(true);
+		return;
+	}
+
 	if (IsStretchEnabled())
 	{
 		m_soundtouch->clear();
@@ -445,9 +494,30 @@ void AudioStream::EmptyBuffer()
 	m_wpos.store(m_rpos.load(std::memory_order_acquire), std::memory_order_release);
 }
 
+void AudioStream::ResetForSavestateLoad()
+{
+	if (m_processing_mode == ProcessingMode::Resample)
+		ResetLowLatencyState(true);
+}
+
 void AudioStream::SetNominalRate(float tempo)
 {
 	m_nominal_rate = tempo;
+}
+
+AudioStream::ProcessingMode AudioStream::SelectProcessingMode(float speed) const
+{
+	// Hysteresis prevents mode changes near the fallback boundary.
+	const float minimum = (m_processing_mode == ProcessingMode::Resample) ? 0.95f : 0.97f;
+	const float maximum = (m_processing_mode == ProcessingMode::Resample) ? 1.05f : 1.03f;
+	return (speed >= minimum && speed <= maximum) ? ProcessingMode::Resample : ProcessingMode::TimeStretch;
+}
+
+void AudioStream::SetTargetSpeed(float speed)
+{
+	m_target_speed = speed;
+	if (m_sync_mode == AudioSynchronizationMode::LowLatency)
+		SetProcessingMode(SelectProcessingMode(speed));
 }
 
 void AudioStream::UpdateTargetTempo(float tempo)
@@ -469,22 +539,54 @@ void AudioStream::UpdateTargetTempo(float tempo)
 	m_dynamic_target_usage = static_cast<float>(m_target_buffer_size) * m_nominal_rate;
 }
 
-void AudioStream::SetStretchEnabled(bool enabled)
+void AudioStream::SetSynchronizationMode(AudioSynchronizationMode mode)
 {
-	if (m_stretch_enabled == enabled)
+	if (m_sync_mode == mode)
+		return;
+
+	m_sync_mode = mode;
+	switch (mode)
+	{
+		case AudioSynchronizationMode::Disabled:
+			SetProcessingMode(ProcessingMode::None);
+			break;
+
+		case AudioSynchronizationMode::TimeStretch:
+			SetProcessingMode(ProcessingMode::TimeStretch);
+			break;
+
+		case AudioSynchronizationMode::LowLatency:
+			SetProcessingMode(SelectProcessingMode(m_target_speed));
+			break;
+
+		case AudioSynchronizationMode::Count:
+			break;
+	}
+}
+
+void AudioStream::SetProcessingMode(ProcessingMode mode)
+{
+	if (m_processing_mode == mode)
 		return;
 
 	// can't resize the buffers while paused
 	const bool paused = m_paused;
 	if (!paused)
 		SetPaused(true);
+	if (IsExpansionEnabled())
+	{
+		m_expander->Flush();
+		m_expand_output_buffer = nullptr;
+		m_expand_buffer_pos = 0;
+	}
 
+	ProcessorDestroy();
 	DestroyBuffer();
-	StretchDestroy();
-	m_stretch_enabled = enabled;
-
+	m_processing_mode = mode;
 	AllocateBuffer();
-	StretchAllocate();
+	ProcessorAllocate();
+	if (mode == ProcessingMode::Resample)
+		ResetLowLatencyState(true);
 
 	if (!paused)
 		SetPaused(false);
@@ -492,7 +594,19 @@ void AudioStream::SetStretchEnabled(bool enabled)
 
 void AudioStream::SetPaused(bool paused)
 {
+	if (m_paused == paused)
+		return;
+
 	m_paused = paused;
+	if (m_processing_mode == ProcessingMode::Resample)
+	{
+		if (paused)
+			ResetLowLatencyState(false);
+		else if (GetBufferedFramesRelaxed() == 0)
+			ResetLowLatencyState(true);
+		else
+			m_rate_controller->Reset();
+	}
 }
 
 void AudioStream::SetOutputVolume(u32 volume)
@@ -562,7 +676,7 @@ void AudioStream::EndWrite(u32 num_frames)
 
 void AudioStream::WriteChunk(const SampleType* chunk)
 {
-	if (!IsExpansionEnabled() && !IsStretchEnabled())
+	if (!IsExpansionEnabled() && m_processing_mode == ProcessingMode::None)
 	{
 		InternalWriteFrames(chunk, CHUNK_SIZE);
 		return;
@@ -570,12 +684,12 @@ void AudioStream::WriteChunk(const SampleType* chunk)
 
 	if (IsExpansionEnabled())
 	{
-		// StretchWriteBlock() overwrites the staging buffer on output, so we need to copy into the expand buffer first.
+		// ProcessWriteBlock() overwrites the staging buffer on output, so we need to copy into the expand buffer first.
 		std::memcpy(m_expand_buffer.get() + m_expand_buffer_pos * NUM_INPUT_CHANNELS, chunk, CHUNK_SIZE * NUM_INPUT_CHANNELS * sizeof(SampleType));
 
 		// Output the corresponding block.
 		if (m_expand_output_buffer)
-			StretchWriteBlock(m_expand_output_buffer + m_expand_buffer_pos * m_internal_channels);
+			ProcessWriteBlock(m_expand_output_buffer + m_expand_buffer_pos * m_internal_channels);
 
 		// Decode the next block if we buffered enough.
 		m_expand_buffer_pos += CHUNK_SIZE;
@@ -587,7 +701,7 @@ void AudioStream::WriteChunk(const SampleType* chunk)
 	}
 	else
 	{
-		StretchWriteBlock(chunk);
+		ProcessWriteBlock(chunk);
 	}
 }
 
@@ -595,6 +709,127 @@ template <class T>
 __fi static bool IsInRange(const T& val, const T& min, const T& max)
 {
 	return (min <= val && val <= max);
+}
+
+void AudioStream::ProcessorAllocate()
+{
+	switch (m_processing_mode)
+	{
+		case ProcessingMode::None:
+			break;
+
+		case ProcessingMode::Resample:
+			ResampleAllocate();
+			break;
+
+		case ProcessingMode::TimeStretch:
+			StretchAllocate();
+			break;
+	}
+}
+
+void AudioStream::ProcessorDestroy()
+{
+	ResampleDestroy();
+	StretchDestroy();
+}
+
+void AudioStream::ProcessWriteBlock(const float* block)
+{
+	switch (m_processing_mode)
+	{
+		case ProcessingMode::None:
+			InternalWriteFrames(block, CHUNK_SIZE);
+			break;
+
+		case ProcessingMode::Resample:
+			ResampleBlock(block);
+			break;
+
+		case ProcessingMode::TimeStretch:
+			StretchWriteBlock(block);
+			break;
+	}
+}
+
+void AudioStream::ResampleAllocate()
+{
+	m_resampler = std::make_unique<AudioRateResampler>(m_internal_channels);
+	m_rate_controller = std::make_unique<AudioRateController>(m_sample_rate, m_target_buffer_size);
+	m_seen_discontinuity_count = m_discontinuity_count.load(std::memory_order_relaxed);
+	m_fade_in_frames_remaining = std::min(m_sample_rate / 200u, m_target_buffer_size);
+}
+
+void AudioStream::ResampleDestroy()
+{
+	m_rate_controller.reset();
+	m_resampler.reset();
+}
+
+void AudioStream::PrimeLowLatencyBuffer()
+{
+	pxAssert(m_processing_mode == ProcessingMode::Resample);
+	std::fill_n(m_staging_buffer.get(), CHUNK_SIZE * m_internal_channels, 0.0f);
+	for (u32 frames = 0; frames < m_target_buffer_size; frames += CHUNK_SIZE)
+		InternalWriteFrames(m_staging_buffer.get(), CHUNK_SIZE);
+}
+
+void AudioStream::ResetLowLatencyState(bool prime_buffer)
+{
+	if (!m_resampler || !m_rate_controller)
+		return;
+
+	m_wpos.store(m_rpos.load(std::memory_order_acquire), std::memory_order_release);
+	if (IsExpansionEnabled())
+	{
+		m_expander->Flush();
+		m_expand_output_buffer = nullptr;
+		m_expand_buffer_pos = 0;
+	}
+	m_staging_buffer_pos = 0;
+	m_resampler->Reset();
+	m_rate_controller->Reset();
+	m_seen_discontinuity_count = m_discontinuity_count.load(std::memory_order_relaxed);
+	m_fade_in_frames_remaining = std::min(m_sample_rate / 200u, m_target_buffer_size);
+	m_filling = false;
+	if (prime_buffer)
+		PrimeLowLatencyBuffer();
+}
+
+void AudioStream::ResampleBlock(const float* block)
+{
+	const float* input = block;
+	if (m_fade_in_frames_remaining > 0)
+	{
+		const u32 fade_total = std::max(m_sample_rate / 200u, 1u);
+		for (u32 frame = 0; frame < CHUNK_SIZE; frame++)
+		{
+			const float gain =
+				1.0f - (static_cast<float>(m_fade_in_frames_remaining) / static_cast<float>(fade_total));
+			for (u32 channel = 0; channel < m_internal_channels; channel++)
+				m_staging_buffer[frame * m_internal_channels + channel] =
+					block[frame * m_internal_channels + channel] * gain;
+			if (m_fade_in_frames_remaining > 0)
+				m_fade_in_frames_remaining--;
+		}
+		input = m_staging_buffer.get();
+	}
+
+	const u32 discontinuity_count = m_discontinuity_count.load(std::memory_order_relaxed);
+	const float rate = m_rate_controller->Update(
+		GetBufferedFramesRelaxed(), m_callback_frames.load(std::memory_order_relaxed), CHUNK_SIZE, m_target_speed,
+		discontinuity_count != m_seen_discontinuity_count);
+	m_seen_discontinuity_count = discontinuity_count;
+	m_resampler->SetRate(rate);
+	m_resampler->PutFrames(input, CHUNK_SIZE);
+
+	while (m_resampler->GetAvailableFrames() > 0)
+	{
+		const u32 output_frames = m_resampler->ReceiveFrames(m_staging_buffer.get(), CHUNK_SIZE * 2);
+		if (output_frames == 0)
+			break;
+		InternalWriteFrames(m_staging_buffer.get(), output_frames);
+	}
 }
 
 void AudioStream::StretchAllocate()
@@ -632,23 +867,15 @@ void AudioStream::StretchDestroy()
 
 void AudioStream::StretchWriteBlock(const float* block)
 {
-	if (IsStretchEnabled())
-	{
-		m_soundtouch->putSamples(block, CHUNK_SIZE);
+	m_soundtouch->putSamples(block, CHUNK_SIZE);
 
-		u32 tempProgress;
-		while (tempProgress = m_soundtouch->receiveSamples(m_staging_buffer.get(), CHUNK_SIZE), tempProgress != 0)
-		{
-			InternalWriteFrames(m_staging_buffer.get(), tempProgress);
-		}
-
-		if (IsStretchEnabled())
-			UpdateStretchTempo();
-	}
-	else
+	u32 tempProgress;
+	while (tempProgress = m_soundtouch->receiveSamples(m_staging_buffer.get(), CHUNK_SIZE), tempProgress != 0)
 	{
-		InternalWriteFrames(block, CHUNK_SIZE);
+		InternalWriteFrames(m_staging_buffer.get(), tempProgress);
 	}
+
+	UpdateStretchTempo();
 }
 
 float AudioStream::AddAndGetAverageTempo(float val)
@@ -775,6 +1002,7 @@ void AudioStream::StretchOverrun()
 {
 	// Produced more frames than can fit in the buffer.
 	m_stretch_reset++;
+	m_discontinuity_count.fetch_add(1, std::memory_order_relaxed);
 
 	// Drop two packets to give the time stretcher a bit more time to slow things down.
 	const u32 discard = CHUNK_SIZE * 2;
@@ -785,6 +1013,9 @@ void AudioStreamParameters::LoadSave(SettingsWrapper& wrap, const char* section)
 {
 	wrap.EnumEntry(section, "ExpansionMode", expansion_mode, &AudioStream::ParseExpansionMode, &AudioStream::GetExpansionModeName, DEFAULT_EXPANSION_MODE);
 	buffer_ms = static_cast<u16>(std::clamp<int>(wrap.EntryBitfield(section, "BufferMS", buffer_ms, DEFAULT_BUFFER_MS), 0, std::numeric_limits<u16>::max()));
+	low_latency_buffer_ms = static_cast<u16>(std::clamp<int>(wrap.EntryBitfield(section, "LowLatencyBufferMS",
+																 low_latency_buffer_ms, DEFAULT_LOW_LATENCY_BUFFER_MS),
+		10, 100));
 	output_latency_ms = static_cast<u16>(std::clamp<int>(wrap.EntryBitfield(section, "OutputLatencyMS",
 															 output_latency_ms, DEFAULT_OUTPUT_LATENCY_MS),
 		1, std::numeric_limits<u16>::max()));

--- a/pcsx2/Host/AudioStream.cpp
+++ b/pcsx2/Host/AudioStream.cpp
@@ -134,15 +134,20 @@ u32 AudioStream::GetAlignedBufferSize(u32 size)
 	return Common::AlignUpPow2(size, CHUNK_SIZE);
 }
 
-u32 AudioStream::GetBufferSizeForMS(u32 sample_rate, u32 ms)
+u32 AudioStream::GetFrameCountForMS(u32 sample_rate, u32 milliseconds)
 {
-	return GetAlignedBufferSize((ms * sample_rate) / 1000u);
+	const u64 frames = (static_cast<u64>(milliseconds) * sample_rate) / 1000u;
+	return static_cast<u32>(std::clamp<u64>(frames, 1, std::numeric_limits<u32>::max()));
 }
 
-u32 AudioStream::GetMSForBufferSize(u32 sample_rate, u32 buffer_size)
+u32 AudioStream::GetMSForFrames(u32 sample_rate, u32 frames)
 {
-	buffer_size = GetAlignedBufferSize(buffer_size);
-	return (buffer_size * 1000u) / sample_rate;
+	return static_cast<u32>((static_cast<u64>(frames) * 1000u) / sample_rate);
+}
+
+u32 AudioStream::GetMSForFramesCeil(u32 sample_rate, u32 frames)
+{
+	return static_cast<u32>((static_cast<u64>(frames) * 1000u + sample_rate - 1u) / sample_rate);
 }
 
 static constexpr const std::array s_backend_names = {
@@ -779,9 +784,10 @@ void AudioStream::StretchOverrun()
 void AudioStreamParameters::LoadSave(SettingsWrapper& wrap, const char* section)
 {
 	wrap.EnumEntry(section, "ExpansionMode", expansion_mode, &AudioStream::ParseExpansionMode, &AudioStream::GetExpansionModeName, DEFAULT_EXPANSION_MODE);
-	minimal_output_latency = wrap.EntryBitBool(section, "OutputLatencyMinimal", DEFAULT_OUTPUT_LATENCY_MINIMAL);
 	buffer_ms = static_cast<u16>(std::clamp<int>(wrap.EntryBitfield(section, "BufferMS", buffer_ms, DEFAULT_BUFFER_MS), 0, std::numeric_limits<u16>::max()));
-	output_latency_ms = static_cast<u16>(std::clamp<int>(wrap.EntryBitfield(section, "OutputLatencyMS", output_latency_ms, DEFAULT_OUTPUT_LATENCY_MS), 0, std::numeric_limits<u16>::max()));
+	output_latency_ms = static_cast<u16>(std::clamp<int>(wrap.EntryBitfield(section, "OutputLatencyMS",
+															 output_latency_ms, DEFAULT_OUTPUT_LATENCY_MS),
+		1, std::numeric_limits<u16>::max()));
 
 	stretch_sequence_length_ms = static_cast<u16>(std::clamp<int>(wrap.EntryBitfield(section, "StretchSequenceLengthMS", DEFAULT_STRETCH_SEQUENCE_LENGTH), 0, std::numeric_limits<u16>::max()));
 	stretch_seekwindow_ms = static_cast<u16>(std::clamp<int>(wrap.EntryBitfield(section, "StretchSeekWindowMS", DEFAULT_STRETCH_SEEKWINDOW), 0, std::numeric_limits<u16>::max()));

--- a/pcsx2/Host/AudioStream.h
+++ b/pcsx2/Host/AudioStream.h
@@ -13,6 +13,8 @@
 #include <string_view>
 #include <vector>
 
+class AudioRateController;
+class AudioRateResampler;
 class Error;
 
 class FreeSurroundDecoder;
@@ -23,6 +25,13 @@ namespace soundtouch
 
 class AudioStream
 {
+	enum class ProcessingMode : u8
+	{
+		None,
+		Resample,
+		TimeStretch,
+	};
+
 public:
 	using SampleType = float;
 
@@ -45,8 +54,6 @@ public:
 public:
 	virtual ~AudioStream();
 
-	static u32 GetAlignedBufferSize(u32 size);
-	static u32 GetFrameCountForMS(u32 sample_rate, u32 milliseconds);
 	static u32 GetMSForFrames(u32 sample_rate, u32 frames);
 	static u32 GetMSForFramesCeil(u32 sample_rate, u32 frames);
 
@@ -61,16 +68,12 @@ public:
 	__fi u32 GetSampleRate() const { return m_sample_rate; }
 	__fi u32 GetInternalChannels() const { return m_internal_channels; }
 	__fi u32 GetOutputChannels() const { return m_internal_channels; }
-	__fi u32 GetBufferSize() const { return m_buffer_size; }
-	__fi u32 GetTargetBufferSize() const { return m_target_buffer_size; }
 	__fi u32 GetOutputVolume() const { return m_volume; }
-	__fi float GetNominalTempo() const { return m_nominal_rate; }
 	__fi AudioExpansionMode GetExpansionMode() const { return m_parameters.expansion_mode; }
 	__fi bool IsExpansionEnabled() const { return m_parameters.expansion_mode != AudioExpansionMode::Disabled; }
-	__fi bool IsStretchEnabled() const { return m_stretch_enabled; }
+	__fi bool IsStretchEnabled() const { return m_processing_mode == ProcessingMode::TimeStretch; }
+	__fi AudioSynchronizationMode GetSynchronizationMode() const { return m_sync_mode; }
 	__fi bool IsPaused() const { return m_paused; }
-
-	u32 GetBufferedFramesRelaxed() const;
 
 	/// Temporarily pauses the stream, preventing it from requesting data.
 	virtual void SetPaused(bool paused);
@@ -83,18 +86,20 @@ public:
 	void WriteFrame(const SampleType* frame);
 	void EndWrite(u32 num_frames);
 	void EmptyBuffer();
+	void ResetForSavestateLoad();
 
 	/// Nominal rate is used for both resampling and timestretching, input samples are assumed to be this amount faster
 	/// than the sample rate.
 	void SetNominalRate(float tempo);
+	void SetTargetSpeed(float speed);
 	void UpdateTargetTempo(float tempo);
 
-	void SetStretchEnabled(bool enabled);
+	void SetSynchronizationMode(AudioSynchronizationMode mode);
 
 	static std::vector<std::pair<std::string, std::string>> GetDriverNames(AudioBackend backend);
 	static std::vector<DeviceInfo> GetOutputDevices(AudioBackend backend, const char* driver);
 	static std::unique_ptr<AudioStream> CreateStream(AudioBackend backend, u32 sample_rate, const AudioStreamParameters& parameters,
-		const char* driver_name, const char* device_name, bool stretch_enabled, Error* error = nullptr);
+		const char* driver_name, const char* device_name, AudioSynchronizationMode sync_mode, Error* error = nullptr);
 	static std::unique_ptr<AudioStream> CreateNullStream(u32 sample_rate, u32 buffer_ms);
 
 protected:
@@ -114,7 +119,8 @@ protected:
 	using SampleReader = void (*)(SampleType* dest, const SampleType* src, u32 num_frames);
 
 	AudioStream(u32 sample_rate, const AudioStreamParameters& parameters);
-	void BaseInitialize(SampleReader sample_reader, bool stretch_enabled);
+	void BaseInitialize(SampleReader sample_reader, AudioSynchronizationMode sync_mode);
+	static u32 GetFrameCountForMS(u32 sample_rate, u32 milliseconds);
 
 	void ReadFrames(SampleType* samples, u32 num_frames);
 
@@ -129,7 +135,8 @@ protected:
 	AudioStreamParameters m_parameters;
 	u8 m_internal_channels = 0;
 	u8 m_output_channels = 0;
-	bool m_stretch_enabled = false;
+	AudioSynchronizationMode m_sync_mode = AudioSynchronizationMode::Disabled;
+	ProcessingMode m_processing_mode = ProcessingMode::None;
 	bool m_stretch_inactive = false;
 	bool m_filling = false;
 	bool m_paused = false;
@@ -143,17 +150,30 @@ private:
 	static std::vector<std::pair<std::string, std::string>> GetCubebDriverNames();
 	static std::vector<DeviceInfo> GetCubebOutputDevices(const char* driver);
 	static std::unique_ptr<AudioStream> CreateCubebAudioStream(u32 sample_rate, const AudioStreamParameters& parameters,
-		const char* driver_name, const char* device_name, bool stretch_enabled, Error* error);
+		const char* driver_name, const char* device_name, AudioSynchronizationMode sync_mode, Error* error);
 
 	static std::unique_ptr<AudioStream> CreateSDLAudioStream(u32 sample_rate, const AudioStreamParameters& parameters,
-		bool stretch_enabled, Error* error);
+		AudioSynchronizationMode sync_mode, Error* error);
 
 	void AllocateBuffer();
 	void DestroyBuffer();
+	static u32 GetAlignedBufferSize(u32 size);
+	u32 GetBufferedFramesRelaxed() const;
 
 	void InternalWriteFrames(const SampleType* samples, u32 num_frames);
 
 	void ExpandAllocate();
+
+	void ProcessorAllocate();
+	void ProcessorDestroy();
+	void ProcessWriteBlock(const float* block);
+	void SetProcessingMode(ProcessingMode mode);
+	ProcessingMode SelectProcessingMode(float speed) const;
+	void PrimeLowLatencyBuffer();
+	void ResetLowLatencyState(bool prime_buffer);
+	void ResampleAllocate();
+	void ResampleDestroy();
+	void ResampleBlock(const float* block);
 
 	void StretchAllocate();
 	void StretchDestroy();
@@ -170,7 +190,11 @@ private:
 
 	std::atomic<u32> m_rpos{0};
 	std::atomic<u32> m_wpos{0};
+	std::atomic<u32> m_callback_frames{0};
+	std::atomic<u32> m_discontinuity_count{0};
 
+	std::unique_ptr<AudioRateResampler> m_resampler;
+	std::unique_ptr<AudioRateController> m_rate_controller;
 	std::unique_ptr<soundtouch::SoundTouch> m_soundtouch;
 
 	u32 m_target_buffer_size = 0;
@@ -178,7 +202,10 @@ private:
 
 	u32 m_stretch_ok_count = 0;
 	float m_nominal_rate = 1.0f;
+	float m_target_speed = 1.0f;
 	float m_dynamic_target_usage = 0.0f;
+	u32 m_fade_in_frames_remaining = 0;
+	u32 m_seen_discontinuity_count = 0;
 
 	u32 m_average_position = 0;
 	u32 m_average_available = 0;

--- a/pcsx2/Host/AudioStream.h
+++ b/pcsx2/Host/AudioStream.h
@@ -46,8 +46,9 @@ public:
 	virtual ~AudioStream();
 
 	static u32 GetAlignedBufferSize(u32 size);
-	static u32 GetBufferSizeForMS(u32 sample_rate, u32 ms);
-	static u32 GetMSForBufferSize(u32 sample_rate, u32 buffer_size);
+	static u32 GetFrameCountForMS(u32 sample_rate, u32 milliseconds);
+	static u32 GetMSForFrames(u32 sample_rate, u32 frames);
+	static u32 GetMSForFramesCeil(u32 sample_rate, u32 frames);
 
 	static std::optional<AudioBackend> ParseBackendName(const char* str);
 	static const char* GetBackendName(AudioBackend backend);

--- a/pcsx2/Host/AudioStreamTypes.h
+++ b/pcsx2/Host/AudioStreamTypes.h
@@ -26,10 +26,19 @@ enum class AudioExpansionMode : u8
 	Count
 };
 
+enum class AudioSynchronizationMode : u8
+{
+	Disabled,
+	TimeStretch,
+	LowLatency,
+	Count
+};
+
 struct AudioStreamParameters
 {
 	AudioExpansionMode expansion_mode = DEFAULT_EXPANSION_MODE;
 	u16 buffer_ms = DEFAULT_BUFFER_MS;
+	u16 low_latency_buffer_ms = DEFAULT_LOW_LATENCY_BUFFER_MS;
 	u16 output_latency_ms = DEFAULT_OUTPUT_LATENCY_MS;
 
 	u16 stretch_sequence_length_ms = DEFAULT_STRETCH_SEQUENCE_LENGTH;
@@ -51,6 +60,7 @@ struct AudioStreamParameters
 
 	static constexpr AudioExpansionMode DEFAULT_EXPANSION_MODE = AudioExpansionMode::Disabled;
 	static constexpr u16 DEFAULT_BUFFER_MS = 50;
+	static constexpr u16 DEFAULT_LOW_LATENCY_BUFFER_MS = 20;
 	static constexpr u16 DEFAULT_OUTPUT_LATENCY_MS = 20;
 
 	static constexpr u16 DEFAULT_EXPAND_BLOCK_SIZE = 2048;

--- a/pcsx2/Host/AudioStreamTypes.h
+++ b/pcsx2/Host/AudioStreamTypes.h
@@ -29,7 +29,6 @@ enum class AudioExpansionMode : u8
 struct AudioStreamParameters
 {
 	AudioExpansionMode expansion_mode = DEFAULT_EXPANSION_MODE;
-	bool minimal_output_latency = DEFAULT_OUTPUT_LATENCY_MINIMAL;
 	u16 buffer_ms = DEFAULT_BUFFER_MS;
 	u16 output_latency_ms = DEFAULT_OUTPUT_LATENCY_MS;
 
@@ -53,7 +52,6 @@ struct AudioStreamParameters
 	static constexpr AudioExpansionMode DEFAULT_EXPANSION_MODE = AudioExpansionMode::Disabled;
 	static constexpr u16 DEFAULT_BUFFER_MS = 50;
 	static constexpr u16 DEFAULT_OUTPUT_LATENCY_MS = 20;
-	static constexpr bool DEFAULT_OUTPUT_LATENCY_MINIMAL = false;
 
 	static constexpr u16 DEFAULT_EXPAND_BLOCK_SIZE = 2048;
 	static constexpr float DEFAULT_EXPAND_CIRCULAR_WRAP = 90.0f;

--- a/pcsx2/Host/CubebAudioStream.cpp
+++ b/pcsx2/Host/CubebAudioStream.cpp
@@ -171,14 +171,12 @@ bool CubebAudioStream::Initialize(const char* driver_name, const char* device_na
 	params.layout = channel_setups[static_cast<size_t>(m_parameters.expansion_mode)].first;
 	params.prefs = CUBEB_STREAM_PREF_NONE;
 
-	u32 latency_frames = GetBufferSizeForMS(
-		m_sample_rate, (m_parameters.minimal_output_latency) ? m_parameters.buffer_ms : m_parameters.output_latency_ms);
-	u32 min_latency_frames = 0;
-	rv = cubeb_get_min_latency(m_context, &params, &min_latency_frames);
+	u32 minimum_latency_frames = 0;
+	rv = cubeb_get_min_latency(m_context, &params, &minimum_latency_frames);
 	if (rv == CUBEB_ERROR_NOT_SUPPORTED)
 	{
-		DEV_LOG("Cubeb backend does not support latency queries, using latency of {} ms ({} frames).",
-			m_parameters.buffer_ms, latency_frames);
+		minimum_latency_frames = 0;
+		DEV_LOG("Cubeb backend does not support minimum latency queries.");
 	}
 	else
 	{
@@ -189,19 +187,20 @@ bool CubebAudioStream::Initialize(const char* driver_name, const char* device_na
 			return false;
 		}
 
-		const u32 minimum_latency_ms = GetMSForBufferSize(m_sample_rate, min_latency_frames);
-		DEV_LOG("Minimum latency: {} ms ({} audio frames)", minimum_latency_ms, min_latency_frames);
-		if (m_parameters.minimal_output_latency)
-		{
-			// use minimum
-			latency_frames = min_latency_frames;
-		}
-		else if (minimum_latency_ms > m_parameters.output_latency_ms)
-		{
-			WARNING_LOG("Minimum latency is above requested latency: {} vs {}, adjusting to compensate.",
-				min_latency_frames, latency_frames);
-			latency_frames = min_latency_frames;
-		}
+		const u32 minimum_latency_ms = GetMSForFramesCeil(m_sample_rate, minimum_latency_frames);
+		DEV_LOG("Minimum latency: {} ms ({} audio frames)", minimum_latency_ms, minimum_latency_frames);
+	}
+
+	u32 latency_frames = GetFrameCountForMS(m_sample_rate, m_parameters.output_latency_ms);
+	const bool below_minimum = minimum_latency_frames > 0 && latency_frames < minimum_latency_frames;
+	if (below_minimum)
+	{
+		WARNING_LOG("Configured output latency requests {} frames below Cubeb's guaranteed minimum of {} frames.",
+			latency_frames, minimum_latency_frames);
+	}
+	else
+	{
+		DEV_LOG("Requesting Cubeb latency of {} frames.", latency_frames);
 	}
 
 	cubeb_devid selected_device = nullptr;
@@ -245,6 +244,15 @@ bool CubebAudioStream::Initialize(const char* driver_name, const char* device_na
 
 	rv = cubeb_stream_init(m_context, &stream, stream_name, nullptr, nullptr, selected_device, &params, latency_frames,
 		&CubebAudioStream::DataCallback, StateCallback, this);
+	// Verified subminimum requests have an effect on cubeb backends
+	if (rv != CUBEB_OK && below_minimum && !stream)
+	{
+		WARNING_LOG("Subminimum Cubeb latency request failed with {}; retrying the guaranteed minimum of {} frames.",
+			GetCubebErrorString(rv), minimum_latency_frames);
+		latency_frames = minimum_latency_frames;
+		rv = cubeb_stream_init(m_context, &stream, stream_name, nullptr, nullptr, selected_device, &params,
+			latency_frames, &CubebAudioStream::DataCallback, StateCallback, this);
+	}
 
 	if (devices_valid)
 		cubeb_device_collection_destroy(m_context, &devices);

--- a/pcsx2/Host/CubebAudioStream.cpp
+++ b/pcsx2/Host/CubebAudioStream.cpp
@@ -32,7 +32,7 @@ namespace
 
 		void SetPaused(bool paused) override;
 
-		bool Initialize(const char* driver_name, const char* device_name, bool stretch_enabled, Error* error);
+		bool Initialize(const char* driver_name, const char* device_name, AudioSynchronizationMode sync_mode, Error* error);
 
 	private:
 		static void LogCallback(const char* fmt, ...);
@@ -117,7 +117,8 @@ void CubebAudioStream::DestroyContextAndStream()
 #endif
 }
 
-bool CubebAudioStream::Initialize(const char* driver_name, const char* device_name, bool stretch_enabled, Error* error)
+bool CubebAudioStream::Initialize(
+	const char* driver_name, const char* device_name, AudioSynchronizationMode sync_mode, Error* error)
 {
 	cubeb_set_log_callback(CUBEB_LOG_NORMAL, LogCallback);
 
@@ -237,13 +238,13 @@ bool CubebAudioStream::Initialize(const char* driver_name, const char* device_na
 		}
 	}
 
-	BaseInitialize(channel_setups[static_cast<size_t>(m_parameters.expansion_mode)].second, stretch_enabled);
+	BaseInitialize(channel_setups[static_cast<size_t>(m_parameters.expansion_mode)].second, sync_mode);
 
 	char stream_name[32];
 	std::snprintf(stream_name, sizeof(stream_name), "%p", this);
 
-	rv = cubeb_stream_init(m_context, &stream, stream_name, nullptr, nullptr, selected_device, &params, latency_frames,
-		&CubebAudioStream::DataCallback, StateCallback, this);
+	rv = cubeb_stream_init(m_context, &stream, stream_name, nullptr, nullptr, selected_device, &params,
+		latency_frames, &CubebAudioStream::DataCallback, StateCallback, this);
 	// Verified subminimum requests have an effect on cubeb backends
 	if (rv != CUBEB_OK && below_minimum && !stream)
 	{
@@ -295,21 +296,33 @@ void CubebAudioStream::SetPaused(bool paused)
 	if (paused == m_paused || !stream)
 		return;
 
-	const int rv = paused ? cubeb_stream_stop(stream) : cubeb_stream_start(stream);
-	if (rv != CUBEB_OK)
+	if (paused)
 	{
-		ERROR_LOG("Could not {} stream: {}", paused ? "pause" : "resume", GetCubebErrorString(rv));
+		const int rv = cubeb_stream_stop(stream);
+		if (rv != CUBEB_OK)
+		{
+			ERROR_LOG("Could not pause stream: {}", GetCubebErrorString(rv));
+			return;
+		}
+
+		AudioStream::SetPaused(true);
 		return;
 	}
 
-	m_paused = paused;
+	AudioStream::SetPaused(false);
+	const int rv = cubeb_stream_start(stream);
+	if (rv != CUBEB_OK)
+	{
+		AudioStream::SetPaused(true);
+		ERROR_LOG("Could not resume stream: {}", GetCubebErrorString(rv));
+	}
 }
 
 std::unique_ptr<AudioStream> AudioStream::CreateCubebAudioStream(u32 sample_rate, const AudioStreamParameters& parameters,
-	const char* driver_name, const char* device_name, bool stretch_enabled, Error* error)
+	const char* driver_name, const char* device_name, AudioSynchronizationMode sync_mode, Error* error)
 {
 	std::unique_ptr<CubebAudioStream> stream = std::make_unique<CubebAudioStream>(sample_rate, parameters);
-	if (!stream->Initialize(driver_name, device_name, stretch_enabled, error))
+	if (!stream->Initialize(driver_name, device_name, sync_mode, error))
 		stream.reset();
 	return stream;
 }

--- a/pcsx2/Host/CubebAudioStream.cpp
+++ b/pcsx2/Host/CubebAudioStream.cpp
@@ -15,6 +15,9 @@
 #include "fmt/format.h"
 #include "IconsFontAwesome.h"
 
+#include <algorithm>
+#include <cmath>
+
 #ifdef _WIN32
 #include "common/RedtapeWindows.h"
 #include <objbase.h>
@@ -24,6 +27,29 @@
 
 namespace
 {
+	static constexpr const char* CUBEB_WASAPI_BACKEND = "wasapi";
+	static constexpr const char* CUBEB_IAUDIOCLIENT3_BACKEND = "iaudioclient3";
+	static constexpr const char* CUBEB_WASAPI_EXCLUSIVE_BACKEND = "wasapi-exclusive";
+
+	u32 GetCubebDeviceMinimumLatencyFrames(
+		const cubeb_device_info& device, u32 target_rate, const char* backend_id, u32 fallback_frames)
+	{
+		const bool is_wasapi = (backend_id && std::strcmp(backend_id, CUBEB_WASAPI_BACKEND) == 0);
+		const bool is_iaudioclient3 =
+			(backend_id && std::strcmp(backend_id, CUBEB_IAUDIOCLIENT3_BACKEND) == 0);
+		const bool is_wasapi_exclusive =
+			(backend_id && std::strcmp(backend_id, CUBEB_WASAPI_EXCLUSIVE_BACKEND) == 0);
+		if ((!is_wasapi && !is_iaudioclient3 && !is_wasapi_exclusive) || device.default_rate == 0)
+			return fallback_frames;
+
+		const u32 device_frames = (is_iaudioclient3 || is_wasapi_exclusive) ? device.latency_lo : device.latency_hi;
+		if (device_frames == 0)
+			return fallback_frames;
+
+		return static_cast<u32>((static_cast<u64>(device_frames) * target_rate + device.default_rate - 1) /
+								device.default_rate);
+	}
+
 	class CubebAudioStream : public AudioStream
 	{
 	public:
@@ -49,6 +75,8 @@ namespace
 
 		cubeb* m_context = nullptr;
 		cubeb_stream* stream = nullptr;
+		std::vector<float> m_s16_conversion_buffer;
+		bool m_s16_output = false;
 	};
 } // namespace
 
@@ -139,6 +167,10 @@ bool CubebAudioStream::Initialize(
 		return false;
 	}
 
+	const char* backend_id = cubeb_get_backend_id(m_context);
+	m_s16_output =
+		(backend_id && std::strcmp(backend_id, CUBEB_WASAPI_EXCLUSIVE_BACKEND) == 0);
+
 	static constexpr const std::array<std::pair<cubeb_channel_layout, SampleReader>,
 		static_cast<size_t>(AudioExpansionMode::Count)>
 		channel_setups = {{
@@ -166,7 +198,7 @@ bool CubebAudioStream::Initialize(
 		}};
 
 	cubeb_stream_params params = {};
-	params.format = CUBEB_SAMPLE_FLOAT32LE;
+	params.format = m_s16_output ? CUBEB_SAMPLE_S16LE : CUBEB_SAMPLE_FLOAT32LE;
 	params.rate = m_sample_rate;
 	params.channels = m_output_channels;
 	params.layout = channel_setups[static_cast<size_t>(m_parameters.expansion_mode)].first;
@@ -187,21 +219,6 @@ bool CubebAudioStream::Initialize(
 			DestroyContextAndStream();
 			return false;
 		}
-
-		const u32 minimum_latency_ms = GetMSForFramesCeil(m_sample_rate, minimum_latency_frames);
-		DEV_LOG("Minimum latency: {} ms ({} audio frames)", minimum_latency_ms, minimum_latency_frames);
-	}
-
-	u32 latency_frames = GetFrameCountForMS(m_sample_rate, m_parameters.output_latency_ms);
-	const bool below_minimum = minimum_latency_frames > 0 && latency_frames < minimum_latency_frames;
-	if (below_minimum)
-	{
-		WARNING_LOG("Configured output latency requests {} frames below Cubeb's guaranteed minimum of {} frames.",
-			latency_frames, minimum_latency_frames);
-	}
-	else
-	{
-		DEV_LOG("Requesting Cubeb latency of {} frames.", latency_frames);
 	}
 
 	cubeb_devid selected_device = nullptr;
@@ -221,6 +238,8 @@ bool CubebAudioStream::Initialize(
 					INFO_LOG("Using output device '{}' ({}).", di.device_id,
 						di.friendly_name ? di.friendly_name : di.device_id);
 					selected_device = di.devid;
+					minimum_latency_frames = GetCubebDeviceMinimumLatencyFrames(
+						di, m_sample_rate, cubeb_get_backend_id(m_context), minimum_latency_frames);
 					break;
 				}
 			}
@@ -238,7 +257,30 @@ bool CubebAudioStream::Initialize(
 		}
 	}
 
+	u32 latency_frames = GetFrameCountForMS(m_sample_rate, m_parameters.output_latency_ms);
+	const bool below_minimum = minimum_latency_frames > 0 && latency_frames < minimum_latency_frames;
+	if (minimum_latency_frames > 0)
+	{
+		DEV_LOG("Minimum latency: {} ms ({} audio frames)",
+			GetMSForFramesCeil(m_sample_rate, minimum_latency_frames), minimum_latency_frames);
+	}
+	if (below_minimum)
+	{
+		WARNING_LOG("Configured output latency requests {} frames below Cubeb's guaranteed minimum of {} frames.",
+			latency_frames, minimum_latency_frames);
+	}
+	else
+	{
+		DEV_LOG("Requesting Cubeb latency of {} frames.", latency_frames);
+	}
+
 	BaseInitialize(channel_setups[static_cast<size_t>(m_parameters.expansion_mode)].second, sync_mode);
+	if (m_s16_output)
+	{
+		// Cubeb accepts at most 96,000 requested frames. Leave another second
+		// for a driver-aligned exclusive buffer without allocating in the callback.
+		m_s16_conversion_buffer.resize(static_cast<size_t>(96000 + m_sample_rate) * m_output_channels);
+	}
 
 	char stream_name[32];
 	std::snprintf(stream_name, sizeof(stream_name), "%p", this);
@@ -287,7 +329,28 @@ void CubebAudioStream::StateCallback(cubeb_stream* stream, void* user_ptr, cubeb
 long CubebAudioStream::DataCallback(cubeb_stream* stm, void* user_ptr, const void* input_buffer, void* output_buffer,
 	long nframes)
 {
-	static_cast<CubebAudioStream*>(user_ptr)->ReadFrames(static_cast<float*>(output_buffer), static_cast<u32>(nframes));
+	CubebAudioStream* const stream = static_cast<CubebAudioStream*>(user_ptr);
+	if (!stream->m_s16_output)
+	{
+		stream->ReadFrames(static_cast<float*>(output_buffer), static_cast<u32>(nframes));
+		return nframes;
+	}
+
+	const size_t sample_count = static_cast<size_t>(nframes) * stream->m_output_channels;
+	if (sample_count > stream->m_s16_conversion_buffer.size())
+	{
+		ERROR_LOG("WASAPI exclusive callback requested too many frames: {}", nframes);
+		return CUBEB_ERROR;
+	}
+
+	float* const input = stream->m_s16_conversion_buffer.data();
+	stream->ReadFrames(input, static_cast<u32>(nframes));
+	s16* const output = static_cast<s16*>(output_buffer);
+	for (size_t i = 0; i < sample_count; i++)
+	{
+		const float sample = std::clamp(input[i], -1.0f, 1.0f);
+		output[i] = static_cast<s16>(std::lrintf(sample * (sample < 0.0f ? 32768.0f : 32767.0f)));
+	}
 	return nframes;
 }
 
@@ -334,7 +397,15 @@ std::vector<std::pair<std::string, std::string>> AudioStream::GetCubebDriverName
 
 	auto cubeb_names = cubeb_get_backend_names();
 	for (size_t i = 0; i < cubeb_names.count; i++)
-		names.emplace_back(cubeb_names.names[i], cubeb_names.names[i]);
+	{
+		const char* name = cubeb_names.names[i];
+		std::string display_name = name;
+		if (std::strcmp(name, CUBEB_IAUDIOCLIENT3_BACKEND) == 0)
+			display_name = TRANSLATE_STR("AudioStream", "IAudioClient3 (Low Latency)");
+		else if (std::strcmp(name, CUBEB_WASAPI_EXCLUSIVE_BACKEND) == 0)
+			display_name = TRANSLATE_STR("AudioStream", "WASAPI (Exclusive)");
+		names.emplace_back(name, std::move(display_name));
+	}
 
 	return names;
 }
@@ -383,7 +454,10 @@ std::vector<AudioStream::DeviceInfo> AudioStream::GetCubebOutputDevices(const ch
 
 	// we need stream parameters to query latency
 	cubeb_stream_params params = {};
-	params.format = CUBEB_SAMPLE_FLOAT32LE;
+	const char* backend_id = cubeb_get_backend_id(context);
+	params.format = (backend_id && std::strcmp(backend_id, CUBEB_WASAPI_EXCLUSIVE_BACKEND) == 0) ?
+	                    CUBEB_SAMPLE_S16LE :
+	                    CUBEB_SAMPLE_FLOAT32LE;
 	params.rate = 48000;
 	params.channels = 2;
 	params.layout = CUBEB_LAYOUT_UNDEFINED;
@@ -392,14 +466,14 @@ std::vector<AudioStream::DeviceInfo> AudioStream::GetCubebOutputDevices(const ch
 	u32 min_latency = 0;
 	cubeb_get_min_latency(context, &params, &min_latency);
 	ret[0].minimum_latency_frames = min_latency;
-
 	for (size_t i = 0; i < devices.count; i++)
 	{
 		const cubeb_device_info& di = devices.device[i];
 		if (!di.device_id)
 			continue;
 
-		ret.emplace_back(di.device_id, di.friendly_name ? di.friendly_name : di.device_id, min_latency);
+		ret.emplace_back(di.device_id, di.friendly_name ? di.friendly_name : di.device_id,
+			GetCubebDeviceMinimumLatencyFrames(di, params.rate, backend_id, min_latency));
 	}
 
 	return ret;

--- a/pcsx2/Host/SDLAudioStream.cpp
+++ b/pcsx2/Host/SDLAudioStream.cpp
@@ -19,7 +19,7 @@ namespace
 
 		void SetPaused(bool paused) override;
 
-		bool OpenDevice(bool stretch_enabled, Error* error);
+		bool OpenDevice(AudioSynchronizationMode sync_mode, Error* error);
 		void CloseDevice();
 
 	protected:
@@ -65,19 +65,19 @@ SDLAudioStream::~SDLAudioStream()
 }
 
 std::unique_ptr<AudioStream> AudioStream::CreateSDLAudioStream(u32 sample_rate, const AudioStreamParameters& parameters,
-	bool stretch_enabled, Error* error)
+	AudioSynchronizationMode sync_mode, Error* error)
 {
 	if (!InitializeSDLAudio(error))
 		return {};
 
 	std::unique_ptr<SDLAudioStream> stream = std::make_unique<SDLAudioStream>(sample_rate, parameters);
-	if (!stream->OpenDevice(stretch_enabled, error))
+	if (!stream->OpenDevice(sync_mode, error))
 		stream.reset();
 
 	return stream;
 }
 
-bool SDLAudioStream::OpenDevice(bool stretch_enabled, Error* error)
+bool SDLAudioStream::OpenDevice(AudioSynchronizationMode sync_mode, Error* error)
 {
 	pxAssert(!IsOpen());
 
@@ -117,7 +117,7 @@ bool SDLAudioStream::OpenDevice(bool stretch_enabled, Error* error)
 	else
 		DEV_LOG("SDL_GetAudioDeviceFormat() failed {}", SDL_GetError());
 
-	BaseInitialize(sample_readers[static_cast<size_t>(m_parameters.expansion_mode)], stretch_enabled);
+	BaseInitialize(sample_readers[static_cast<size_t>(m_parameters.expansion_mode)], sync_mode);
 	SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(m_stream));
 
 	return true;
@@ -129,11 +129,15 @@ void SDLAudioStream::SetPaused(bool paused)
 		return;
 
 	if (paused)
+	{
 		SDL_PauseAudioDevice(SDL_GetAudioStreamDevice(m_stream));
+		AudioStream::SetPaused(true);
+	}
 	else
+	{
+		AudioStream::SetPaused(false);
 		SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(m_stream));
-
-	m_paused = paused;
+	}
 }
 
 void SDLAudioStream::CloseDevice()

--- a/pcsx2/Host/SDLAudioStream.cpp
+++ b/pcsx2/Host/SDLAudioStream.cpp
@@ -102,8 +102,7 @@ bool SDLAudioStream::OpenDevice(bool stretch_enabled, Error* error)
 			READ_CHANNEL_REAR_LEFT, READ_CHANNEL_REAR_RIGHT>,
 	}};
 
-	uint samples = GetBufferSizeForMS(
-		m_sample_rate, (m_parameters.minimal_output_latency) ? m_parameters.buffer_ms : m_parameters.output_latency_ms);
+	uint samples = GetFrameCountForMS(m_sample_rate, m_parameters.output_latency_ms);
 
 	SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, fmt::format("{}", samples).c_str());
 

--- a/pcsx2/ImGui/FullscreenUI_Internal.h
+++ b/pcsx2/ImGui/FullscreenUI_Internal.h
@@ -422,7 +422,9 @@ namespace FullscreenUI
 		std::pair<ImFont*, float> summary_font = g_medium_font);
 	void DrawIntRangeSetting(SettingsInterface* bsi, const char* title, const char* summary, const char* section, const char* key,
 		int default_value, int min_value, int max_value, const char* format = "%d", bool enabled = true,
-		float height = ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT, std::pair<ImFont*, float> font = g_large_font, std::pair<ImFont*, float> summary_font = g_medium_font);
+		float height = ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT, std::pair<ImFont*, float> font = g_large_font,
+		std::pair<ImFont*, float> summary_font = g_medium_font, std::optional<int> marker_value = std::nullopt,
+		const char* marker_label = nullptr, const char* below_marker_message = nullptr);
 	void DrawIntSpinBoxSetting(SettingsInterface* bsi, const char* title, const char* summary, const char* section, const char* key,
 		int default_value, int min_value, int max_value, int step_value, const char* format = "%d", bool enabled = true,
 		float height = ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT, std::pair<ImFont*, float> font = g_large_font, std::pair<ImFont*, float> summary_font = g_medium_font);

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -3515,17 +3515,9 @@ void FullscreenUI::DrawAudioSettingsPage()
 	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_BUCKET, "Buffer Size"),
 		FSUI_CSTR("Determines the amount of audio buffered before being pulled by the host API."),
 		"SPU2/Output", "BufferMS", AudioStreamParameters::DEFAULT_BUFFER_MS, 10, 500, FSUI_CSTR("%d ms"));
-	if (!GetEffectiveBoolSetting(bsi, "Audio", "OutputLatencyMinimal", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MINIMAL))
-	{
-		DrawIntRangeSetting(
-			bsi, FSUI_ICONSTR(ICON_FA_STOPWATCH_20, "Output Latency"),
-			FSUI_CSTR("Determines how much latency there is between the audio being picked up by the host API, and "
-					  "played through speakers."),
-			"SPU2/Output", "OutputLatencyMS", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS, 1, 500, FSUI_CSTR("%d ms"));
-	}
-	DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_STOPWATCH, "Minimal Output Latency"),
-		FSUI_CSTR("When enabled, the minimum supported output latency will be used for the host API."),
-		"SPU2/Output", "OutputLatencyMinimal", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MINIMAL);
+	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_STOPWATCH_20, "Output Latency"),
+		FSUI_CSTR("Requests the host output latency. The backend may adjust or reject subminimum values."),
+		"SPU2/Output", "OutputLatencyMS", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS, 1, 500, FSUI_CSTR("%d ms"));
 
 	EndMenuButtons();
 }
@@ -5948,7 +5940,6 @@ TRANSLATE_NOOP("FullscreenUI", "Expansion");
 TRANSLATE_NOOP("FullscreenUI", "Synchronization");
 TRANSLATE_NOOP("FullscreenUI", "Buffer Size");
 TRANSLATE_NOOP("FullscreenUI", "Output Latency");
-TRANSLATE_NOOP("FullscreenUI", "Minimal Output Latency");
 TRANSLATE_NOOP("FullscreenUI", "Create Memory Card");
 TRANSLATE_NOOP("FullscreenUI", "Memory Card Directory");
 TRANSLATE_NOOP("FullscreenUI", "Folder Memory Card Filter");

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -3515,6 +3515,10 @@ void FullscreenUI::DrawAudioSettingsPage()
 	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_BUCKET, "Buffer Size"),
 		FSUI_CSTR("Determines the amount of audio buffered before being pulled by the host API."),
 		"SPU2/Output", "BufferMS", AudioStreamParameters::DEFAULT_BUFFER_MS, 10, 500, FSUI_CSTR("%d ms"));
+	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_STOPWATCH, "Low-Latency Buffer"),
+		FSUI_CSTR("Larger buffers reduce underrun in exchange for latency."),
+		"SPU2/Output", "LowLatencyBufferMS", AudioStreamParameters::DEFAULT_LOW_LATENCY_BUFFER_MS, 10, 100,
+		FSUI_CSTR("%d ms"));
 	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_STOPWATCH_20, "Output Latency"),
 		FSUI_CSTR("Requests the host output latency. The backend may adjust or reject subminimum values."),
 		"SPU2/Output", "OutputLatencyMS", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS, 1, 500, FSUI_CSTR("%d ms"));

--- a/pcsx2/ImGui/FullscreenUI_Settings.cpp
+++ b/pcsx2/ImGui/FullscreenUI_Settings.cpp
@@ -15,6 +15,7 @@
 #include "Input/InputManager.h"
 #include "MTGS.h"
 #include "Patch.h"
+#include "SPU2/spu2.h"
 #include "USB/USB.h"
 #include "VMManager.h"
 #include "ps2/BiosTools.h"
@@ -572,7 +573,9 @@ void FullscreenUI::DrawIntListSetting(SettingsInterface* bsi, const char* title,
 }
 
 void FullscreenUI::DrawIntRangeSetting(SettingsInterface* bsi, const char* title, const char* summary, const char* section, const char* key,
-	int default_value, int min_value, int max_value, const char* format, bool enabled, float height, std::pair<ImFont*, float> font, std::pair<ImFont*, float> summary_font)
+	int default_value, int min_value, int max_value, const char* format, bool enabled, float height, std::pair<ImFont*, float> font,
+	std::pair<ImFont*, float> summary_font, std::optional<int> marker_value, const char* marker_label,
+	const char* below_marker_message)
 {
 	const bool game_settings = IsEditingGameSettings(bsi);
 	const std::optional<int> value =
@@ -583,7 +586,7 @@ void FullscreenUI::DrawIntRangeSetting(SettingsInterface* bsi, const char* title
 	if (MenuButtonWithValue(title, summary, value_text.c_str(), enabled, height, font, summary_font))
 		ImGui::OpenPopup(title);
 
-	ImGui::SetNextWindowSize(LayoutScale(500.0f, 192.0f));
+	ImGui::SetNextWindowSize(LayoutScale(500.0f, marker_value.has_value() ? 280.0f : 192.0f));
 	ImGui::SetNextWindowPos(ImGui::GetIO().DisplaySize * 0.5f, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
 
 	ImGui::PushFont(g_large_font.first, g_large_font.second);
@@ -622,9 +625,43 @@ void FullscreenUI::DrawIntRangeSetting(SettingsInterface* bsi, const char* title
 
 			SetSettingsChanged(bsi);
 		}
+		if (marker_value.has_value() && max_value > min_value && marker_value.value() >= min_value &&
+			marker_value.value() <= max_value)
+		{
+			const ImVec2 slider_min = ImGui::GetItemRectMin();
+			const ImVec2 slider_max = ImGui::GetItemRectMax();
+			const float marker_fraction = static_cast<float>(marker_value.value() - min_value) /
+			                              static_cast<float>(max_value - min_value);
+			const float grab_padding = 2.0f;
+			const float slider_size = slider_max.x - slider_min.x - (grab_padding * 2.0f);
+			const float grab_size = std::min(
+				std::max(slider_size / static_cast<float>(max_value - min_value + 1), ImGui::GetStyle().GrabMinSize),
+				slider_size);
+			const float marker_min = slider_min.x + grab_padding + (grab_size * 0.5f);
+			const float marker_max = slider_max.x - grab_padding - (grab_size * 0.5f);
+			const float marker_x = marker_min + ((marker_max - marker_min) * marker_fraction);
+			ImGui::GetWindowDrawList()->AddLine(ImVec2(marker_x, slider_min.y), ImVec2(marker_x, slider_max.y),
+				ImGui::GetColorU32(ImVec4(1.0f, 0.75f, 0.25f, 1.0f)), LayoutScale(3.0f));
+		}
 
 		ImGui::PopStyleColor(7);
 		ImGui::PopStyleVar(3);
+		if (marker_label)
+		{
+			ImGui::SetCursorPosY(ImGui::GetCursorPosY() + LayoutScale(8.0f));
+			ImGui::PushTextWrapPos(0.0f);
+			if (below_marker_message && marker_value.has_value() && dlg_value < marker_value.value())
+			{
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.75f, 0.25f, 1.0f));
+				ImGui::TextUnformatted(below_marker_message);
+				ImGui::PopStyleColor();
+			}
+			else
+			{
+				ImGui::TextUnformatted(marker_label);
+			}
+			ImGui::PopTextWrapPos();
+		}
 
 		ImGui::SetCursorPosY(ImGui::GetCursorPosY() + LayoutScale(10.0f));
 		if (MenuButtonWithoutSummary(FSUI_CSTR("OK"), true, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY, g_large_font, ImVec2(0.5f, 0.0f)))
@@ -3480,6 +3517,68 @@ void FullscreenUI::DrawOSDSettingsPage()
 void FullscreenUI::DrawAudioSettingsPage()
 {
 	SettingsInterface* bsi = GetEditingSettingsInterface();
+	const auto get_effective_string = [bsi](const char* key, const char* default_value) {
+		if (IsEditingGameSettings(bsi))
+		{
+			std::optional<std::string> value = bsi->GetOptionalStringValue("SPU2/Output", key);
+			if (value.has_value())
+				return std::move(value.value());
+		}
+		return Host::Internal::GetBaseSettingsLayer()->GetStringValue("SPU2/Output", key, default_value);
+	};
+
+	const AudioBackend backend = AudioStream::ParseBackendName(
+		get_effective_string("Backend", AudioStream::GetBackendName(Pcsx2Config::SPU2Options::DEFAULT_BACKEND)).c_str())
+	                                 .value_or(Pcsx2Config::SPU2Options::DEFAULT_BACKEND);
+	const std::string driver_name = get_effective_string("DriverName", "");
+	const std::string device_name = get_effective_string("DeviceName", "");
+
+	struct OutputLatencyMinimumCache
+	{
+		AudioBackend backend = AudioBackend::Count;
+		std::string driver_name;
+		std::string device_name;
+		u32 frames = 0;
+	};
+	static OutputLatencyMinimumCache minimum_cache;
+	if (minimum_cache.backend != backend || minimum_cache.driver_name != driver_name ||
+		minimum_cache.device_name != device_name)
+	{
+		minimum_cache.backend = backend;
+		minimum_cache.driver_name = driver_name;
+		minimum_cache.device_name = device_name;
+		minimum_cache.frames = 0;
+
+		const std::vector<AudioStream::DeviceInfo> devices = AudioStream::GetOutputDevices(backend, driver_name.c_str());
+		const auto device = std::find_if(devices.begin(), devices.end(), [&device_name](const AudioStream::DeviceInfo& info) {
+			return info.name == device_name;
+		});
+		if (device != devices.end())
+			minimum_cache.frames = device->minimum_latency_frames;
+	}
+
+	const u32 minimum_latency_ms = AudioStream::GetMSForFramesCeil(SPU2::SAMPLE_RATE, minimum_cache.frames);
+	const int output_latency_ms = GetEffectiveIntSetting(
+		bsi, "SPU2/Output", "OutputLatencyMS", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS);
+	const std::optional<int> minimum_latency_marker =
+		minimum_latency_ms > 0 ? std::optional<int>(static_cast<int>(minimum_latency_ms)) : std::nullopt;
+	const SmallString minimum_latency_label = minimum_latency_marker.has_value() ?
+	                                              SmallString::from_format(FSUI_FSTR("Reported minimum: {} ms"),
+													  minimum_latency_marker.value()) :
+	                                              SmallString();
+	const SmallString below_minimum_warning = minimum_latency_marker.has_value() ?
+	                                              SmallString::from_format(
+													  FSUI_FSTR("Reported minimum: {} ms. Requested latency: {} ms. If audio is poor, "
+																"increase the requested latency."),
+													  minimum_latency_marker.value(), output_latency_ms) :
+	                                              SmallString();
+	const SmallString output_latency_summary =
+		(minimum_latency_marker.has_value() && output_latency_ms < minimum_latency_marker.value()) ?
+			below_minimum_warning :
+			(minimum_latency_marker.has_value() ?
+					SmallString::from_format(FSUI_FSTR("Backend minimum: {} ms. The backend may adjust the requested latency."),
+						minimum_latency_marker.value()) :
+					SmallString(FSUI_CSTR("Requests the host output latency. The backend may adjust or reject subminimum values.")));
 
 	BeginMenuButtons();
 
@@ -3519,9 +3618,12 @@ void FullscreenUI::DrawAudioSettingsPage()
 		FSUI_CSTR("Larger buffers reduce underrun in exchange for latency."),
 		"SPU2/Output", "LowLatencyBufferMS", AudioStreamParameters::DEFAULT_LOW_LATENCY_BUFFER_MS, 10, 100,
 		FSUI_CSTR("%d ms"));
-	DrawIntRangeSetting(bsi, FSUI_ICONSTR(ICON_FA_STOPWATCH_20, "Output Latency"),
-		FSUI_CSTR("Requests the host output latency. The backend may adjust or reject subminimum values."),
-		"SPU2/Output", "OutputLatencyMS", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS, 1, 500, FSUI_CSTR("%d ms"));
+	DrawIntRangeSetting(
+		bsi, FSUI_ICONSTR(ICON_FA_STOPWATCH_20, "Output Latency"),
+		output_latency_summary.c_str(), "SPU2/Output", "OutputLatencyMS", AudioStreamParameters::DEFAULT_OUTPUT_LATENCY_MS,
+		1, 500, FSUI_CSTR("%d ms"), true, ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT, g_large_font, g_medium_font,
+		minimum_latency_marker, minimum_latency_marker.has_value() ? minimum_latency_label.c_str() : nullptr,
+		minimum_latency_marker.has_value() ? below_minimum_warning.c_str() : nullptr);
 
 	EndMenuButtons();
 }

--- a/pcsx2/Pcsx2Config.cpp
+++ b/pcsx2/Pcsx2Config.cpp
@@ -1212,10 +1212,12 @@ bool Pcsx2Config::GSOptions::ShouldDump(u64 draw, int frame) const
 static constexpr const std::array s_spu2_sync_mode_names = {
 	"Disabled",
 	"TimeStretch",
+	"LowLatency",
 };
 static constexpr const std::array s_spu2_sync_mode_display_names = {
 	TRANSLATE_NOOP("Pcsx2Config", "Disabled (Noisy)"),
 	TRANSLATE_NOOP("Pcsx2Config", "TimeStretch (Recommended)"),
+	TRANSLATE_NOOP("Pcsx2Config", "Low Latency (Resampling)"),
 };
 
 const char* Pcsx2Config::SPU2Options::GetSyncModeName(SPU2SyncMode mode)
@@ -1311,6 +1313,7 @@ bool Pcsx2Config::SPU2Options::operator==(const SPU2Options& right) const
 		   OpEqu(FastForwardVolume) &&
 		   OpEqu(OutputMuted) &&
 		   OpEqu(Backend) &&
+		   OpEqu(SyncMode) &&
 		   OpEqu(StreamParameters) &&
 		   OpEqu(DriverName) &&
 		   OpEqu(DeviceName);

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -119,7 +119,7 @@ void SPU2::CreateOutputStream()
 
 	Error error;
 	s_output_stream = AudioStream::CreateStream(EmuConfig.SPU2.Backend, sample_rate, EmuConfig.SPU2.StreamParameters,
-		EmuConfig.SPU2.DriverName.c_str(), EmuConfig.SPU2.DeviceName.c_str(), EmuConfig.SPU2.IsTimeStretchEnabled(), &error);
+		EmuConfig.SPU2.DriverName.c_str(), EmuConfig.SPU2.DeviceName.c_str(), EmuConfig.SPU2.SyncMode, &error);
 	if (!s_output_stream)
 	{
 		Host::ReportErrorAsync("Error",
@@ -131,6 +131,7 @@ void SPU2::CreateOutputStream()
 
 	SPU2::UpdateOutputVolume();
 	s_output_stream->SetNominalRate(GetNominalRate());
+	s_output_stream->SetTargetSpeed(VMManager::GetTargetSpeed());
 	s_output_stream->SetPaused(VMManager::GetState() == VMState::Paused);
 }
 
@@ -256,13 +257,14 @@ void SPU2::OnTargetSpeedChanged()
 	if (!s_output_stream)
 		return;
 
-	if (!s_output_stream->IsStretchEnabled())
+	if (s_output_stream->GetSynchronizationMode() == AudioSynchronizationMode::Disabled)
 	{
 		s_output_stream->EmptyBuffer();
 		s_current_chunk_pos = 0;
 	}
 
 	s_output_stream->SetNominalRate(GetNominalRate());
+	s_output_stream->SetTargetSpeed(VMManager::GetTargetSpeed());
 
 	// Flipped save as speed has already changed.
 	if (!s_output_muted)
@@ -358,9 +360,9 @@ void SPU2::CheckForConfigChanges(const Pcsx2Config& old_config)
 	{
 		CreateOutputStream();
 	}
-	else if (opts.IsTimeStretchEnabled() != old_opts.IsTimeStretchEnabled())
+	else if (opts.SyncMode != old_opts.SyncMode)
 	{
-		s_output_stream->SetStretchEnabled(opts.IsTimeStretchEnabled());
+		s_output_stream->SetSynchronizationMode(opts.SyncMode);
 	}
 
 #ifdef PCSX2_DEVBUILD
@@ -479,7 +481,12 @@ s32 SPU2freeze(FreezeAction mode, freezeData* data)
 	switch (mode)
 	{
 		case FreezeAction::Load:
-			return SPU2Savestate::ThawIt(spud);
+		{
+			const s32 result = SPU2Savestate::ThawIt(spud);
+			if (result == 0 && s_output_stream)
+				s_output_stream->ResetForSavestateLoad();
+			return result;
+		}
 		case FreezeAction::Save:
 			return SPU2Savestate::FreezeIt(spud);
 

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -259,6 +259,8 @@
     <ClCompile Include="GS\Renderers\Vulkan\vk_mem_alloc.cpp">
       <ExcludedFromBuild Condition="'$(Platform)'=='ARM64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="Host\AudioRateController.cpp" />
+    <ClCompile Include="Host\AudioRateResampler.cpp" />
     <ClCompile Include="Host\AudioStream.cpp" />
     <ClCompile Include="Host\CubebAudioStream.cpp" />
     <ClCompile Include="Host\SDLAudioStream.cpp" />
@@ -709,6 +711,8 @@
     <ClInclude Include="GS\Renderers\Vulkan\VKSwapChain.h">
       <ExcludedFromBuild Condition="'$(Platform)'=='ARM64'">true</ExcludedFromBuild>
     </ClInclude>
+    <ClInclude Include="Host\AudioRateController.h" />
+    <ClInclude Include="Host\AudioRateResampler.h" />
     <ClInclude Include="Host\AudioStream.h" />
     <ClInclude Include="Host\AudioStreamTypes.h" />
     <ClInclude Include="ImGui\FullscreenUI.h" />

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -1449,6 +1449,12 @@
     <ClCompile Include="Host\AudioStream.cpp">
       <Filter>Misc\Host</Filter>
     </ClCompile>
+    <ClCompile Include="Host\AudioRateController.cpp">
+      <Filter>Misc\Host</Filter>
+    </ClCompile>
+    <ClCompile Include="Host\AudioRateResampler.cpp">
+      <Filter>Misc\Host</Filter>
+    </ClCompile>
     <ClCompile Include="Host\SDLAudioStream.cpp">
       <Filter>Misc\Host</Filter>
     </ClCompile>
@@ -2414,6 +2420,12 @@
       <Filter>System\Ps2\USB\usb-eyetoy</Filter>
     </ClInclude>
     <ClInclude Include="Host\AudioStream.h">
+      <Filter>Misc\Host</Filter>
+    </ClInclude>
+    <ClInclude Include="Host\AudioRateController.h">
+      <Filter>Misc\Host</Filter>
+    </ClInclude>
+    <ClInclude Include="Host\AudioRateResampler.h">
       <Filter>Misc\Host</Filter>
     </ClInclude>
     <ClInclude Include="Host\AudioStreamTypes.h">


### PR DESCRIPTION
### Description of Changes
Add a low-latency audio sync mode with tight rate control and resampling. The new sync mode keeps the correction window capped at +/-1% target speed, allowing tighter buffers and much lower latency at the cost of sounding like hot garbage during slowdowns.

Through testing, I also noticed that requesting lower latency amounts than what cubeb reports as the minimum actually **does** result in those latencies being requested.

For instance, on my linux machine I have all my audio devices tuned for low latency playback and is capable of running pulseaudio with only a 64 frame quant (~0.02ms). Cubeb reports 25ms as the minimum floor for the pulse backend which is way too high even for a non-tuned system.

If I ignore that and request 1ms from cubeb anyway, the measured rate ended up being ~120 frames, ~4ms. Significantly better than before.

Currently in PCSX2, TimeStretch is enabled through the SoundTouch library with ::setTempo. This does great work during fast-forward and slowdowns as it keeps the pitch of the audio the same and sounds nice and clean. Problem is, with the current defaults, SoundTouch is configured with a 30ms sequence, 20ms seek window and 10ms overlap. On average this results in ~40ms of delay, even if the rest of the pipeline is set to tight values. In practice, this meant the minimum latency with all minimum values set was ~80ms.

TimeStretch does still sound great however, so when fast-forwarding or slow-mo, pcsx2 will switch to TimeStretch till the game goes back to full speed.

In my testing on linux with all settings set as low as they could go, I was getting a real end-to-end audio latency of about **11ms** which is perfect for rhythm titles! Over a few hour play session in Frequency I only got 48 partial underflows. They were not perceptible to me, but more sensitive users may need to increase buffer size.

### New Windows Backends
On windows I added two new backend modes. Thank you to @Filoppi for their open PR https://github.com/mozilla/cubeb/pull/740 on cubeb, it made this work much easier.

**WASAPI Exclusive Mode**: You're likely familiar with this, has high compatibility and very low latency, depending on hardware you can get this below 3ms. Downside is no mixer support, so no volume changing and nothing else on your computer will be able to play audio.

**IAudioClient3**: More modern audio interface from Microsoft. Needs hardware capable of WaveRT to run in low latency mode. If WaveRT is supported then IAC3 can run at or below 3ms latency as well, without the mixer trade off. Basically exclusive mode without the downsides! If WaveRT is not supported, then it will operate at 10ms latency, same was WASAPI shared mode. Most hardware after 2015 has WaveRT support so this is the preferred mode, but if you have older hardware there is still WASAPI exclusive.

<img width="905" height="831" alt="image" src="https://github.com/user-attachments/assets/91856ad3-c0bd-4286-869d-f2d399af0508" />
