### PR TITLE
DEV9: Add Druaga Online IC card reader support

### DIFF
--- a/pcsx2/CMakeLists.txt
+++ b/pcsx2/CMakeLists.txt
@@ -325,6 +325,7 @@ set(pcsx2DEV9Sources
 	DEV9/ACATA_IO.cpp
 	DEV9/ACATA_IO_CHD.cpp
 	DEV9/ACATAPI.cpp
+	DEV9/ACDruagaCardReader.cpp
 	DEV9/ACJV.cpp
 	DEV9/ACUART.cpp
 	DEV9/ACUART_GLUE.cpp
@@ -333,6 +334,7 @@ set(pcsx2DEV9Sources
 
 # DEV9 headers
 set(pcsx2DEV9Headers
+	DEV9/ACDruagaCardReader.h
 	DEV9/AdapterUtils.h
 	DEV9/ATA/ATA.h
 	DEV9/ATA/HddCreate.h

--- a/pcsx2/DEV9/ACDruagaCardReader.cpp
+++ b/pcsx2/DEV9/ACDruagaCardReader.cpp
@@ -1,0 +1,440 @@
+#include "ACDruagaCardReader.h"
+
+#include "VMManager.h"
+#include "common/Console.h"
+#include "common/FileSystem.h"
+#include "common/Path.h"
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cstring>
+
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+namespace ACDruagaCardReader
+{
+static constexpr size_t CARD_SIZE = 0x300;
+static constexpr size_t MAX_FRAME_SIZE = 64;
+
+enum class Command : u8
+{
+	PrepareAccess = 0x40,
+	Read16 = 0x41,
+	Write16 = 0x42,
+	Control = 0x44,
+	FinishAccess = 0x47,
+	Read48 = 0x48,
+	Write48 = 0x49,
+	Configure = 0x50,
+	Initialize = 0x56,
+	PollStatus = 0x80,
+	TransportStart = 0x81,
+	TransportContinue = 0x82,
+	Identify = 0x83,
+};
+
+enum class CardPhase
+{
+	Absent,
+	TransportRequested,
+	TransportContinuing,
+	Ready,
+	Releasing,
+};
+
+struct Request
+{
+	Command command;
+	std::vector<u8> payload;
+};
+
+static std::vector<u8> s_tx;
+static std::deque<std::vector<u8>> s_replies;
+static std::array<u8, CARD_SIZE> s_card{};
+static std::string s_card_path;
+static FileSystem::ManagedCFilePtr s_card_file;
+static CardPhase s_phase = CardPhase::Absent;
+static bool s_card_mounted = false;
+
+static std::vector<u8> SerializeFrame(Command command, const u8* payload, size_t payload_size)
+{
+	std::vector<u8> frame;
+	frame.reserve(payload_size + 7);
+	frame.push_back(0x02);
+	frame.push_back(static_cast<u8>(command));
+	frame.push_back(static_cast<u8>(payload_size));
+	frame.insert(frame.end(), payload, payload + payload_size);
+	frame.push_back(0x03);
+	u8 checksum = 0;
+	for (size_t i = 1; i < frame.size(); i++)
+		checksum ^= frame[i];
+	frame.insert(frame.end(), {checksum, 0x0d, 0x0a});
+	return frame;
+}
+
+template <size_t N>
+static void QueueReply(Command command, const std::array<u8, N>& payload)
+{
+	s_replies.push_back(SerializeFrame(command, payload.data(), payload.size()));
+}
+
+static bool HasPayloadSize(const Request& request, size_t expected)
+{
+	if (request.payload.size() == expected)
+		return true;
+	Console.Error("ACUART: Druaga reader command 0x%02x has %zu payload bytes; expected %zu",
+		static_cast<u8>(request.command), request.payload.size(), expected);
+	return false;
+}
+
+static int CardFileDescriptor()
+{
+	if (!s_card_file)
+		return -1;
+#ifdef _WIN32
+	return _fileno(s_card_file.get());
+#else
+	return fileno(s_card_file.get());
+#endif
+}
+
+static bool ReadCardFile()
+{
+	const int fd = CardFileDescriptor();
+	if (fd < 0)
+		return false;
+
+	size_t completed = 0;
+	while (completed < s_card.size())
+	{
+#ifdef _WIN32
+		if (_lseeki64(fd, static_cast<s64>(completed), SEEK_SET) < 0)
+			return false;
+		const int result = _read(fd, s_card.data() + completed, static_cast<unsigned int>(s_card.size() - completed));
+#else
+		const ssize_t result = pread(fd, s_card.data() + completed, s_card.size() - completed, static_cast<off_t>(completed));
+#endif
+		if (result > 0)
+		{
+			completed += static_cast<size_t>(result);
+			continue;
+		}
+		if (result < 0 && errno == EINTR)
+			continue;
+		return false;
+	}
+	return true;
+}
+
+static bool WriteCardRange(size_t offset, const u8* data, size_t size)
+{
+	const int fd = CardFileDescriptor();
+	if (fd < 0 || offset > CARD_SIZE || size > CARD_SIZE - offset)
+		return false;
+
+	size_t completed = 0;
+	while (completed < size)
+	{
+#ifdef _WIN32
+		if (_lseeki64(fd, static_cast<s64>(offset + completed), SEEK_SET) < 0)
+			break;
+		const int result = _write(fd, data + completed, static_cast<unsigned int>(size - completed));
+#else
+		const ssize_t result = pwrite(fd, data + completed, size - completed, static_cast<off_t>(offset + completed));
+#endif
+		if (result > 0)
+		{
+			completed += static_cast<size_t>(result);
+			continue;
+		}
+		if (result < 0 && errno == EINTR)
+			continue;
+		break;
+	}
+
+	const bool written = completed == size;
+	if (!written)
+		Console.Error("ACUART: Druaga reader failed to write %zu bytes at card offset 0x%zx in '%s'",
+			size, offset, s_card_path.c_str());
+	return written;
+}
+
+static void UnmountCard()
+{
+	s_card_file.reset();
+	s_card_path.clear();
+	s_card_mounted = false;
+	s_phase = CardPhase::Absent;
+}
+
+static u32 ReadCardU32(size_t offset)
+{
+	return static_cast<u32>(s_card[offset]) |
+		(static_cast<u32>(s_card[offset + 1]) << 8) |
+		(static_cast<u32>(s_card[offset + 2]) << 16) |
+		(static_cast<u32>(s_card[offset + 3]) << 24);
+}
+
+static void QueueOperationReply(Command command, bool success)
+{
+	QueueReply(command, std::array<u8, 2>{success ? u8{0x00} : u8{0x02}, 0x00});
+}
+
+template <size_t N>
+static std::optional<size_t> BlockOffset(u8 block)
+{
+	const size_t offset = static_cast<size_t>(block) * N;
+	return (offset <= s_card.size() && N <= s_card.size() - offset) ? std::optional<size_t>(offset) : std::nullopt;
+}
+
+template <size_t N>
+static void ReadBlock(const Request& request)
+{
+	if (!HasPayloadSize(request, 1))
+		return;
+	std::array<u8, N + 2> payload{};
+	const std::optional<size_t> offset = BlockOffset<N>(request.payload[0]);
+	if (!s_card_mounted || !offset.has_value())
+		payload[0] = 0x02;
+	else
+		std::memcpy(payload.data() + 2, s_card.data() + *offset, N);
+	QueueReply(request.command, payload);
+}
+
+template <size_t N>
+static void WriteBlock(const Request& request)
+{
+	if (!HasPayloadSize(request, N + 1))
+		return;
+	const std::optional<size_t> offset = BlockOffset<N>(request.payload[0]);
+	if (!s_card_mounted || !offset.has_value())
+	{
+		QueueOperationReply(request.command, false);
+		return;
+	}
+	const u8* const data = request.payload.data() + 1;
+	const bool written = WriteCardRange(*offset, data, N);
+	if (written)
+		std::memcpy(s_card.data() + *offset, data, N);
+	QueueOperationReply(request.command, written);
+}
+
+static void HandleRequest(const Request& request)
+{
+	switch (request.command)
+	{
+		case Command::Identify:
+			if (HasPayloadSize(request, 0))
+				QueueReply(request.command, std::array<u8, 4>{'3', '5', '0', '0'});
+			break;
+		case Command::Initialize:
+			if (HasPayloadSize(request, 0))
+				QueueReply(request.command, std::array<u8, 2>{0x00, 0x00});
+			break;
+		case Command::Configure:
+			if (HasPayloadSize(request, 13))
+				QueueReply(request.command, std::array<u8, 2>{0x00, 0x00});
+			break;
+		case Command::PollStatus:
+			if (HasPayloadSize(request, 0))
+			{
+				const u8 status = (s_phase == CardPhase::Absent) ? 0x00 :
+					((s_phase == CardPhase::Ready || s_phase == CardPhase::Releasing) ? 0x02 : 0x01);
+				QueueReply(request.command, std::array<u8, 1>{status});
+			}
+			break;
+		case Command::TransportStart:
+			if (HasPayloadSize(request, 1))
+			{
+				if (request.payload[0] == '1' && s_phase == CardPhase::TransportRequested)
+					s_phase = CardPhase::TransportContinuing;
+				else if (request.payload[0] == '6' && s_card_mounted)
+					s_phase = CardPhase::Releasing;
+				QueueReply(request.command, std::array<u8, 1>{'1'});
+			}
+			break;
+		case Command::TransportContinue:
+			if (HasPayloadSize(request, 1))
+			{
+				if (request.payload[0] == '1' && s_phase == CardPhase::TransportContinuing)
+					s_phase = CardPhase::Ready;
+				else if (request.payload[0] == '1' && s_phase == CardPhase::Releasing)
+					UnmountCard();
+				QueueReply(request.command, std::array<u8, 1>{'1'});
+			}
+			break;
+		case Command::PrepareAccess:
+			if (HasPayloadSize(request, 4))
+				QueueOperationReply(request.command, s_card_mounted);
+			break;
+		case Command::FinishAccess:
+			if (HasPayloadSize(request, 0))
+				QueueOperationReply(request.command, s_card_mounted);
+			break;
+		case Command::Read16:
+			ReadBlock<16>(request);
+			break;
+		case Command::Read48:
+			ReadBlock<48>(request);
+			break;
+		case Command::Write16:
+			WriteBlock<16>(request);
+			break;
+		case Command::Write48:
+			WriteBlock<48>(request);
+			break;
+		case Command::Control:
+		{
+			if (!HasPayloadSize(request, 5) || !s_card_mounted || request.payload[0] != 2)
+			{
+				QueueOperationReply(request.command, false);
+				break;
+			}
+			const u32 amount = static_cast<u32>(request.payload[1]) |
+				(static_cast<u32>(request.payload[2]) << 8) |
+				(static_cast<u32>(request.payload[3]) << 16) |
+				(static_cast<u32>(request.payload[4]) << 24);
+			u32 generation = ReadCardU32(0x20);
+			u32 complement = ReadCardU32(0x24);
+			const u32 repeated = ReadCardU32(0x28);
+			if (generation != repeated || generation != ~complement)
+			{
+				QueueOperationReply(request.command, false);
+				break;
+			}
+			std::array<u8, 12> header{};
+			std::memcpy(header.data(), s_card.data() + 0x20, header.size());
+			generation -= amount;
+			complement = ~generation;
+			const auto write_u32 = [&header](size_t offset, u32 value) {
+				header[offset] = static_cast<u8>(value);
+				header[offset + 1] = static_cast<u8>(value >> 8);
+				header[offset + 2] = static_cast<u8>(value >> 16);
+				header[offset + 3] = static_cast<u8>(value >> 24);
+			};
+			write_u32(0, generation);
+			write_u32(4, complement);
+			std::copy_n(header.data(), 4, header.data() + 8);
+			const bool written = WriteCardRange(0x20, header.data(), header.size());
+			if (written)
+				std::memcpy(s_card.data() + 0x20, header.data(), header.size());
+			QueueOperationReply(request.command, written);
+			break;
+		}
+		default:
+			Console.Error("ACUART: Druaga reader command 0x%02x is not implemented", static_cast<u8>(request.command));
+			break;
+	}
+}
+
+void Reset()
+{
+	s_tx.clear();
+	s_replies.clear();
+	s_card.fill(0);
+	UnmountCard();
+}
+
+void WriteByte(u8 value)
+{
+	if (s_tx.empty() && value != 0x02)
+		return;
+	s_tx.push_back(value);
+	if (s_tx.size() < 3)
+		return;
+	const size_t frame_size = static_cast<size_t>(s_tx[2]) + 7;
+	if (frame_size > MAX_FRAME_SIZE)
+	{
+		Console.Error("ACUART: Druaga reader rejected oversized frame (%zu bytes)", frame_size);
+		s_tx.clear();
+		return;
+	}
+	if (s_tx.size() < frame_size)
+		return;
+
+	const size_t delimiter = frame_size - 4;
+	u8 checksum = 0;
+	for (size_t i = 1; i <= delimiter; i++)
+		checksum ^= s_tx[i];
+	const bool valid = s_tx[delimiter] == 0x03 && s_tx[delimiter + 1] == checksum &&
+		s_tx[delimiter + 2] == 0x0d && s_tx[delimiter + 3] == 0x0a;
+	if (!valid)
+	{
+		Console.Error("ACUART: Druaga reader rejected an invalid frame");
+		s_tx.clear();
+		return;
+	}
+	Request request{static_cast<Command>(s_tx[1]), std::vector<u8>(s_tx.begin() + 3, s_tx.begin() + delimiter)};
+	s_tx.clear();
+	HandleRequest(request);
+}
+
+std::optional<std::vector<u8>> TakeReply()
+{
+	if (s_replies.empty())
+		return std::nullopt;
+	std::vector<u8> reply = std::move(s_replies.front());
+	s_replies.pop_front();
+	return reply;
+}
+
+bool InsertCard(u8 number)
+{
+	if (number > 9 || s_phase != CardPhase::Absent)
+	{
+		Console.Warning("ACUART: Druaga reader cannot insert card%u while another card is active", number);
+		return false;
+	}
+	const std::string game_directory = VMManager::GetArcadeGameDataDirectory();
+	if (game_directory.empty())
+	{
+		Console.Error("ACUART: Druaga reader cannot insert a card without an active arcade game data directory");
+		return false;
+	}
+
+	const std::string directory = Path::Combine(game_directory, "cards");
+	const std::string path = Path::Combine(directory, "card" + std::to_string(number) + ".bin");
+	FileSystem::ManagedCFilePtr file = FileSystem::OpenManagedSharedCFile(
+		path.c_str(), "r+b", FileSystem::FileShareMode::DenyReadWrite);
+	if (!file)
+	{
+		Console.Error("ACUART: Druaga reader cannot exclusively open IC card '%s'", path.c_str());
+		return false;
+	}
+
+#ifndef _WIN32
+	struct flock lock = {};
+	lock.l_type = F_WRLCK;
+	lock.l_whence = SEEK_SET;
+	if (fcntl(fileno(file.get()), F_SETLK, &lock) != 0)
+	{
+		Console.Error("ACUART: Druaga reader cannot lock IC card '%s'", path.c_str());
+		return false;
+	}
+#endif
+
+	if (FileSystem::FSize64(file.get()) != CARD_SIZE)
+	{
+		Console.Error("ACUART: Druaga IC card '%s' does not have the required %zu bytes", path.c_str(), CARD_SIZE);
+		return false;
+	}
+
+	s_card_path = path;
+	s_card_file = std::move(file);
+	if (!ReadCardFile())
+	{
+		Console.Error("ACUART: Druaga reader cannot read IC card '%s'", path.c_str());
+		UnmountCard();
+		return false;
+	}
+	s_card_mounted = true;
+	s_phase = CardPhase::TransportRequested;
+	return true;
+}
+} // namespace ACDruagaCardReader

--- a/pcsx2/DEV9/ACDruagaCardReader.h
+++ b/pcsx2/DEV9/ACDruagaCardReader.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "MemoryTypes.h"
+
+#include <deque>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace ACDruagaCardReader
+{
+	void Reset();
+	void WriteByte(u8 value);
+	std::optional<std::vector<u8>> TakeReply();
+	bool InsertCard(u8 number);
+} // namespace ACDruagaCardReader

--- a/pcsx2/DEV9/ACUART_GLUE.cpp
+++ b/pcsx2/DEV9/ACUART_GLUE.cpp
@@ -1,9 +1,12 @@
 #include "ACUART_GLUE.h"
 #include "ACUART.h"
+#include "ACDruagaCardReader.h"
 #include "ACCORE.h"
 #include "Config.h"
 #include "common/Console.h"
 #include <deque>
+#include <optional>
+#include <vector>
 
 #define ACUART_LOG(fmt, ...) if (EmuConfig.Arcade.UARTVerbose) Console.WriteLn(Color_Gray, "ACUART:" fmt __VA_OPT__(,) __VA_ARGS__)
 #define ACUART_WARN(fmt, ...) if (EmuConfig.Arcade.UARTVerbose) Console.Warning("ACUART:" fmt __VA_OPT__(,) __VA_ARGS__)
@@ -134,12 +137,82 @@ public:
 };
 
 
+class DruagaReaderDevice : public ACUARTDevice
+{
+private:
+    // The ACUART driver defaults to 9600 baud and 8N1 framing. One character takes
+    // 10 / 9600 seconds, or approximately 1.04 ms. In this path, 240 DEV9 update ticks
+    // take approximately 2 ms. This delay gives the UART about two character times to
+    // report transmit completion before it delivers the reader reply.
+    //
+    // This is a compatibility delay, not an exact hardware-cycle conversion. DEV9async()
+    // passes a constant tick instead of elapsed IOP cycles. The shared ACUART core also
+    // does not emulate its 16-byte FIFO, shift-register timing, or separate TX and RX
+    // interrupt state. Baud-based timing requires shared changes and live verification
+    // for all current ACUART devices.
+    static constexpr u32 REPLY_DELAY_TICKS = 240;
+
+    std::deque<u8> fifo;
+    std::optional<std::vector<u8>> pendingReply;
+    u32 replyDelay = 0;
+
+public:
+    void Reset() override
+    {
+        fifo.clear();
+        pendingReply.reset();
+        replyDelay = 0;
+        ACDruagaCardReader::Reset();
+    }
+
+    void TxByte(u8 value) override
+    {
+        ACDruagaCardReader::WriteByte(value);
+        if (!pendingReply.has_value())
+        {
+            pendingReply = ACDruagaCardReader::TakeReply();
+            if (pendingReply.has_value())
+                replyDelay = 0;
+        }
+    }
+
+    bool RxByte(u8& value) override
+    {
+        if (fifo.empty())
+            return false;
+        value = fifo.front();
+        fifo.pop_front();
+        return true;
+    }
+
+    bool HasData() const override
+    {
+        return !fifo.empty();
+    }
+
+    void Tick(u32 cycles) override
+    {
+        if (!fifo.empty() || !pendingReply.has_value())
+            return;
+        replyDelay += cycles;
+        if (replyDelay < REPLY_DELAY_TICKS)
+            return;
+        replyDelay = 0;
+        fifo.insert(fifo.end(), pendingReply->begin(), pendingReply->end());
+        pendingReply.reset();
+        ACCORE::intr(ACCORE::INTRN_UART);
+    }
+};
+
+
 
 bool ACUART::SetupGameHandler(const std::string& S) {
     if (S == "NM00001")
         s_device = std::make_unique<RRVHandleDevice>();
     else if (S == "NM00010" || S == "NM00015")
         s_device = std::make_unique<Bg3HandleDevice>();
+    else if (S == "NM00028")
+        s_device = std::make_unique<DruagaReaderDevice>();
     else 
         return false;
     s_device->Reset();

--- a/pcsx2/Hotkeys.cpp
+++ b/pcsx2/Hotkeys.cpp
@@ -117,6 +117,22 @@ static void HotkeySaveStateSlot(s32 slot)
 	});
 }
 
