### PR TITLE
Qt: align JVS controls to the top

### DIFF
--- a/pcsx2-qt/Settings/JVSControlsWidget.cpp
+++ b/pcsx2-qt/Settings/JVSControlsWidget.cpp
@@ -484,7 +484,7 @@ static void buildJvsLayoutPage(JVSControlsWidget* self, SettingsInterface* sif, 
 			note->setStyleSheet("font-style: italic;");
 			g->addWidget(note, row++, 0, 1, 3);
 		}
-		grid->addWidget(group, idx / 2, idx % 2);
+		grid->addWidget(group, idx / 2, idx % 2, Qt::AlignTop);
 		idx++;
 	}
 	pageLayout->addLayout(grid);


### PR DESCRIPTION
### Description of Changes

The elements in the JVS per-game input selection should be top-aligned for a leaner look.

### Rationale behind Changes

This just looks better.

### Suggested Testing Steps
 - Open the JVS input configuration to confirm the elements are now top-aligned.

### Did you use AI to help find, test, or implement this issue or feature?

This patch was generated using ChatGPT-5.6-Sol. I have performed a manual review and clean-up afterwards to verify the implementation and make sure that the change scope is minimal.

### Related GameIDs

n/a