### PR TITLE
VMManager: load patches for arcade game IDs

### DIFF
--- a/pcsx2/GameDatabase.cpp
+++ b/pcsx2/GameDatabase.cpp
@@ -46,12 +46,12 @@ std::string GameDatabaseSchema::GameEntry::memcardFiltersAsString() const
 	return fmt::to_string(fmt::join(memcardFilters, "/"));
 }
 
-const std::string* GameDatabaseSchema::GameEntry::findPatch(u32 crc) const
+const std::string* GameDatabaseSchema::GameEntry::findPatch(std::optional<u32> crc) const
 {
-	if (crc == 0)
+	if (!crc.has_value())
 		return nullptr;
 
-	auto it = patches.find(crc);
+	auto it = patches.find(*crc);
 	if (it != patches.end())
 		return &it->second;
 

--- a/pcsx2/GameDatabase.h
+++ b/pcsx2/GameDatabase.h
@@ -116,7 +116,7 @@ namespace GameDatabaseSchema
 		}arcade;
 		// Returns the list of memory card serials as a `/` delimited string
 		std::string memcardFiltersAsString() const;
-		const std::string* findPatch(u32 crc) const;
+		const std::string* findPatch(std::optional<u32> crc) const;
 		const char* compatAsString() const;
 
 		/// Applies Core game fixes to an existing config.

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <optional>
 #include <span>
 #include <sstream>
 #include <type_traits>
@@ -137,7 +138,7 @@ namespace Patch
 	static std::vector<std::string> s_enabled_patches;
 	static std::vector<std::string> s_just_enabled_cheats;
 	static std::vector<std::string> s_just_enabled_patches;
-	static u32 s_patches_crc;
+	static std::optional<u32> s_patches_crc;
 	static std::optional<float> s_override_aspect_ratio;
 	static std::optional<GSInterlaceMode> s_override_interlace_mode;
 
@@ -728,7 +729,7 @@ u32 Patch::EnablePatches(const std::vector<PatchGroup>* patches, const std::vect
 	return count;
 }
 