+static void HotkeySelectICCard(bool next)
+{
+	const u8 card = next ? VMManager::SelectNextICCard() : VMManager::SelectPreviousICCard();
+	Host::AddIconOSDMessage("SelectICCard", ICON_FA_ID_CARD,
+		fmt::format(TRANSLATE_FS("Hotkeys", "Selected IC card {}."), card), Host::OSD_QUICK_DURATION);
+}
+
+static void HotkeyInsertICCard(u8 card)
+{
+	const bool inserted = VMManager::InsertICCard(card);
+	Host::AddIconOSDMessage("InsertICCard", ICON_FA_ID_CARD,
+		fmt::format(inserted ? TRANSLATE_FS("Hotkeys", "Inserted IC card {}.") :
+			TRANSLATE_FS("Hotkeys", "Could not insert IC card {}."), card),
+		Host::OSD_QUICK_DURATION);
+}
+
 static bool CanPause()
 {
 	static constexpr const float PAUSE_INTERVAL = 3.0f;
@@ -336,6 +352,40 @@ DEFINE_HOTKEY_SAVESTATE_X(10, TRANSLATE_NOOP("Hotkeys", "Save State To Slot 10")
 DEFINE_HOTKEY_LOADSTATE_X(10, TRANSLATE_NOOP("Hotkeys", "Load State From Slot 10"))
 #undef DEFINE_HOTKEY_SAVESTATE_X
 #undef DEFINE_HOTKEY_LOADSTATE_X
+
+DEFINE_HOTKEY("SelectPreviousCard", TRANSLATE_NOOP("Hotkeys", "IC Cards"),
+	TRANSLATE_NOOP("Hotkeys", "Select Previous IC Card"), [](s32 pressed) {
+		if (!pressed && VMManager::HasValidVM())
+			Host::RunOnCPUThread([]() { HotkeySelectICCard(false); });
+	})
+DEFINE_HOTKEY("SelectNextCard", TRANSLATE_NOOP("Hotkeys", "IC Cards"),
+	TRANSLATE_NOOP("Hotkeys", "Select Next IC Card"), [](s32 pressed) {
+		if (!pressed && VMManager::HasValidVM())
+			Host::RunOnCPUThread([]() { HotkeySelectICCard(true); });
+	})
+DEFINE_HOTKEY("InsertSelectedCard", TRANSLATE_NOOP("Hotkeys", "IC Cards"),
+	TRANSLATE_NOOP("Hotkeys", "Insert Selected IC Card"), [](s32 pressed) {
+		if (!pressed && VMManager::HasValidVM())
+			Host::RunOnCPUThread([]() { HotkeyInsertICCard(VMManager::GetSelectedICCard()); });
+	})
+
+#define DEFINE_HOTKEY_INSERT_CARD(cardnum, title) \
+	DEFINE_HOTKEY("InsertCard" #cardnum, TRANSLATE_NOOP("Hotkeys", "IC Cards"), title, [](s32 pressed) { \
+		if (!pressed && VMManager::HasValidVM()) \
+			Host::RunOnCPUThread([]() { HotkeyInsertICCard(cardnum); }); \
+	})
+DEFINE_HOTKEY_INSERT_CARD(0, TRANSLATE_NOOP("Hotkeys", "Insert IC Card 0"))
+DEFINE_HOTKEY_INSERT_CARD(1, TRANSLATE_NOOP("Hotkeys", "Insert IC Card 1"))
+DEFINE_HOTKEY_INSERT_CARD(2, TRANSLATE_NOOP("Hotkeys", "Insert IC Card 2"))
+DEFINE_HOTKEY_INSERT_CARD(3, TRANSLATE_NOOP("Hotkeys", "Insert IC Card 3"))
+DEFINE_HOTKEY_INSERT_CARD(4, TRANSLATE_NOOP("Hotkeys", "Insert IC Card 4"))
+DEFINE_HOTKEY_INSERT_CARD(5, TRANSLATE_NOOP("Hotkeys", "Insert IC Card 5"))
+DEFINE_HOTKEY_INSERT_CARD(6, TRANSLATE_NOOP("Hotkeys", "Insert IC Card 6"))
+DEFINE_HOTKEY_INSERT_CARD(7, TRANSLATE_NOOP("Hotkeys", "Insert IC Card 7"))
+DEFINE_HOTKEY_INSERT_CARD(8, TRANSLATE_NOOP("Hotkeys", "Insert IC Card 8"))
+DEFINE_HOTKEY_INSERT_CARD(9, TRANSLATE_NOOP("Hotkeys", "Insert IC Card 9"))
+#undef DEFINE_HOTKEY_INSERT_CARD
+
 DEFINE_HOTKEY("Mute", TRANSLATE_NOOP("Hotkeys", "Audio"), TRANSLATE_NOOP("Hotkeys", "Toggle Mute"), [](s32 pressed) {
 	if (!pressed && VMManager::HasValidVM())
 		HotkeyToggleMute();

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -85,6 +85,7 @@
 
 #include "DEV9/ACATA.h"
 #include "DEV9/ACATAPI.h"
+#include "DEV9/ACDruagaCardReader.h"
 #include "DEV9/ACJV.h"
 #include "DEV9/ACSRAM.h"
 
@@ -193,6 +194,7 @@ static std::string s_elf_override;
 static std::string s_acgame;
 static std::string s_acgame_data_directory;
 static std::string s_acgame_serial;
+static u8 s_selected_ic_card = 0;
 std::string ArcadeiLinkID;
 static std::string s_input_profile_name;
 static u32 s_frame_advance_count = 0;
@@ -351,6 +353,35 @@ std::string VMManager::GetArcadeGameDataDirectory()
 {
 	std::unique_lock lock(s_info_mutex);
 	return s_acgame_data_directory;
+}
+
+u8 VMManager::GetSelectedICCard()
+{
+	std::unique_lock lock(s_info_mutex);
+	return s_selected_ic_card;
+}
+
+u8 VMManager::SelectPreviousICCard()
+{
+	std::unique_lock lock(s_info_mutex);
+	s_selected_ic_card = (s_selected_ic_card == 0) ? 9 : (s_selected_ic_card - 1);
+	return s_selected_ic_card;
+}
+
+u8 VMManager::SelectNextICCard()
+{
+	std::unique_lock lock(s_info_mutex);
+	s_selected_ic_card = (s_selected_ic_card == 9) ? 0 : (s_selected_ic_card + 1);
+	return s_selected_ic_card;
+}
+
+bool VMManager::InsertICCard(u8 card)
+{
+	const std::string serial = GetDiscSerial();
+	if (serial == "NM00028")
+		return ACDruagaCardReader::InsertCard(card);
+
+	return false;
 }
 
 std::string VMManager::GetDiscSerial()
@@ -1497,7 +1528,6 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 					std::unique_lock lock(s_info_mutex);
 					s_acgame_data_directory = std::move(basedir);
 				}
-
 				return true;
 			}
 		}

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -191,6 +191,7 @@ static std::pair<u32, u32> s_elf_text_range;
 static bool s_elf_executed = false;
 static std::string s_elf_override;
 static std::string s_acgame;
