### PR TITLE
DEV9: add Druaga Online input mapping

### DIFF
--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -447,7 +447,6 @@ JVS_MODE ACJV::ResolveModeFromGameId(const std::string& gameid)
 {
 	if (s_racing_layouts.count(gameid))   return JVS_MODE::DRIVE;
 	if (s_fighting_layouts.count(gameid)) return JVS_MODE::FIGHTING;
-	if (s_standard_layouts.count(gameid)) return JVS_MODE::STANDARD;
 	if (s_gun_mappings.count(gameid))     return JVS_MODE::LIGHTGUN;
 	if (std::ranges::find(s_drum_games, gameid) != std::ranges::end(s_drum_games))
 		return JVS_MODE::DRUM;
@@ -455,6 +454,7 @@ JVS_MODE ACJV::ResolveModeFromGameId(const std::string& gameid)
 		return JVS_MODE::TWINSTICK;
 	if (std::ranges::find(s_touch_games, gameid) != std::ranges::end(s_touch_games))
 		return JVS_MODE::TOUCH;
+	if (s_standard_layouts.count(gameid)) return JVS_MODE::STANDARD;
 	return JVS_MODE::DEFAULT;
 }
 

--- a/pcsx2/DEV9/ACJV.cpp
+++ b/pcsx2/DEV9/ACJV.cpp
@@ -425,6 +425,7 @@ static const std::map<std::string, StandardLayout> s_standard_layouts = {
 	{"NM10003", StandardLayout::TECHNICBEAT}, // Technic Beat (unique unofficial gameid; NM00003 = Vampire Night, GameIndex PR #92)
 	{"NM00030", StandardLayout::GUNDAMQUIZ},  // Gundam Quiz Warrior (moved from Fighting: a quiz, not a fighter)
 	{"NM00037", StandardLayout::INUFUKU},     // Quiz Suku Suku Inufuku 2
+	{"NM00028", StandardLayout::DRUAGA},      // Druaga Online
 };
 
 // Drum (Taiko) and twin-stick (Zoids) gameids for ResolveModeFromGameId (no per-button table).
@@ -496,6 +497,7 @@ std::span<const InputBindingInfo> ACJV::GetStandardButtons()
 		case StandardLayout::TECHNICBEAT: return s_standard_technicbeat;
 		case StandardLayout::GUNDAMQUIZ:  return s_standard_gundamquiz;
 		case StandardLayout::INUFUKU:     return s_standard_inufuku;
+		case StandardLayout::DRUAGA:      return s_standard_druaga;
 	}
 	return {};
 }

--- a/pcsx2/DEV9/ACJV.h
+++ b/pcsx2/DEV9/ACJV.h
@@ -74,6 +74,7 @@ enum class StandardLayout {
 	TECHNICBEAT, // NM10003: Technic Beat (3 buttons)
 	GUNDAMQUIZ,  // NM00030: Gundam Quiz Warrior (4-button Gundam wiring)
 	INUFUKU,     // NM00037: Quiz Inufuku 2 (answer buttons 1-4 on the directional bits)
+	DRUAGA,      // NM00028: Druaga Online (physical attack button on Sw2)
 };
 
 #define JVS_WHEEL_CHANNEL_MAX 3

--- a/pcsx2/DEV9/ACJV_Inputs.h
+++ b/pcsx2/DEV9/ACJV_Inputs.h
@@ -220,6 +220,9 @@ static constexpr InputBindingInfo s_standard_gundamquiz[] = {
 	{"GundamQuiz_Melee",  TRANSLATE_NOOP("JVS", "Answer C"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Triangle},
 	{"GundamQuiz_Jump",   TRANSLATE_NOOP("JVS", "Answer D"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_3, GenericInputBinding::Cross},
 };
+static constexpr InputBindingInfo s_standard_druaga[] = {
+	{"Druaga_Attack", TRANSLATE_NOOP("JVS", "Attack"), nullptr, InputBindingInfo::Type::Button, JVS_BTN_2, GenericInputBinding::Cross},
+};
 
 // Standard page: section title + action buttons per layout.
 static constexpr ACJV::LayoutInfo s_standard_layout_ui[] = {
@@ -228,6 +231,7 @@ static constexpr ACJV::LayoutInfo s_standard_layout_ui[] = {
 	{"Necchuu! Pro Yakyuu 2002",   s_standard_baseball,    false},
 	{"Gundam Quiz Warrior",        s_standard_gundamquiz,  false},
 	{"Quiz Suku Suku Inufuku 2",   s_standard_inufuku,     false, TRANSLATE_NOOP("JVS", "Answer buttons 1-4 sit on the Up/Down/Left/Right switches")},
+	{"Druaga Online",              s_standard_druaga,      true},
 };
 
 static constexpr const std::array<InputBindingInfo, 2> s_jvs_coin_bindings = {{


### PR DESCRIPTION
### Description of Changes

 - Add a dedicated JVS input mode for Druaga Online.
 - Change input mode selection order to match touching before standard.

### Rationale behind Changes

Druaga Online requires its own JVS input mapping. Without this mapping, PCSX2x6 does not expose the correct controls for the game.

The input mode selection priority needed to be changed because Druaga requires both touch input and physical input. Matching standard before touch will cause the touch screen to not work.

### Suggested Testing Steps

  - Bind the movement and attack controls.
  - Start the game and confirm that movement works.
  - Confirm that the attack control works during gameplay.

### Did you use AI to help find, test, or implement this issue or feature?

This patch was generated using ChatGPT-5.6-Sol. I have performed a manual review and clean-up afterwards to verify the implementation and make sure that the change scope is minimal.

### Related GameIDs

NM00028