-void Patch::ReloadPatches(const std::string& serial, u32 crc, bool reload_files, bool reload_enabled_list, bool verbose,
+void Patch::ReloadPatches(const std::string& serial, std::optional<u32> crc, bool reload_files, bool reload_enabled_list, bool verbose,
 	bool verbose_if_changed)
 {
 	reload_files |= (s_patches_crc != crc);
@@ -754,7 +755,7 @@ void Patch::ReloadPatches(const std::string& serial, u32 crc, bool reload_files,
 
 		s_game_patches.clear();
 		EnumeratePnachFiles(
-			serial, s_patches_crc, false, false, [](const std::string& filename, const std::string& pnach_data) {
+			serial, s_patches_crc.value_or(0), false, false, [](const std::string& filename, const std::string& pnach_data) {
 				const u32 patch_count = LoadPatchesFromString(&s_game_patches, pnach_data);
 				if (patch_count > 0)
 					Console.WriteLn(Color_Green, fmt::format("Found {} game patches in {}.", patch_count, filename));
@@ -762,7 +763,7 @@ void Patch::ReloadPatches(const std::string& serial, u32 crc, bool reload_files,
 
 		s_cheat_patches.clear();
 		EnumeratePnachFiles(
-			serial, s_patches_crc, true, false, [](const std::string& filename, const std::string& pnach_data) {
+			serial, s_patches_crc.value_or(0), true, false, [](const std::string& filename, const std::string& pnach_data) {
 				const u32 patch_count = LoadPatchesFromString(&s_cheat_patches, pnach_data);
 				if (patch_count > 0)
 					Console.WriteLn(Color_Green, fmt::format("Found {} cheats in {}.", patch_count, filename));
@@ -886,7 +887,7 @@ void Patch::UnloadPatches()
 {
 	s_override_interlace_mode = {};
 	s_override_aspect_ratio = {};
-	s_patches_crc = 0;
+	s_patches_crc.reset();
 	s_active_patches = {};
 	s_active_pnach_dynamic_patches = {};
 	s_active_gamedb_dynamic_patches = {};

--- a/pcsx2/Patch.h
+++ b/pcsx2/Patch.h
@@ -20,6 +20,7 @@
 #include "common/MemoryInterface.h"
 #include "common/SmallString.h"
 
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -159,7 +160,8 @@ namespace Patch
 	extern std::string GetPnachFilename(const std::string_view serial, u32 crc, bool cheats);
 
 	/// Reloads cheats/patches. If verbose is set, the number of patches loaded will be shown in the OSD.
-	extern void ReloadPatches(const std::string& serial, u32 crc, bool reload_files, bool reload_enabled_list, bool verbose, bool verbose_if_changed);
+	extern void ReloadPatches(const std::string& serial, std::optional<u32> crc, bool reload_files, bool reload_enabled_list, bool verbose,
+		bool verbose_if_changed);
 
 	extern void UpdateActivePatches(bool reload_enabled_list, bool verbose, bool verbose_if_changed, bool apply_new_patches);
 	extern void ApplyPatchSettingOverrides();

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -922,7 +922,7 @@ void VMManager::Internal::UpdateEmuFolders()
 	if (VMManager::HasValidVM())
 	{
 		if (EmuFolders::Cheats != old_cheats_directory || EmuFolders::Patches != old_patches_directory)
-			Patch::ReloadPatches(s_disc_serial, GetCRCForPatches(), true, false, true, true);
+			Patch::ReloadPatches(GetSerialForGameSettings(), GetCRCForPatches(), true, false, true, true);
 
 		if (EmuFolders::MemoryCards != old_memcards_directory)
 		{
@@ -1219,7 +1219,7 @@ void VMManager::UpdateDiscDetails(bool booting)
 	ApplySettings();
 
 	// Patches are game-dependent, thus should get applied after game settings ia loaded.
-	Patch::ReloadPatches(s_disc_serial, HasBootedELF() ? GetCRCForPatches() : 0, true, true, false, false);
+	Patch::ReloadPatches(GetSerialForGameSettings(), HasBootedELF() ? GetCRCForPatches() : 0, true, true, false, false);
 
 	ReportGameChangeToHost();
 	if (MTGS::IsOpen())
@@ -1256,7 +1256,7 @@ void VMManager::HandleELFChange(bool verbose_patches_if_changed)
 	Achievements::GameChanged(s_disc_crc, crc_to_report);
 
 	Console.WriteLn(Color_StrongOrange, fmt::format("ELF changed, active CRC {:08X} ({})", crc_to_report, s_elf_path));
-	Patch::ReloadPatches(s_disc_serial, HasBootedELF() ? GetCRCForPatches() : 0, false, false, false, verbose_patches_if_changed);
+	Patch::ReloadPatches(GetSerialForGameSettings(), HasBootedELF() ? GetCRCForPatches() : 0, false, false, false, verbose_patches_if_changed);
 	ApplyCoreSettings();
 }
 
@@ -3116,7 +3116,7 @@ void VMManager::Internal::ELFLoadingOnCPUThread(std::string elf_path)
 	// Remove patches, if we're changing games, we don't want to be applying the patch for the old game while it's loading.
 	if (!was_running_bios)
 	{
-		Patch::ReloadPatches(s_disc_serial, 0, false, false, false, true);
+		Patch::ReloadPatches(GetSerialForGameSettings(), 0, false, false, false, true);
 		ApplyCoreSettings();
 	}
 }
@@ -3432,7 +3432,7 @@ void VMManager::ReloadPatches(bool reload_files, bool reload_enabled_list, bool 
 	if (!HasValidVM())
 		return;
 
-	Patch::ReloadPatches(s_disc_serial, HasBootedELF() ? GetCRCForPatches() : 0, reload_files, reload_enabled_list, verbose, verbose_if_changed);
+	Patch::ReloadPatches(GetSerialForGameSettings(), HasBootedELF() ? GetCRCForPatches() : 0, reload_files, reload_enabled_list, verbose, verbose_if_changed);
 
 	// Might change widescreen mode.
 	if (Patch::ReloadPatchAffectingOptions())

--- a/pcsx2/VMManager.cpp
+++ b/pcsx2/VMManager.cpp
@@ -902,8 +902,11 @@ std::string VMManager::GetDebuggerSettingsFilePathForCurrentGame()
 	return GetDebuggerSettingsFilePath(s_disc_serial, s_current_crc);
 }
 
-static u32 GetCRCForPatches()
+static std::optional<u32> GetCRCForPatches()
 {
+	if (!VMManager::HasBootedELF())
+		return std::nullopt;
+
 	return s_acgame.empty() ? s_current_crc : 0; // arcade: patches are keyed by the gameid alone
 }
 
@@ -1219,7 +1222,7 @@ void VMManager::UpdateDiscDetails(bool booting)
 	ApplySettings();
 
 	// Patches are game-dependent, thus should get applied after game settings ia loaded.
-	Patch::ReloadPatches(GetSerialForGameSettings(), HasBootedELF() ? GetCRCForPatches() : 0, true, true, false, false);
+	Patch::ReloadPatches(GetSerialForGameSettings(), GetCRCForPatches(), true, true, false, false);
 
 	ReportGameChangeToHost();
 	if (MTGS::IsOpen())
@@ -1256,7 +1259,7 @@ void VMManager::HandleELFChange(bool verbose_patches_if_changed)
 	Achievements::GameChanged(s_disc_crc, crc_to_report);
 
 	Console.WriteLn(Color_StrongOrange, fmt::format("ELF changed, active CRC {:08X} ({})", crc_to_report, s_elf_path));
-	Patch::ReloadPatches(GetSerialForGameSettings(), HasBootedELF() ? GetCRCForPatches() : 0, false, false, false, verbose_patches_if_changed);
+	Patch::ReloadPatches(GetSerialForGameSettings(), GetCRCForPatches(), false, false, false, verbose_patches_if_changed);
 	ApplyCoreSettings();
 }
 
@@ -3116,7 +3119,7 @@ void VMManager::Internal::ELFLoadingOnCPUThread(std::string elf_path)
 	// Remove patches, if we're changing games, we don't want to be applying the patch for the old game while it's loading.
 	if (!was_running_bios)
 	{
-		Patch::ReloadPatches(GetSerialForGameSettings(), 0, false, false, false, true);
+		Patch::ReloadPatches(GetSerialForGameSettings(), std::nullopt, false, false, false, true);
 		ApplyCoreSettings();
 	}
 }
@@ -3432,7 +3435,8 @@ void VMManager::ReloadPatches(bool reload_files, bool reload_enabled_list, bool 
 	if (!HasValidVM())
 		return;
 
-	Patch::ReloadPatches(GetSerialForGameSettings(), HasBootedELF() ? GetCRCForPatches() : 0, reload_files, reload_enabled_list, verbose, verbose_if_changed);
+	Patch::ReloadPatches(GetSerialForGameSettings(), GetCRCForPatches(), reload_files, reload_enabled_list, verbose,
+		verbose_if_changed);
 
 	// Might change widescreen mode.
 	if (Patch::ReloadPatchAffectingOptions())


### PR DESCRIPTION
### Description of Changes

Use `VMManager::GetSerialForGameSettings()` when patches are loaded or reloaded.

This lets arcade launches use the GameID from the `.acgame` file as the GameDB lookup key. Normal disc games continue to use their disc serial.

This fixes https://github.com/PS2Homebrew-arcade/pcsx2x6/commit/8462c6986 which changed four Patch::ReloadPatches() calls to use the arcade-aware GetCRCForPatches(), but it continued to pass s_disc_serial as the patch lookup key.

### Rationale behind Changes

Arcade CHDs can have an empty disc serial. The `.acgame` file contains the correct arcade GameID, but the patch-loading code used the disc serial directly.

As a result, PCSX2x6 could not find the arcade GameDB entry and did not load its `default` patches.

### Suggested Testing Steps

1. Start any game through its `.acgame` file.
2. Confirm that the `default` GameDB patches for that load.

### Did you use AI to help find, test, or implement this issue or feature?

This patch was generated using ChatGPT-5.6-Sol. I have performed a manual review and clean-up afterwards to verify the implementation and make sure that the change scope is minimal.

### Related GameIDs

Druaga Online (NM00028) will make use of this functionality.