+static std::string s_acgame_data_directory;
 static std::string s_acgame_serial;
 std::string ArcadeiLinkID;
 static std::string s_input_profile_name;
@@ -344,6 +345,12 @@ std::string VMManager::GetDiscPath()
 {
 	std::unique_lock lock(s_info_mutex);
 	return CDVDsys_GetFile(CDVDsys_GetSourceType());
+}
+
+std::string VMManager::GetArcadeGameDataDirectory()
+{
+	std::unique_lock lock(s_info_mutex);
+	return s_acgame_data_directory;
 }
 
 std::string VMManager::GetDiscSerial()
@@ -1486,6 +1493,11 @@ bool VMManager::AutoDetectSource(const std::string& filename, Error* error)
 				Console.WriteLnFmt(Color_Green, "ACGAME: sram:'{}'", ACSRAM::filepath);
 				Console.WriteLnFmt(Color_Green, "ACGAME: media:'{}'", ACATA::imgpath);
 
+				{
+					std::unique_lock lock(s_info_mutex);
+					s_acgame_data_directory = std::move(basedir);
+				}
+
 				return true;
 			}
 		}
@@ -1918,6 +1930,7 @@ void VMManager::Shutdown(bool save_resume_state)
 
 	{
 		std::unique_lock lock(s_info_mutex);
+		s_acgame_data_directory = {};
 		ClearDiscDetails();
 	}
 

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -94,6 +94,18 @@ namespace VMManager
 	/// Returns the data directory from the current arcade game config.
 	std::string GetArcadeGameDataDirectory();
 
