### PR TITLE
ACUART: fix interrupt and transmitter state

### DIFF
--- a/pcsx2/DEV9/ACCORE.cpp
+++ b/pcsx2/DEV9/ACCORE.cpp
@@ -1,6 +1,7 @@
 #include "DEV9.h"
 #include "IopDma.h"
 #include "ACCORE.h"
+#include "ACUART.h"
 #include "ACJV.h"
 #include "ACMACROS.h"
 #include "common/Console.h"
@@ -17,7 +18,7 @@ u16 ACCORE::Read16(u32 mem) {
 	case 0x1241C000:
 		// Console.Error("%-16s %08X: %04X", __FUNCTION__, mem, INTR_REG);
     	return INTR_REG; // ACRAM will wait 0xFFFFF times for this to not have 0x1000 bitmask set. also used inside intr_intr (interrup handler 13 declared on accore)
-    
+
     break;
     default: Console.Error("%-16s %08X:  %04X", "ACUNK::Read16", mem, 0); return 0;
     }
@@ -87,6 +88,7 @@ void ACCORE::Interrupt(u32 mem, u16 v) {
 		break;
 	case ACCORE_INTR_UART:
 		CLRB(INTR_REG, CAUS_UART); // acknowledge the UART RX interrupt (clear its cause bit)
+		ACUART::RefreshInterruptLine();
 		break;
 	default:
 		Console.Warning("ACCORE: unknown INTR write to: %08X", mem);

--- a/pcsx2/DEV9/ACUART.cpp
+++ b/pcsx2/DEV9/ACUART.cpp
@@ -29,6 +29,38 @@ u16 ACUART::DLL = 0;
 u16 ACUART::DLH = 0;
 u16 ACUART::FCR_SHADOW = 0;
 std::unique_ptr<ACUARTDevice> ACUART::s_device;
+static bool s_tx_ready = true;
+static bool s_tx_interrupt_pending = false;
+
+void ACUART::ResetTransmitState()
+{
+	s_tx_ready = true;
+	s_tx_interrupt_pending = false;
+}
+
+void ACUART::RefreshInterruptLine()
+{
+	const bool rx_interrupt_pending = (IER & 0x01) && s_device && s_device->HasData();
+	const bool tx_interrupt_pending = (IER & 0x02) && s_tx_interrupt_pending;
+	if (rx_interrupt_pending || tx_interrupt_pending)
+		ACCORE::intr(ACCORE::INTRN_UART);
+}
+
+void ACUART::Tick(u32 cycles)
+{
+	if (!s_tx_ready)
+	{
+		s_tx_ready = true;
+		if (IER & 0x02)
+		{
+			s_tx_interrupt_pending = true;
+			RefreshInterruptLine();
+		}
+	}
+
+	if (s_device)
+		s_device->Tick(cycles);
+}
 
 u16 ACUART::Read16(u32 addr) {
 	u16 r = 0;
@@ -54,7 +86,15 @@ u16 ACUART::Read16(u32 addr) {
 			r = ACUART::IER;
 		break;
 	case 0x004: // IIR (read-only)
-		r = 0x01; // no interrupt pending, 16550 mode
+		if ((IER & 0x01) && s_device && s_device->HasData())
+			r = 0x04; // RX data available
+		else if ((IER & 0x02) && s_tx_interrupt_pending)
+		{
+			r = 0x02; // TX holding register empty
+			s_tx_interrupt_pending = false;
+		}
+		else
+			r = 0x01; // no interrupt pending, 16550 mode
 		break;
 	case 0x006: // LCR
 		r = ACUART::LCR;
@@ -67,7 +107,7 @@ u16 ACUART::Read16(u32 addr) {
 		// bit 6 = TEMT (TX shift register empty)
 		// both set = transmitter idle, ready to accept data
 		// bit 0 = DR (RX data ready) — set while the V257 status FIFO has bytes (RRV)
-		r = 0x60 | ((s_device && s_device->HasData()) ? 0x01 : 0x00);
+		r = (s_tx_ready ? 0x60 : 0x00) | ((s_device && s_device->HasData()) ? 0x01 : 0x00);
 		//r = 0x60 | ((s_v257RxFifo.empty()) ? 0x00 : 0x01);
 		break;
 	case 0x00C: // MSR
@@ -91,6 +131,8 @@ void ACUART::Write16(u32 addr, u16 val) {
 		if (ACUART::LCR & 0x80)
 			ACUART::DLL = val;
 		else {
+			s_tx_ready = false;
+			s_tx_interrupt_pending = false;
 			ACUART_LOG("TX:%02X", val);
 			if (s_device)
 				s_device->TxByte((u8)val);
@@ -100,10 +142,22 @@ void ACUART::Write16(u32 addr, u16 val) {
 		if (ACUART::LCR & 0x80)
 			ACUART::DLH = val;
 		else
+		{
+			const u16 old_ier = ACUART::IER;
 			ACUART::IER = val;
+			if (!(val & 0x02))
+				s_tx_interrupt_pending = false;
+			else if (!(old_ier & 0x02) && s_tx_ready)
+			{
+				s_tx_interrupt_pending = true;
+				RefreshInterruptLine();
+			}
+		}
 		break;
 	case 0x004: // FCR (write-only) — val=7 on module stop: enable FIFO + reset RX/TX (acUartModuleStop)
 		ACUART::FCR_SHADOW = val & 0xC9; // preserve trigger level + enable bits
+		if (val & 0x04)
+			ResetTransmitState();
 		break;
 	case 0x006: // LCR
 		ACUART::LCR = val;

--- a/pcsx2/DEV9/ACUART.h
+++ b/pcsx2/DEV9/ACUART.h
@@ -8,6 +8,9 @@
 
 namespace ACUART {
     bool SetupGameHandler(const std::string& S);
+    void ResetTransmitState();
+    void RefreshInterruptLine();
+    void Tick(u32 cycles);
     u16 Read16(u32 addr);
     void Write16(u32 addr, u16 val);
     extern std::unique_ptr<ACUARTDevice> s_device;

--- a/pcsx2/DEV9/ACUART_GLUE.cpp
+++ b/pcsx2/DEV9/ACUART_GLUE.cpp
@@ -142,6 +142,7 @@ bool ACUART::SetupGameHandler(const std::string& S) {
         s_device = std::make_unique<Bg3HandleDevice>();
     else 
         return false;
+    ResetTransmitState();
     s_device->Reset();
     return true;
 }

--- a/pcsx2/DEV9/DEV9.cpp
+++ b/pcsx2/DEV9/DEV9.cpp
@@ -106,6 +106,7 @@ s32 DEV9init()
 	DevCon.WriteLn("DEV9: DEV9init");
 
 	memset(&dev9, 0, sizeof(dev9));
+	ACUART::ResetTransmitState();
 	dev9.ata = new ATA();
 	DevCon.WriteLn("DEV9: DEV9init2");
 
@@ -1174,7 +1175,7 @@ void DEV9async(u32 cycles)
 {
 	//smap_async(cycles);
 	//dev9.ata->Async(cycles);
-	if (ACUART::s_device) ACUART::s_device->Tick(cycles);
+	ACUART::Tick(cycles);
 	ACJV::UpdateFcaFrame();     // ...and free-run the FCA-1 input frame
 }
 


### PR DESCRIPTION
### Description of Changes

 - Track the ACUART transmit holding register state.
 - Mark the transmitter busy after a byte is written and ready again on the next DEV9 update.
 - Track pending transmit-empty interrupts.
 - Report receive-data and transmit-empty causes through the Interrupt Identification Register.
 - Preserve a pending UART cause when the guest acknowledges another cause.
 - Reset transmitter state during DEV9 initialization, game-handler setup, and transmit FIFO reset.
 - Update the selected ACUART device through the generic ACUART tick function.

 ### Rationale behind Changes

ACUART previously reported that no interrupt was pending and that the transmitter was always empty. This prevented comsumers from correctly identifying receive-data and transmit-empty interrupts.

The changes implement the generic UART state needed by ACUART devices without adding game-specific behavior.

### Suggested Testing Steps

The other consumers of the ACUART interface are the Battle Gear 3 and Ridge Racer V ACUART devices. I do not have access to those games so I cannot verify that this change does not affect them. Their use of the interface should not be impacted.

### Did you use AI to help find, test, or implement this issue or feature?

This patch was generated using ChatGPT-5.6-Sol. I have performed a manual review and clean-up afterwards to verify the implementation and make sure that the change scope is minimal.

### Related GameIDs

This change is necessary for the upcoming Druaga Online (NM00028) ACUART card reader emulation for properly managing two-way communication.