### PR TITLE
GameDB: Add Druaga Online runtime patches

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -205,6 +205,9 @@ NM00028:
       content: |-
         comment=Use full-height progressive video
         patch=1,EE,004016C0,word,24100010
+        comment=Run at 60 frames per second
+        patch=1,EE,00127DD0,word,2405003C
+        patch=1,EE,00128340,word,2405003C
         comment=Set the Tower IP address (change the values to match your address)
         // The default values keep the game's original address, 192.168.33.20.
         // ASCII bytes: 0 = 0x30, 1 = 0x31, 2 = 0x32, 3 = 0x33, 4 = 0x34.

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -198,6 +198,20 @@ NM00028:
   bootprog: DRULOAD
   media: DVD
   input: touchscreen
+  patches:
+    default:
+      content: |-
+        comment=Set the Tower IP address (change the values to match your address)
+        // The default values keep the game's original address, 192.168.33.20.
+        // ASCII bytes: 0 = 0x30, 1 = 0x31, 2 = 0x32, 3 = 0x33, 4 = 0x34.
+        // ASCII bytes: 5 = 0x35, 6 = 0x36, 7 = 0x37, 8 = 0x38, 9 = 0x39, . = 0x2E.
+        // Split the address into four-character groups and reverse the byte order in each group.
+        // Pad the final group with 0x00 bytes before you reverse it.
+        // Example: 192.168.33.20 becomes 2E323931, 2E383631, 322E3333, 00000030.
+        patch=1,EE,00465560,word,2E323931
+        patch=1,EE,00465564,word,2E383631
+        patch=1,EE,00465568,word,322E3333
+        patch=1,EE,0046556C,word,00000030
 NM00029:
   name: Kinnikuman Muscle Grand Prix
   region: System256

--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -198,9 +198,13 @@ NM00028:
   bootprog: DRULOAD
   media: DVD
   input: touchscreen
+  gsHWFixes:
+    deinterlace: 1 # The patch selects the full-height progressive video path.
   patches:
     default:
       content: |-
+        comment=Use full-height progressive video
+        patch=1,EE,004016C0,word,24100010
         comment=Set the Tower IP address (change the values to match your address)
         // The default values keep the game's original address, 192.168.33.20.
         // ASCII bytes: 0 = 0x30, 1 = 0x31, 2 = 0x32, 3 = 0x33, 4 = 0x34.


### PR DESCRIPTION
### Description of Changes

Add three default GameDB patches for Druaga Online:

- An editable Tower IP address patch.
- A full-height progressive video patch.
- A 60 FPS patch.

The Tower address patch initially writes the game's original `192.168.33.20` address which is a NOOP. Its comments explain how to convert another IPv4 address to ASCII bytes and arrange the bytes in the required order.

This patch depends on https://github.com/PS2Homebrew-arcade/pcsx2x6/pull/153 for game-ID specific patches to work.

### Rationale behind Changes

 - Druaga Online uses a fixed Tower IP address which cannot be changed and is unlikely to fit the user's network. There is no other way of changing the IP address other than by directly patching the game's executable. Users must change this address when their Tower runs at a different address.

 - The game natively runs interlaced but already contains a code path for progressive output which the patch enables.

 - The 60FPS patch makes the game more pleasant to look at.

### Suggested Testing Steps

1. Change the four Tower address values as described in the patch comments.
2. Start game ID `NM00028`.
3. Confirm that the game uses the full-height progressive video path.
4. Confirm that the game runs at 60 frames per second.
5. Verify that the tower IP address has been change via the game's operator menu.

### Did you use AI to help find, test, or implement this issue or feature?

This patch was generated using ChatGPT-5.6-Sol. I have performed a manual review and clean-up afterwards to verify the implementation and make sure that the change scope is minimal.

### Related GameIDs

Druaga Online (NM00028)