### PR TITLE
DEV9: ignore echoed Linux ICMP requests

### DIFF
--- a/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.cpp
+++ b/pcsx2/DEV9/Sessions/ICMP_Session/ICMP_Session.cpp
@@ -484,8 +484,8 @@ namespace Sessions
 					else
 					{
 #if defined(ICMP_SOCKETS_LINUX)
-						Console.Error("DEV9: ICMP: Unexpected packet");
-						pxAssert(false);
+						// A raw Linux ICMP socket can receive a copy of an echo request
+						// that it just sent.
 #endif
 						// Assume not for us
 						return nullptr;


### PR DESCRIPTION
### Description of Changes

Treat copies of outgoing ICMP echo requests received through a Linux raw socket as expected packets. These packets are ignored instead of producing an error message and triggering an assertion.

### Rationale behind Changes

A raw ICMP socket on Linux can receive a copy of an echo request that it just sent. This is normal socket behavior, not an unexpected packet.

Games that require a network connection may send pings to their servers to check for connectivity. The original code asserts on such behavior. In particular, it crashes Druaga Online during network tests.

### Suggested Testing Steps

 - Start a game that uses pings to check for connectivity (e.g., Druaga Online)
 - Before this patch the game will crash. After this patch it does not.

### Did you use AI to help find, test, or implement this issue or feature?

This patch was generated using ChatGPT-5.6-Sol. I have performed a manual review and clean-up afterwards to verify the implementation and make sure that the change scope is minimal.

### Related GameIDs

NM00028