+	/// Returns the selected IC card number.
+	u8 GetSelectedICCard();
+
+	/// Selects the previous IC card number and returns it.
+	u8 SelectPreviousICCard();
+
+	/// Selects the next IC card number and returns it.
+	u8 SelectNextICCard();
+
+	/// Inserts an IC card into the current game's card reader. Returns true if the card was inserted.
+	bool InsertICCard(u8 card);
+
 	/// Returns the serial of the disc currently running.
 	std::string GetDiscSerial();
 

--- a/pcsx2/VMManager.h
+++ b/pcsx2/VMManager.h
@@ -91,6 +91,9 @@ namespace VMManager
 	/// Returns the path of the disc currently running.
 	std::string GetDiscPath();
 
+	/// Returns the data directory from the current arcade game config.
+	std::string GetArcadeGameDataDirectory();
+
 	/// Returns the serial of the disc currently running.
 	std::string GetDiscSerial();
 

--- a/pcsx2/pcsx2.vcxproj
+++ b/pcsx2/pcsx2.vcxproj
@@ -176,6 +176,7 @@
     <ClCompile Include="DEV9\ACATA_IO.cpp" />
     <ClCompile Include="DEV9\ACATA_IO_CHD.cpp" />
     <ClCompile Include="DEV9\ACATAPI.cpp" />
+    <ClCompile Include="DEV9\ACDruagaCardReader.cpp" />
     <ClCompile Include="DEV9\ACJV.cpp" />
     <ClCompile Include="DEV9\ACUART.cpp" />
     <ClCompile Include="DEV9\ACUART_GLUE.cpp" />

--- a/pcsx2/pcsx2.vcxproj.filters
+++ b/pcsx2/pcsx2.vcxproj.filters
@@ -887,6 +887,9 @@
     <ClCompile Include="DEV9\ACATAPI.cpp">
       <Filter>System\Ps2\ACMMIO</Filter>
     </ClCompile>
+    <ClCompile Include="DEV9\ACDruagaCardReader.cpp">
+      <Filter>System\Ps2\ACMMIO</Filter>
+    </ClCompile>
     <ClCompile Include="DEV9\ACJV.cpp">
       <Filter>System\Ps2\ACMMIO</Filter>
     </ClCompile>


### PR DESCRIPTION
### Description of Changes

This PR adds IC card reader emulation support for Druaga Online (NM00028).

 - Emulate the serial IC card reader used by the game.
 - Connect the reader through the existing ACUART device interface.
 - Support card insertion, reading, writing, and persistent storage.
 - Store card data in the arcade game data directory.
 - Add VMManager APIs for selecting and inserting IC cards.
 - Add hotkeys for selecting a card and inserting either the selected card or a specific card.

This PR depends on the generic ACUART interrupt and transmitter-state changes (https://github.com/PS2Homebrew-arcade/pcsx2x6/pull/148).

### Rationale behind Changes

Druaga Online communicates with an external IC card reader through ACUART. Without an emulated reader, the game is not playable as all character data is stored on the card.

The VMManager API keeps card selection and insertion separate from the device implementation. Other games can easily hook into the insertion function to trigger their own insertion logic.

Cards must be stored in the game folder given in the game's acfile in a "cards" subfolder and named card0.bin to card9.bin. This was an ad-hoc design decision and seemed like the best fit to keep game-specific content in the same location.

IC card management hotkeys were designed to mimic the existing save state hotkeys.

### Suggested Testing Steps

 - Start the game and confirm that the card reader initializes without an error.
 - Select an IC card with the new selection hotkeys.
 - Insert the selected card and confirm that the game detects it.
 - Use the direct insertion hotkeys and confirm that they insert the requested card.
 - Play a game and confirm that the saved card data loads and saves correctly.

The game and card reader emulation cannot create game cards by themselves and require the Tower unit to do that. I will follow up with a solution for that problem in a separate repository later. For now please use the attached card file.
[card1.zip](https://github.com/user-attachments/files/31373776/card1.zip)
Without network support the game will start in a very restricted mode and might not reach the gameplay screen. Still, the game should boot up without any card reader error.

**!! The code has only been tested on Linux !!**
The Windows-specific code should be fine but I do not currently have access to a Windows development environment for verification.

### Did you use AI to help find, test, or implement this issue or feature?

This patch was generated using ChatGPT-5.6-Sol. I have performed a manual review and clean-up afterwards to verify the implementation and make sure that the change scope is minimal.

  ### Related GameIDs

  NM00028